### PR TITLE
Example collector config: Use collect all databases option in the example

### DIFF
--- a/contrib/pganalyze-collector.conf
+++ b/contrib/pganalyze-collector.conf
@@ -4,14 +4,14 @@
 #api_key: your_api_key
 
 [server1]
-#db_name: mydb
+#db_name: mydb, *
 #db_username: myusername
 #db_password: mypassword
 #db_host: 127.0.0.1
 #db_port: 5432
 
 #[server2]
-#db_name: mydb, *
+#db_name: mydb, mydb2, mydb3
 #db_username: myusername
 #db_password: mypassword
 #db_host: 127.0.0.1


### PR DESCRIPTION
This improves the chance that this is set up correctly from the
beginning, without requiring a backwards incompatible change in the
collector.