### PR TITLE
Use Golang 1.14.3 patch release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 sudo: required
 go:
-- "1.14"
+- "1.14.3"
 env:
   - GO111MODULE=on
 before_install:
@@ -21,4 +21,4 @@ deploy:
   on:
     repo: pganalyze/collector
     tags: true
-    go: "1.14"
+    go: "1.14.3"

--- a/integration_test/Dockerfile.test-pg10
+++ b/integration_test/Dockerfile.test-pg10
@@ -1,6 +1,6 @@
 FROM postgres:10
 
-ENV GOVERSION 1.14
+ENV GOVERSION 1.14.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg11
+++ b/integration_test/Dockerfile.test-pg11
@@ -1,6 +1,6 @@
 FROM postgres:11
 
-ENV GOVERSION 1.14
+ENV GOVERSION 1.14.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg12
+++ b/integration_test/Dockerfile.test-pg12
@@ -1,6 +1,6 @@
 FROM postgres:12
 
-ENV GOVERSION 1.14
+ENV GOVERSION 1.14.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg13
+++ b/integration_test/Dockerfile.test-pg13
@@ -1,6 +1,6 @@
 FROM postgres:13-beta1
 
-ENV GOVERSION 1.14
+ENV GOVERSION 1.14.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg92
+++ b/integration_test/Dockerfile.test-pg92
@@ -1,6 +1,6 @@
 FROM postgres:9.2
 
-ENV GOVERSION 1.14
+ENV GOVERSION 1.14.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg93
+++ b/integration_test/Dockerfile.test-pg93
@@ -1,6 +1,6 @@
 FROM postgres:9.3
 
-ENV GOVERSION 1.14
+ENV GOVERSION 1.14.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg94
+++ b/integration_test/Dockerfile.test-pg94
@@ -1,6 +1,6 @@
 FROM postgres:9.4
 
-ENV GOVERSION 1.14
+ENV GOVERSION 1.14.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg95
+++ b/integration_test/Dockerfile.test-pg95
@@ -1,6 +1,6 @@
 FROM postgres:9.5
 
-ENV GOVERSION 1.14
+ENV GOVERSION 1.14.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg96
+++ b/integration_test/Dockerfile.test-pg96
@@ -1,6 +1,6 @@
 FROM postgres:9.6
 
-ENV GOVERSION 1.14
+ENV GOVERSION 1.14.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/packages/src/Dockerfile.build.deb-systemd
+++ b/packages/src/Dockerfile.build.deb-systemd
@@ -1,7 +1,7 @@
 FROM debian:jessie
 
 ENV GOPATH /go
-ENV GOVERSION 1.14
+ENV GOVERSION 1.14.3
 ENV CODE_DIR $GOPATH/src/github.com/pganalyze/collector
 ENV PATH $PATH:/usr/local/go/bin
 ENV ROOT_DIR /root

--- a/packages/src/Dockerfile.build.deb-upstart
+++ b/packages/src/Dockerfile.build.deb-upstart
@@ -1,7 +1,7 @@
 FROM ubuntu:trusty
 
 ENV GOPATH /go
-ENV GOVERSION 1.14
+ENV GOVERSION 1.14.3
 ENV CODE_DIR $GOPATH/src/github.com/pganalyze/collector
 ENV PATH $PATH:/usr/local/go/bin
 ENV ROOT_DIR /root

--- a/packages/src/Dockerfile.build.rpm-systemd
+++ b/packages/src/Dockerfile.build.rpm-systemd
@@ -1,7 +1,7 @@
 FROM centos:7
 
 ENV GOPATH /go
-ENV GOVERSION 1.14
+ENV GOVERSION 1.14.3
 ENV CODE_DIR $GOPATH/src/github.com/pganalyze/collector
 ENV PATH $PATH:/usr/local/go/bin
 ENV ROOT_DIR /root

--- a/packages/src/Dockerfile.build.rpm-sysvinit
+++ b/packages/src/Dockerfile.build.rpm-sysvinit
@@ -1,7 +1,7 @@
 FROM centos:6
 
 ENV GOPATH /go
-ENV GOVERSION 1.14
+ENV GOVERSION 1.14.3
 ENV CODE_DIR $GOPATH/src/github.com/pganalyze/collector
 ENV PATH $PATH:/usr/local/go/bin
 ENV ROOT_DIR /root


### PR DESCRIPTION
See https://github.com/golang/go/issues/37436 which was causing
"mlock of signal stack failed: 12" on Ubuntu systems.