### PR TITLE
Improve non-fatal error message to clarify the collector still works

### DIFF
--- a/input/full.go
+++ b/input/full.go
@@ -76,8 +76,9 @@ func CollectFull(server state.Server, connection *sql.DB, globalCollectionOpts s
 
 	ts.Replication, err = postgres.GetReplication(logger, connection, ts.Version, systemType)
 	if err != nil {
-		logger.PrintWarning("Error collecting replication statistics: %s", err)
-		// We intentionally accept this as a non-fatal issue (at least for now)
+		// We intentionally accept this as a non-fatal issue (at least for now), because we've historically
+		// had issues make this work reliably
+		logger.PrintWarning("Skipping replication statistics, due to error: %s", err)
 		err = nil
 	}
 


### PR DESCRIPTION
There are a set of error messages (now changed to warnings), that are
acceptable in some cases, and don't stop the data being sent. Clarify
the messages to be clear that only some data is missing, and being skipped.