### PR TITLE
Heroku: Use log line number for sorting log lines before processing

### DIFF
--- a/input/postgres/explain.go
+++ b/input/postgres/explain.go
@@ -24,6 +24,11 @@ func RunExplain(db *sql.DB, connectedDbName string, inputs []state.PostgresQuery
 			continue
 		}
 
+		// Ignore backup start queries (they usually take long but not because of something that can be EXPLAINed)
+		if strings.Contains(sample.Query, "pg_start_backup") {
+			continue
+		}
+
 		// TODO: We should run EXPLAIN for other databases here, which means we actually
 		// need to split the query samples per database, and then make one connection for each DB
 		if sample.Database != "" && sample.Database != connectedDbName {

--- a/logs/stream.go
+++ b/logs/stream.go
@@ -3,6 +3,7 @@ package logs
 import (
 	"fmt"
 	"io/ioutil"
+	"sort"
 	"time"
 
 	"github.com/pganalyze/collector/output/pganalyze_collector"
@@ -79,6 +80,12 @@ func AnalyzeStreamInGroups(logLines []state.LogLine) (state.LogState, state.LogF
 	}
 
 	for _, logLines := range backendLogLines {
+		sort.Slice(logLines, func(i, j int) bool {
+			if logLines[i].LogLineNumber != logLines[j].LogLineNumber {
+				return logLines[i].LogLineNumber < logLines[j].LogLineNumber
+			}
+			return logLines[i].OccurredAt.Unix() < logLines[j].OccurredAt.Unix()
+		})
 		var analyzableLogLines []state.LogLine
 		for _, logLine := range logLines {
 			if logLine.LogLevel != pganalyze_collector.LogLineInformation_UNKNOWN {

--- a/state/logs.go
+++ b/state/logs.go
@@ -141,6 +141,9 @@ type LogLine struct {
 	LogLevel   pganalyze_collector.LogLineInformation_LogLevel
 	BackendPid int32
 
+	// %l in log_line_prefix (or similar syslog equivalents)
+	LogLineNumber int32
+
 	Content string
 
 	Classification pganalyze_collector.LogLineInformation_LogClassification


### PR DESCRIPTION
This avoids issues where Logplex sends out lines out-of-order, leading
to lines being truncated.