### PR TITLE
Fix ecs credentials

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -137,8 +137,8 @@ func createHttpClient(requireSSL bool) *http.Client {
 	}
 	if requireSSL {
 		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-			// Require secure conection for everything except the EC2 metadata service
-			if !strings.HasSuffix(addr, ":443") && addr != "169.254.169.254:80" {
+			// Require secure conection for everything except the EC2 and ECS metadata services
+			if !strings.HasSuffix(addr, ":443") && addr != "169.254.169.254:80" && addr != "169.254.170.2:80" {
 				return nil, fmt.Errorf("Unencrypted connection is not permitted by pganalyze configuration")
 			}
 			return (&net.Dialer{Timeout: 30 * time.Second, KeepAlive: 30 * time.Second, DualStack: true}).DialContext(ctx, network, addr)

--- a/util/awsutil/amazon.go
+++ b/util/awsutil/amazon.go
@@ -14,7 +14,12 @@ func GetAwsSession(config config.ServerConfig) (*session.Session, error) {
 		creds = credentials.NewStaticCredentials(config.AwsAccessKeyID, config.AwsSecretAccessKey, "")
 	}
 
-	return session.NewSession(&aws.Config{Credentials: creds, Region: aws.String(config.AwsRegion), HTTPClient: config.HTTPClient})
+	return session.NewSession(&aws.Config{
+		Credentials:                   creds,
+		CredentialsChainVerboseErrors: aws.Bool(true),
+		Region:                        aws.String(config.AwsRegion),
+		HTTPClient:                    config.HTTPClient,
+	})
 }
 
 //sess.Handlers.Send.PushFront(func(r *request.Request) {


### PR DESCRIPTION
I got an interesting error while trying to setup the pganalyze collector in an aws ecs service backed by fargate:

```
2019/07/16 13:24:33 E [default] Rds/Logs: Could not find RDS instance: NoCredentialProviders: no valid providers in chain
caused by: EnvAccessKeyNotFound: failed to find credentials in the environment.
SharedCredsLoad: failed to load profile, .
CredentialsEndpointError: failed to load credentials
caused by: RequestError: send request failed
caused by: Get http://169.254.170.2/v2/credentials/abcdef12-3456-789a-bcde-f1234567: Unencrypted connection is not permitted by pganalyze configuration
```

ECS tasks using a slightly different metadata endpoint which should probably also be whitelisted. I've pushed a custom docker image with this new code and it works great. Sorry, I didn't look too hard at tests yet. 😅