### PR TITLE
FIX: SystemD will not restart a crashed collector daemon 

### DIFF
--- a/contrib/systemd/pganalyze-collector.service
+++ b/contrib/systemd/pganalyze-collector.service
@@ -11,6 +11,7 @@ ProtectHome=true
 CapabilityBoundingSet=
 NoNewPrivileges=true
 MemoryLimit=256MB
+Restart=Always
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Irony.