### PR TITLE
Password must be provided for Postgres docker images

### DIFF
--- a/integration_test/Makefile
+++ b/integration_test/Makefile
@@ -1,5 +1,5 @@
 DOCKER_BUILD_OPTS = -t pganalyze-collector-test ..
-DOCKER_RUN_CMD = docker run --name pganalyze-collector-test -v `pwd`/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d/ -d pganalyze-collector-test
+DOCKER_RUN_CMD = docker run --name pganalyze-collector-test -v `pwd`/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d/ -e POSTGRES_PASSWORD=password -d pganalyze-collector-test
 
 .PHONY: pg92 pg93 pg94 pg95 pg96 pg10 pg11
 


### PR DESCRIPTION
The integration tests fail. The `pganalyze-collector-test` container fails to start because of the following error:
```
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD to a non-empty value for the
       superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".

       You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
       connections without a password. This is *not* recommended.

       See PostgreSQL documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html
```

This is due to change in the official postgres docker images available in docker hub.