### PR TITLE
Add ignore_schema_regexp

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -104,12 +104,12 @@ type ServerConfig struct {
 	// development and debugging. The value needs to be the name of the container.
 	LogDockerTail string `ini:"db_log_docker_tail"`
 
-	// **DEPRECATED**: Please use ignore_schema_regexp instead, since that uses an
-	// optimized code path in the collector and can avoid long-running queries.
-	//
 	// Specifies a table pattern to ignore - no statistics will be collected for
 	// tables that match the name. This uses Golang's filepath.Match function for
 	// comparison, so you can e.g. use "*" for wildcard matching.
+	//
+	// Deprecated: Please use ignore_schema_regexp instead, since that uses an
+	// optimized code path in the collector and can avoid long-running queries.
 	IgnoreTablePattern string `ini:"ignore_table_pattern"`
 
 	// Specifies a regular expression to ignore - no statistics will be collected for

--- a/config/config.go
+++ b/config/config.go
@@ -104,10 +104,18 @@ type ServerConfig struct {
 	// development and debugging. The value needs to be the name of the container.
 	LogDockerTail string `ini:"db_log_docker_tail"`
 
+	// **DEPRECATED**: Please use ignore_table_regexp instead, since that uses an
+	// optimized code path in the collector and can avoid long-running queries.
+	//
 	// Specifies a table pattern to ignore - no statistics will be collected for
 	// tables that match the name. This uses Golang's filepath.Match function for
 	// comparison, so you can e.g. use "*" for wildcard matching.
 	IgnoreTablePattern string `ini:"ignore_table_pattern"`
+
+	// Specifies a regular expression to ignore - no statistics will be collected for
+	// tables or schemas that match the name. E.g., to ignore tables that start with
+	// "ignored_", set this to "^ignored_".
+	IgnoreTableRegexp string `ini:"ignore_table_regexp"`
 
 	// Specifies the frequency of query statistics collection in seconds
 	//

--- a/config/config.go
+++ b/config/config.go
@@ -104,7 +104,7 @@ type ServerConfig struct {
 	// development and debugging. The value needs to be the name of the container.
 	LogDockerTail string `ini:"db_log_docker_tail"`
 
-	// **DEPRECATED**: Please use ignore_table_regexp instead, since that uses an
+	// **DEPRECATED**: Please use ignore_schema_regexp instead, since that uses an
 	// optimized code path in the collector and can avoid long-running queries.
 	//
 	// Specifies a table pattern to ignore - no statistics will be collected for
@@ -113,9 +113,12 @@ type ServerConfig struct {
 	IgnoreTablePattern string `ini:"ignore_table_pattern"`
 
 	// Specifies a regular expression to ignore - no statistics will be collected for
-	// tables or schemas that match the name. E.g., to ignore tables that start with
-	// "ignored_", set this to "^ignored_".
-	IgnoreTableRegexp string `ini:"ignore_table_regexp"`
+	// tables, views, functions, or schemas that match the name. Note that the match
+	// is applied to the '.'-joined concantenation of schema name and object name.
+	// E.g., to ignore tables that start with "ignored_", set this to "^ignored_". To
+	// ignore table "foo" only in the public schema, set to "^public\.foo$" (N.B.: you
+	// should escape the dot since that has special meaning in a regexp).
+	IgnoreSchemaRegexp string `ini:"ignore_schema_regexp"`
 
 	// Specifies the frequency of query statistics collection in seconds
 	//

--- a/config/read.go
+++ b/config/read.go
@@ -442,5 +442,21 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 		}
 	}
 
+	var hasIgnoreTablePattern = false
+	for _, server := range conf.Servers {
+		if server.IgnoreTablePattern != "" {
+			hasIgnoreTablePattern = true
+			break
+		}
+	}
+
+	if hasIgnoreTablePattern {
+		if os.Getenv("IGNORE_TABLE_PATTERN") != "" {
+			logger.PrintVerbose("Deprecated: Setting IGNORE_TABLE_PATTERN is deprecated; please use IGNORE_SCHEMA_REGEXP instead")
+		} else {
+			logger.PrintVerbose("Deprecated: Setting ignore_table_pattern is deprecated; please use ignore_schema_regexp instead")
+		}
+	}
+
 	return conf, nil
 }

--- a/config/read.go
+++ b/config/read.go
@@ -173,8 +173,8 @@ func getDefaultConfig() *ServerConfig {
 	if ignoreTablePattern := os.Getenv("IGNORE_TABLE_PATTERN"); ignoreTablePattern != "" {
 		config.IgnoreTablePattern = ignoreTablePattern
 	}
-	if ignoreTableRegexp := os.Getenv("IGNORE_TABLE_REGEXP"); ignoreTableRegexp != "" {
-		config.IgnoreTableRegexp = ignoreTableRegexp
+	if ignoreSchemaRegexp := os.Getenv("IGNORE_SCHEMA_REGEXP"); ignoreSchemaRegexp != "" {
+		config.IgnoreSchemaRegexp = ignoreSchemaRegexp
 	}
 	if queryStatsInterval := os.Getenv("QUERY_STATS_INTERVAL"); queryStatsInterval != "" {
 		config.QueryStatsInterval, _ = strconv.Atoi(queryStatsInterval)

--- a/config/read.go
+++ b/config/read.go
@@ -173,6 +173,9 @@ func getDefaultConfig() *ServerConfig {
 	if ignoreTablePattern := os.Getenv("IGNORE_TABLE_PATTERN"); ignoreTablePattern != "" {
 		config.IgnoreTablePattern = ignoreTablePattern
 	}
+	if ignoreTableRegexp := os.Getenv("IGNORE_TABLE_REGEXP"); ignoreTableRegexp != "" {
+		config.IgnoreTableRegexp = ignoreTableRegexp
+	}
 	if queryStatsInterval := os.Getenv("QUERY_STATS_INTERVAL"); queryStatsInterval != "" {
 		config.QueryStatsInterval, _ = strconv.Atoi(queryStatsInterval)
 	}

--- a/input/postgres/buffercache.go
+++ b/input/postgres/buffercache.go
@@ -23,7 +23,7 @@ SELECT block_count * pg_catalog.current_setting('block_size')::int, d.datname, n
   JOIN pg_catalog.pg_database d ON (d.oid = reldatabase)
        LEFT JOIN pg_catalog.pg_class c ON (b.relfilenode = pg_catalog.pg_relation_filenode(c.oid) AND (b.reldatabase = 0 OR d.datname = pg_catalog.current_database()))
        LEFT JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
- WHERE ($1 = '' OR (coalesce(c.relname, '') || '.' || coalesce(n.nspname, '')) !~* $1)
+ WHERE ($1 = '' OR (coalesce(n.nspname, '') || '.' || coalesce(c.relname, '')) !~* $1)
 UNION
 SELECT pg_catalog.sum(block_count) * pg_catalog.current_setting('block_size')::int, '', NULL, NULL, 'used'
   FROM buffers

--- a/input/postgres/buffercache.go
+++ b/input/postgres/buffercache.go
@@ -23,7 +23,7 @@ SELECT block_count * pg_catalog.current_setting('block_size')::int, d.datname, n
   JOIN pg_catalog.pg_database d ON (d.oid = reldatabase)
        LEFT JOIN pg_catalog.pg_class c ON (b.relfilenode = pg_catalog.pg_relation_filenode(c.oid) AND (b.reldatabase = 0 OR d.datname = pg_catalog.current_database()))
        LEFT JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
- WHERE ($1 = '' OR (coalesce(n.nspname, '') || '.' || coalesce(c.relname, '')) !~* $1)
+ WHERE ($1 = '' OR (COALESCE(n.nspname, '') || '.' || COALESCE(c.relname, '')) !~* $1)
 UNION
 SELECT pg_catalog.sum(block_count) * pg_catalog.current_setting('block_size')::int, '', NULL, NULL, 'used'
   FROM buffers

--- a/input/postgres/buffercache.go
+++ b/input/postgres/buffercache.go
@@ -23,6 +23,7 @@ SELECT block_count * pg_catalog.current_setting('block_size')::int, d.datname, n
   JOIN pg_catalog.pg_database d ON (d.oid = reldatabase)
        LEFT JOIN pg_catalog.pg_class c ON (b.relfilenode = pg_catalog.pg_relation_filenode(c.oid) AND (b.reldatabase = 0 OR d.datname = pg_catalog.current_database()))
        LEFT JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
+ WHERE $1 = '' OR ((c.relname IS NULL OR c.relname !~* $1) AND (n.nspname IS NULL OR n.nspname !~* $1))
 UNION
 SELECT pg_catalog.sum(block_count) * pg_catalog.current_setting('block_size')::int, '', NULL, NULL, 'used'
   FROM buffers
@@ -67,7 +68,7 @@ func getSharedBufferBytes(db *sql.DB) int64 {
 	return bytes * multiplier
 }
 
-func GetBuffercache(logger *util.Logger, db *sql.DB, systemType string) (report state.PostgresBuffercache, err error) {
+func GetBuffercache(logger *util.Logger, db *sql.DB, systemType, ignoreRegexp string) (report state.PostgresBuffercache, err error) {
 	var sourceTable string
 
 	if statsHelperExists(db, "get_buffercache") {
@@ -82,7 +83,8 @@ func GetBuffercache(logger *util.Logger, db *sql.DB, systemType string) (report 
 		sourceTable = "public.pg_buffercache"
 	}
 
-	rows, err := db.Query(QueryMarkerSQL + fmt.Sprintf(buffercacheSQL, sourceTable))
+	query := QueryMarkerSQL + fmt.Sprintf(buffercacheSQL, sourceTable)
+	rows, err := db.Query(query, ignoreRegexp)
 	if err != nil {
 		if err.(*pq.Error).Code == "42P01" { // undefined_table
 			logger.PrintInfo("pg_buffercache relation does not exist, trying to create extension...")
@@ -92,7 +94,7 @@ func GetBuffercache(logger *util.Logger, db *sql.DB, systemType string) (report 
 				return
 			}
 
-			rows, err = db.Query(QueryMarkerSQL + fmt.Sprintf(buffercacheSQL, sourceTable))
+			rows, err = db.Query(query, ignoreRegexp)
 			if err != nil {
 				return
 			}

--- a/input/postgres/buffercache.go
+++ b/input/postgres/buffercache.go
@@ -23,7 +23,7 @@ SELECT block_count * pg_catalog.current_setting('block_size')::int, d.datname, n
   JOIN pg_catalog.pg_database d ON (d.oid = reldatabase)
        LEFT JOIN pg_catalog.pg_class c ON (b.relfilenode = pg_catalog.pg_relation_filenode(c.oid) AND (b.reldatabase = 0 OR d.datname = pg_catalog.current_database()))
        LEFT JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
- WHERE $1 = '' OR ((c.relname IS NULL OR c.relname !~* $1) AND (n.nspname IS NULL OR n.nspname !~* $1))
+ WHERE ($1 = '' OR (coalesce(c.relname, '') || '.' || coalesce(n.nspname, '')) !~* $1)
 UNION
 SELECT pg_catalog.sum(block_count) * pg_catalog.current_setting('block_size')::int, '', NULL, NULL, 'used'
   FROM buffers

--- a/input/postgres/functions.go
+++ b/input/postgres/functions.go
@@ -33,7 +33,7 @@ SELECT pp.oid,
  WHERE pl.lanname NOT IN ('internal', 'c')
 			 AND pn.nspname NOT IN ('pg_catalog', 'information_schema')
 			 AND pp.proname NOT IN ('pg_stat_statements', 'pg_stat_statements_reset')
-			 AND ($1 = '' OR (pp.proname || '.' || pn.nspname) !~* $1)
+			 AND ($1 = '' OR (pn.nspname || '.' || pp.proname) !~* $1)
 			 `
 
 const functionStatsSQL string = `
@@ -41,7 +41,7 @@ SELECT funcid, calls, total_time, self_time
 	FROM pg_stat_user_functions psuf
  INNER JOIN pg_catalog.pg_proc pp ON (psuf.funcid = pp.oid)
  INNER JOIN pg_catalog.pg_namespace pn ON (pp.pronamespace = pn.oid)
- WHERE ($1 = '' OR (pp.proname || '.' || pn.nspname) !~* $1)`
+ WHERE ($1 = '' OR (pn.nspname || '.' || pp.proname) !~* $1)`
 
 func GetFunctions(db *sql.DB, postgresVersion state.PostgresVersion, currentDatabaseOid state.Oid, ignoreRegexp string) ([]state.PostgresFunction, error) {
 	var kindFields string

--- a/input/postgres/functions.go
+++ b/input/postgres/functions.go
@@ -33,7 +33,7 @@ SELECT pp.oid,
  WHERE pl.lanname NOT IN ('internal', 'c')
 			 AND pn.nspname NOT IN ('pg_catalog', 'information_schema')
 			 AND pp.proname NOT IN ('pg_stat_statements', 'pg_stat_statements_reset')
-			 AND ($1 = '' OR (pp.proname !~* $1 AND pn.nspname !~* $1))
+			 AND ($1 = '' OR (pp.proname || '.' || pn.nspname) !~* $1)
 			 `
 
 const functionStatsSQL string = `
@@ -41,7 +41,7 @@ SELECT funcid, calls, total_time, self_time
 	FROM pg_stat_user_functions psuf
  INNER JOIN pg_catalog.pg_proc pp ON (psuf.funcid = pp.oid)
  INNER JOIN pg_catalog.pg_namespace pn ON (pp.pronamespace = pn.oid)
- WHERE $1 = '' OR (pp.proname !~* $1 AND pn.nspname !~* $1)`
+ WHERE ($1 = '' OR (pp.proname || '.' || pn.nspname) !~* $1)`
 
 func GetFunctions(db *sql.DB, postgresVersion state.PostgresVersion, currentDatabaseOid state.Oid, ignoreRegexp string) ([]state.PostgresFunction, error) {
 	var kindFields string

--- a/input/postgres/relation_bloat.go
+++ b/input/postgres/relation_bloat.go
@@ -30,7 +30,7 @@ columns AS (
 	       AND a.attnum > 0
 				 AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
 				 AND NOT a.attisdropped
-				 AND ($1 = '' OR (c.relname || '.' || n.nspname) !~* $1)
+				 AND ($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)
 ),
 no_stats AS (
 		-- screen out table who have attributes
@@ -130,7 +130,7 @@ WITH btree_index_atts AS (
 				 JOIN pg_catalog.pg_am a ON (ic.relam = a.oid)
 	 WHERE a.amname = 'btree' AND ic.relpages > 0
 				 AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
-				 AND ($1 = '' OR (tc.relname || '.' || n.nspname) !~* $1)
+				 AND ($1 = '' OR (n.nspname || '.' || tc.relname) !~* $1)
 ),
 index_item_sizes AS (
 	SELECT ia.nspname,

--- a/input/postgres/relation_bloat.go
+++ b/input/postgres/relation_bloat.go
@@ -30,7 +30,7 @@ columns AS (
 	       AND a.attnum > 0
 				 AND n.nspname NOT IN ('pg_catalog', 'information_schema', 'pg_toast')
 				 AND NOT a.attisdropped
-				 AND ($1 = '' OR (c.relname !~* $1 AND n.nspname !~* $1))
+				 AND ($1 = '' OR (c.relname || '.' || n.nspname) !~* $1)
 ),
 no_stats AS (
 		-- screen out table who have attributes
@@ -130,7 +130,7 @@ WITH btree_index_atts AS (
 				 JOIN pg_catalog.pg_am a ON (ic.relam = a.oid)
 	 WHERE a.amname = 'btree' AND ic.relpages > 0
 				 AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
-				 AND ($1 = '' OR (tc.relname !~* $1 AND n.nspname !~* $1))
+				 AND ($1 = '' OR (tc.relname || '.' || n.nspname) !~* $1)
 ),
 index_item_sizes AS (
 	SELECT ia.nspname,

--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -52,7 +52,7 @@ SELECT c.oid,
 			 AND c.relpersistence <> 't'
 			 AND c.relname NOT IN ('pg_stat_statements')
 			 AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
-			 AND ($1 = '' OR (c.relname !~* $1 AND n.nspname !~* $1))
+			 AND ($1 = '' OR (c.relname || '.' || n.nspname) !~* $1)
 `
 
 const indexStatsSQL = `
@@ -67,7 +67,7 @@ SELECT s.indexrelid,
 	FROM pg_catalog.pg_stat_user_indexes s
 			 LEFT JOIN pg_catalog.pg_statio_user_indexes sio USING (indexrelid)
  WHERE s.indexrelid NOT IN (SELECT relid FROM locked_relids)
-			 AND ($1 = '' OR (relname !~* $1 AND schemaname !~* $1))
+			 AND ($1 = '' OR (relname || '.' || schemaname) !~* $1)
 `
 
 func GetRelationStats(db *sql.DB, postgresVersion state.PostgresVersion, ignoreRegexp string) (relStats state.PostgresRelationStatsMap, err error) {

--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -52,7 +52,7 @@ SELECT c.oid,
 			 AND c.relpersistence <> 't'
 			 AND c.relname NOT IN ('pg_stat_statements')
 			 AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
-			 AND ($1 = '' OR (c.relname || '.' || n.nspname) !~* $1)
+			 AND ($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)
 `
 
 const indexStatsSQL = `
@@ -67,7 +67,7 @@ SELECT s.indexrelid,
 	FROM pg_catalog.pg_stat_user_indexes s
 			 LEFT JOIN pg_catalog.pg_statio_user_indexes sio USING (indexrelid)
  WHERE s.indexrelid NOT IN (SELECT relid FROM locked_relids)
-			 AND ($1 = '' OR (relname || '.' || schemaname) !~* $1)
+			 AND ($1 = '' OR (schemaname || '.' || relname) !~* $1)
 `
 
 func GetRelationStats(db *sql.DB, postgresVersion state.PostgresVersion, ignoreRegexp string) (relStats state.PostgresRelationStatsMap, err error) {

--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -117,7 +117,7 @@ func GetRelationStats(db *sql.DB, postgresVersion state.PostgresVersion, ignoreR
 		relStats[oid] = stats
 	}
 
-	relStats, err = handleRelationStatsExt(db, relStats, postgresVersion)
+	relStats, err = handleRelationStatsExt(db, relStats, postgresVersion, ignoreRegexp)
 
 	return
 }

--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -67,7 +67,7 @@ SELECT s.indexrelid,
 	FROM pg_catalog.pg_stat_user_indexes s
 			 LEFT JOIN pg_catalog.pg_statio_user_indexes sio USING (indexrelid)
  WHERE s.indexrelid NOT IN (SELECT relid FROM locked_relids)
-			 AND ($1 = '' OR (schemaname || '.' || relname) !~* $1)
+			 AND ($1 = '' OR (s.schemaname || '.' || s.relname) !~* $1)
 `
 
 func GetRelationStats(db *sql.DB, postgresVersion state.PostgresVersion, ignoreRegexp string) (relStats state.PostgresRelationStatsMap, err error) {

--- a/input/postgres/relation_stats_ext.go
+++ b/input/postgres/relation_stats_ext.go
@@ -24,7 +24,7 @@ func handleRelationStatsExt(db *sql.DB, relStats state.PostgresRelationStatsMap,
 		}
 		defer stmt.Close()
 
-		rows, err := stmt.Query()
+		rows, err := stmt.Query(ignoreRegexp)
 		if err != nil {
 			return relStats, fmt.Errorf("RelationStatsExt/Query: %s", err)
 		}

--- a/input/postgres/relations.go
+++ b/input/postgres/relations.go
@@ -249,8 +249,7 @@ func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentData
 	}
 
 	// Constraints
-	rows, err = db.Query(QueryMarkerSQL+constraintsSQL, ignoreRegeAND c.relname !~* $1
-		AND n.nspname !~* $1xp)
+	rows, err = db.Query(QueryMarkerSQL+constraintsSQL, ignoreRegexp)
 	if err != nil {
 		err = fmt.Errorf("Constraints/Query: %s", err)
 		return nil, err

--- a/input/postgres/relations.go
+++ b/input/postgres/relations.go
@@ -39,7 +39,8 @@ const relationsSQL string = `
 	WHERE c.relkind IN ('r','v','m','p')
 				AND c.relpersistence <> 't'
 				AND c.relname NOT IN ('pg_stat_statements')
-				AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')`
+				AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
+				AND ($1 = '' OR (c.relname !~* $1 AND n.nspname !~* $1))`
 
 const columnsSQL string = `
 	 WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock')
@@ -63,6 +64,7 @@ const columnsSQL string = `
 			 AND a.attnum > 0
 			 AND NOT a.attisdropped
 			 AND c.oid NOT IN (SELECT relid FROM locked_relids)
+			 AND ($1 = '' OR (c.relname !~* $1 AND n.nspname !~* $1))
  ORDER BY a.attnum`
 
 const indicesSQL string = `
@@ -89,7 +91,8 @@ SELECT c.oid,
 			 AND c.relpersistence <> 't'
 			 AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
 			 AND c.oid NOT IN (SELECT relid FROM locked_relids)
-			 AND c2.oid NOT IN (SELECT relid FROM locked_relids)`
+			 AND c2.oid NOT IN (SELECT relid FROM locked_relids)
+			 AND ($1 = '' OR (c.relname !~* $1 AND n.nspname !~* $1))`
 
 const constraintsSQL string = `
 	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock')
@@ -107,7 +110,8 @@ SELECT c.oid,
 			 JOIN pg_catalog.pg_class c ON (r.conrelid = c.oid)
 			 JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
 WHERE n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
-			AND c.oid NOT IN (SELECT relid FROM locked_relids)`
+			AND c.oid NOT IN (SELECT relid FROM locked_relids)
+			AND ($1 = '' OR (c.relname !~* $1 AND n.nspname !~* $1))`
 
 const viewDefinitionSQL string = `
 	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock')
@@ -119,9 +123,10 @@ SELECT c.oid,
 			 AND c.relpersistence <> 't'
 			 AND c.relname NOT IN ('pg_stat_statements')
 			 AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
-			 AND c.oid NOT IN (SELECT relid FROM locked_relids)`
+			 AND c.oid NOT IN (SELECT relid FROM locked_relids)
+			 AND ($1 = '' OR (c.relname !~* $1 AND n.nspname !~* $1))`
 
-func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentDatabaseOid state.Oid) ([]state.PostgresRelation, error) {
+func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentDatabaseOid state.Oid, ignoreRegexp string) ([]state.PostgresRelation, error) {
 	relations := make(map[state.Oid]state.PostgresRelation, 0)
 
 	// Relations
@@ -147,7 +152,7 @@ func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentData
 		oidField = relationsSQLOidField
 	}
 
-	rows, err := db.Query(QueryMarkerSQL + fmt.Sprintf(relationsSQL, oidField, optionalFields, partBoundField))
+	rows, err := db.Query(QueryMarkerSQL+fmt.Sprintf(relationsSQL, oidField, optionalFields, partBoundField), ignoreRegexp)
 	if err != nil {
 		err = fmt.Errorf("Relations/Query: %s", err)
 		return nil, err
@@ -181,7 +186,7 @@ func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentData
 	}
 
 	// Columns
-	rows, err = db.Query(QueryMarkerSQL + columnsSQL)
+	rows, err = db.Query(QueryMarkerSQL+columnsSQL, ignoreRegexp)
 	if err != nil {
 		err = fmt.Errorf("Columns/Query: %s", err)
 		return nil, err
@@ -205,7 +210,7 @@ func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentData
 	}
 
 	// Indices
-	rows, err = db.Query(QueryMarkerSQL + indicesSQL)
+	rows, err = db.Query(QueryMarkerSQL+indicesSQL, ignoreRegexp)
 	if err != nil {
 		err = fmt.Errorf("Indices/Query: %s", err)
 		return nil, err
@@ -244,7 +249,8 @@ func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentData
 	}
 
 	// Constraints
-	rows, err = db.Query(QueryMarkerSQL + constraintsSQL)
+	rows, err = db.Query(QueryMarkerSQL+constraintsSQL, ignoreRegeAND c.relname !~* $1
+		AND n.nspname !~* $1xp)
 	if err != nil {
 		err = fmt.Errorf("Constraints/Query: %s", err)
 		return nil, err
@@ -293,7 +299,7 @@ func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentData
 	}
 
 	// View definitions
-	rows, err = db.Query(QueryMarkerSQL + viewDefinitionSQL)
+	rows, err = db.Query(QueryMarkerSQL+viewDefinitionSQL, ignoreRegexp)
 	if err != nil {
 		err = fmt.Errorf("Views/Prepare: %s", err)
 		return nil, err

--- a/input/postgres/relations.go
+++ b/input/postgres/relations.go
@@ -40,7 +40,7 @@ const relationsSQL string = `
 				AND c.relpersistence <> 't'
 				AND c.relname NOT IN ('pg_stat_statements')
 				AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
-				AND ($1 = '' OR (c.relname || '.' || n.nspname) !~* $1)`
+				AND ($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)`
 
 const columnsSQL string = `
 	 WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock')
@@ -64,7 +64,7 @@ const columnsSQL string = `
 			 AND a.attnum > 0
 			 AND NOT a.attisdropped
 			 AND c.oid NOT IN (SELECT relid FROM locked_relids)
-			 AND ($1 = '' OR (c.relname || '.' || n.nspname) !~* $1)
+			 AND ($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)
  ORDER BY a.attnum`
 
 const indicesSQL string = `
@@ -92,7 +92,7 @@ SELECT c.oid,
 			 AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
 			 AND c.oid NOT IN (SELECT relid FROM locked_relids)
 			 AND c2.oid NOT IN (SELECT relid FROM locked_relids)
-			 AND ($1 = '' OR (c.relname || '.' || n.nspname) !~* $1)`
+			 AND ($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)`
 
 const constraintsSQL string = `
 	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock')
@@ -111,7 +111,7 @@ SELECT c.oid,
 			 JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
 WHERE n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
 			AND c.oid NOT IN (SELECT relid FROM locked_relids)
-			AND ($1 = '' OR (c.relname || '.' || n.nspname) !~* $1)`
+			AND ($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)`
 
 const viewDefinitionSQL string = `
 	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock')
@@ -124,7 +124,7 @@ SELECT c.oid,
 			 AND c.relname NOT IN ('pg_stat_statements')
 			 AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
 			 AND c.oid NOT IN (SELECT relid FROM locked_relids)
-			 AND ($1 = '' OR (c.relname || '.' || n.nspname) !~* $1)`
+			 AND ($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)`
 
 func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentDatabaseOid state.Oid, ignoreRegexp string) ([]state.PostgresRelation, error) {
 	relations := make(map[state.Oid]state.PostgresRelation, 0)

--- a/input/postgres/relations.go
+++ b/input/postgres/relations.go
@@ -40,7 +40,7 @@ const relationsSQL string = `
 				AND c.relpersistence <> 't'
 				AND c.relname NOT IN ('pg_stat_statements')
 				AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
-				AND ($1 = '' OR (c.relname !~* $1 AND n.nspname !~* $1))`
+				AND ($1 = '' OR (c.relname || '.' || n.nspname) !~* $1)`
 
 const columnsSQL string = `
 	 WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock')
@@ -64,7 +64,7 @@ const columnsSQL string = `
 			 AND a.attnum > 0
 			 AND NOT a.attisdropped
 			 AND c.oid NOT IN (SELECT relid FROM locked_relids)
-			 AND ($1 = '' OR (c.relname !~* $1 AND n.nspname !~* $1))
+			 AND ($1 = '' OR (c.relname || '.' || n.nspname) !~* $1)
  ORDER BY a.attnum`
 
 const indicesSQL string = `
@@ -92,7 +92,7 @@ SELECT c.oid,
 			 AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
 			 AND c.oid NOT IN (SELECT relid FROM locked_relids)
 			 AND c2.oid NOT IN (SELECT relid FROM locked_relids)
-			 AND ($1 = '' OR (c.relname !~* $1 AND n.nspname !~* $1))`
+			 AND ($1 = '' OR (c.relname || '.' || n.nspname) !~* $1)`
 
 const constraintsSQL string = `
 	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock')
@@ -111,7 +111,7 @@ SELECT c.oid,
 			 JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
 WHERE n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
 			AND c.oid NOT IN (SELECT relid FROM locked_relids)
-			AND ($1 = '' OR (c.relname !~* $1 AND n.nspname !~* $1))`
+			AND ($1 = '' OR (c.relname || '.' || n.nspname) !~* $1)`
 
 const viewDefinitionSQL string = `
 	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock')
@@ -124,7 +124,7 @@ SELECT c.oid,
 			 AND c.relname NOT IN ('pg_stat_statements')
 			 AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
 			 AND c.oid NOT IN (SELECT relid FROM locked_relids)
-			 AND ($1 = '' OR (c.relname !~* $1 AND n.nspname !~* $1))`
+			 AND ($1 = '' OR (c.relname || '.' || n.nspname) !~* $1)`
 
 func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentDatabaseOid state.Oid, ignoreRegexp string) ([]state.PostgresRelation, error) {
 	relations := make(map[state.Oid]state.PostgresRelation, 0)

--- a/input/postgres/schema.go
+++ b/input/postgres/schema.go
@@ -40,7 +40,7 @@ func CollectAllSchemas(server state.Server, collectionOpts state.CollectionOpts,
 			continue
 		}
 
-		ps = collectSchemaData(collectionOpts, logger, schemaConnection, ps, databaseOid, dbName, ts.Version, server.Config.IgnoreTableRegexp)
+		ps = collectSchemaData(collectionOpts, logger, schemaConnection, ps, databaseOid, dbName, ts.Version, server.Config.IgnoreSchemaRegexp)
 		ts.DatabaseOidsWithLocalCatalog = append(ts.DatabaseOidsWithLocalCatalog, databaseOid)
 
 		schemaConnection.Close()

--- a/input/postgres/schema.go
+++ b/input/postgres/schema.go
@@ -40,7 +40,7 @@ func CollectAllSchemas(server state.Server, collectionOpts state.CollectionOpts,
 			continue
 		}
 
-		ps = collectSchemaData(collectionOpts, logger, schemaConnection, ps, databaseOid, dbName, ts.Version)
+		ps = collectSchemaData(collectionOpts, logger, schemaConnection, ps, databaseOid, dbName, ts.Version, server.Config.IgnoreTableRegexp)
 		ts.DatabaseOidsWithLocalCatalog = append(ts.DatabaseOidsWithLocalCatalog, databaseOid)
 
 		schemaConnection.Close()
@@ -49,16 +49,16 @@ func CollectAllSchemas(server state.Server, collectionOpts state.CollectionOpts,
 	return ps, ts
 }
 
-func collectSchemaData(collectionOpts state.CollectionOpts, logger *util.Logger, db *sql.DB, ps state.PersistedState, databaseOid state.Oid, databaseName string, postgresVersion state.PostgresVersion) state.PersistedState {
+func collectSchemaData(collectionOpts state.CollectionOpts, logger *util.Logger, db *sql.DB, ps state.PersistedState, databaseOid state.Oid, databaseName string, postgresVersion state.PostgresVersion, ignoreRegexp string) state.PersistedState {
 	if collectionOpts.CollectPostgresRelations {
-		newRelations, err := GetRelations(db, postgresVersion, databaseOid)
+		newRelations, err := GetRelations(db, postgresVersion, databaseOid, ignoreRegexp)
 		if err != nil {
 			logger.PrintWarning("Skipping table/index data for database \"%s\", due to error: %s", databaseName, err)
 			return ps
 		}
 		ps.Relations = append(ps.Relations, newRelations...)
 
-		newRelationStats, err := GetRelationStats(db, postgresVersion)
+		newRelationStats, err := GetRelationStats(db, postgresVersion, ignoreRegexp)
 		if err != nil {
 			logger.PrintWarning("Skipping table statistics for database \"%s\", due to error: %s", databaseName, err)
 			return ps
@@ -67,7 +67,7 @@ func collectSchemaData(collectionOpts state.CollectionOpts, logger *util.Logger,
 			ps.RelationStats[k] = v
 		}
 
-		newIndexStats, err := GetIndexStats(db, postgresVersion)
+		newIndexStats, err := GetIndexStats(db, postgresVersion, ignoreRegexp)
 		if err != nil {
 			logger.PrintWarning("Skipping index statistics for database \"%s\", due to error: %s", databaseName, err)
 			return ps
@@ -78,7 +78,7 @@ func collectSchemaData(collectionOpts state.CollectionOpts, logger *util.Logger,
 	}
 
 	if collectionOpts.CollectPostgresFunctions {
-		newFunctions, err := GetFunctions(db, postgresVersion, databaseOid)
+		newFunctions, err := GetFunctions(db, postgresVersion, databaseOid, ignoreRegexp)
 		if err != nil {
 			logger.PrintWarning("Skipping stored procedure data for database \"%s\", due to error: %s", databaseName, err)
 			return ps

--- a/input/postgres/vacuum_progress.go
+++ b/input/postgres/vacuum_progress.go
@@ -9,25 +9,30 @@ import (
 )
 
 const vacuumProgressSQLpg95 string = `
-SELECT (EXTRACT(epoch FROM a.query_start)::int::text || pg_catalog.to_char(pid, 'FM0000000'))::bigint AS vacuum_identity,
-			 (EXTRACT(epoch FROM COALESCE(backend_start, pg_catalog.pg_postmaster_start_time()))::int::text || pg_catalog.to_char(pid, 'FM0000000'))::bigint AS backend_identity,
+WITH activity AS (
+	SELECT pg_catalog.to_char(pid, 'FM0000000') AS padded_pid,
+	       EXTRACT(epoch FROM a.query_start)::int::text AS query_start_epoch,
+				 EXTRACT(epoch FROM COALESCE(backend_start, pg_catalog.pg_postmaster_start_time()))::int::text AS backend_start_epoch,
+				 a.datname,
+				 (SELECT pg_catalog.regexp_matches(query, 'autovacuum: VACUUM (ANALYZE )?([^\.]+).([^\(]+)( \(to prevent wraparound\))?'))[2] AS nspname,
+				 (SELECT pg_catalog.regexp_matches(query, 'autovacuum: VACUUM (ANALYZE )?([^\.]+).([^\(]+)( \(to prevent wraparound\))?'))[3] AS relname,
+				 COALESCE(a.usename, '') AS usename,
+				 a.query_start,
+				 a.query LIKE 'autovacuum: VACUUM%%' AS autovacuum
+    FROM %s a
+	 WHERE a.query LIKE 'autovacuum: VACUUM%%'
+)
+SELECT (a.query_start_epoch || a.padded_pid)::bigint AS vacuum_identity,
+			 (a.backend_start_epoch || a.padded_pid)::bigint AS backend_identity,
 			 a.datname,
-			 (SELECT pg_catalog.regexp_matches(query, 'autovacuum: VACUUM (ANALYZE )?([^\.]+).([^\(]+)( \(to prevent wraparound\))?'))[2] AS nspname,
+			 a.nspname,
 			 CASE
-			   WHEN ($1 = '' OR
-				   (COALESCE(n.nspname,
-					  (SELECT pg_catalog.regexp_matches(query, 'autovacuum: VACUUM (ANALYZE )?([^\.]+).([^\(]+)( \(to prevent wraparound\))?'))[2])
-					  || '.' ||
-					  COALESCE(c.relname,
-					  (SELECT pg_catalog.regexp_matches(query, 'autovacuum: VACUUM (ANALYZE )?([^\.]+).([^\(]+)( \(to prevent wraparound\))?'))[3])) !~* $1)
-			   THEN COALESCE(c.relname,
-				   (SELECT pg_catalog.regexp_matches(query, 'autovacuum: VACUUM (ANALYZE )?([^\.]+).([^\(]+)( \(to prevent wraparound\))?'))[3])
-			   ELSE
-				   ''
+			   WHEN ($1 = '' OR (a.nspname || '.' || a.relname) !~* $1) THEN a.relname
+			   ELSE ''
 		   END AS relname,
-			 COALESCE(a.usename, '') AS usename,
+       a.usename,
 			 a.query_start AS started_at,
-			 a.query LIKE 'autovacuum: VACUUM%%' AS autovacuum,
+			 a.autovacuum,
 			 '' AS phase,
 			 0 AS heap_blks_total,
 			 0 AS heap_blks_scanned,
@@ -35,30 +40,35 @@ SELECT (EXTRACT(epoch FROM a.query_start)::int::text || pg_catalog.to_char(pid, 
 			 0 AS index_vacuum_count,
 			 0 AS max_dead_tuples,
 			 0 AS num_dead_tuples
-	FROM %s a
- WHERE a.query LIKE 'autovacuum: VACUUM%%'
+	FROM activity a
 `
 
 const vacuumProgressSQLDefault string = `
-SELECT (EXTRACT(epoch FROM a.query_start)::int::text || pg_catalog.to_char(pid, 'FM0000000'))::bigint AS vacuum_identity,
-			 (EXTRACT(epoch FROM COALESCE(backend_start, pg_catalog.pg_postmaster_start_time()))::int::text || pg_catalog.to_char(pid, 'FM0000000'))::bigint AS backend_identity,
+WITH activity AS (
+	SELECT pg_catalog.to_char(pid, 'FM0000000') AS padded_pid,
+	       EXTRACT(epoch FROM a.query_start)::int::text AS query_start_epoch,
+				 EXTRACT(epoch FROM COALESCE(backend_start, pg_catalog.pg_postmaster_start_time()))::int::text AS backend_start_epoch,
+				 a.datname,
+				 (SELECT pg_catalog.regexp_matches(query, 'autovacuum: VACUUM (ANALYZE )?([^\.]+).([^\(]+)( \(to prevent wraparound\))?'))[2] AS nspname,
+				 (SELECT pg_catalog.regexp_matches(query, 'autovacuum: VACUUM (ANALYZE )?([^\.]+).([^\(]+)( \(to prevent wraparound\))?'))[3] AS relname,
+				 COALESCE(a.usename, '') AS usename,
+				 a.query_start,
+				 a.query LIKE 'autovacuum: VACUUM%%' AS autovacuum,
+				 a.query,
+				 a.pid
+  FROM %s a
+)
+SELECT (query_start_epoch || padded_pid)::bigint AS vacuum_identity,
+			 (backend_start_epoch || padded_pid)::bigint AS backend_identity,
 			 a.datname,
-			 COALESCE(n.nspname, (SELECT pg_catalog.regexp_matches(query, 'autovacuum: VACUUM (ANALYZE )?([^\.]+).([^\(]+)( \(to prevent wraparound\))?'))[2]) AS nspname,
+			 COALESCE(n.nspname, a.nspname) AS nspname,
 			 CASE
-				 WHEN ($1 = '' OR
-					 (COALESCE(n.nspname,
-						(SELECT pg_catalog.regexp_matches(query, 'autovacuum: VACUUM (ANALYZE )?([^\.]+).([^\(]+)( \(to prevent wraparound\))?'))[2])
-						|| '.' ||
-						COALESCE(c.relname,
-						(SELECT pg_catalog.regexp_matches(query, 'autovacuum: VACUUM (ANALYZE )?([^\.]+).([^\(]+)( \(to prevent wraparound\))?'))[3])) !~* $1)
-				 THEN COALESCE(c.relname,
-				   (SELECT pg_catalog.regexp_matches(query, 'autovacuum: VACUUM (ANALYZE )?([^\.]+).([^\(]+)( \(to prevent wraparound\))?'))[3])
-				 ELSE
-				   ''
+				 WHEN ($1 = '' OR (COALESCE(n.nspname, a.nspname) || '.' || COALESCE(c.relname, a.relname)) !~* $1) THEN COALESCE(c.relname, a.relname)
+				 ELSE ''
 			 END AS relname,
-			 COALESCE(a.usename, '') AS usename,
+			 a.usename,
 			 a.query_start AS started_at,
-			 a.query LIKE 'autovacuum: VACUUM%%' AS autovacuum,
+			 a.autovacuum,
 			 COALESCE(v.phase, '') AS phase,
 			 COALESCE(v.heap_blks_total, 0) AS heap_blks_total,
 			 COALESCE(v.heap_blks_scanned, 0) AS heap_blks_scanned,
@@ -67,7 +77,7 @@ SELECT (EXTRACT(epoch FROM a.query_start)::int::text || pg_catalog.to_char(pid, 
 			 COALESCE(v.max_dead_tuples, 0) AS max_dead_tuples,
 			 COALESCE(v.num_dead_tuples, 0) AS num_dead_tuples
 	FROM %s v
-			 JOIN %s a USING (pid)
+			 JOIN activity a USING (pid)
 			 LEFT JOIN pg_catalog.pg_class c ON (c.oid = v.relid)
 			 LEFT JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
  WHERE v.relid IS NOT NULL OR a.query <> '<insufficient privilege>'
@@ -92,7 +102,7 @@ func GetVacuumProgress(logger *util.Logger, db *sql.DB, postgresVersion state.Po
 		} else {
 			vacuumSourceTable = "pg_catalog.pg_stat_progress_vacuum"
 		}
-		sql = fmt.Sprintf(vacuumProgressSQLDefault, vacuumSourceTable, activitySourceTable)
+		sql = fmt.Sprintf(vacuumProgressSQLDefault, activitySourceTable, vacuumSourceTable)
 	}
 
 	stmt, err := db.Prepare(QueryMarkerSQL + sql)

--- a/integration_test/Makefile
+++ b/integration_test/Makefile
@@ -11,13 +11,18 @@ pg92:
 	sleep 10
 	docker exec pganalyze-collector-test pgbench -U postgres -i
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg92_1.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg92_1.json
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg92_2.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg92_2.json
 	docker rm -f pganalyze-collector-test
 	docker rmi pganalyze-collector-test
 	if [ "`jq '.collectorErrors' pg92_2.json | tr -d ' \n\r\t '`" != "null" ]; then \
 		jq '.collectorErrors' pg92_2.json; \
+		exit 1; \
+	fi
+	if jq '.relationReferences' pg92_2.json | grep --quiet pgbench_history; then \
+                echo "failed to ignore table according to IGNORE_SCHEMA_REGEXP=pgbench_history" \
+		jq '.relationReferences' pg92_2.json; \
 		exit 1; \
 	fi
 	jq '.queryInformations[].normalizedQuery' pg92_2.json | sort --version-sort -f > pg92.out
@@ -29,13 +34,18 @@ pg93:
 	sleep 10
 	docker exec pganalyze-collector-test pgbench -U postgres -i
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg93_1.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg93_1.json
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg93_2.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg93_2.json
 	docker rm -f pganalyze-collector-test
 	docker rmi pganalyze-collector-test
 	if [ "`jq '.collectorErrors' pg93_2.json | tr -d ' \n\r\t '`" != "null" ]; then \
 		jq '.collectorErrors' pg93_2.json; \
+		exit 1; \
+	fi
+	if jq '.relationReferences' pg93_2.json | grep --quiet pgbench_history; then \
+                echo "failed to ignore table according to IGNORE_SCHEMA_REGEXP=pgbench_history" \
+		jq '.relationReferences' pg93_2.json; \
 		exit 1; \
 	fi
 	jq '.queryInformations[].normalizedQuery' pg93_2.json | sort --version-sort -f > pg93.out
@@ -47,13 +57,18 @@ pg94:
 	sleep 10
 	docker exec pganalyze-collector-test pgbench -U postgres -i
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg94_1.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg94_1.json
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg94_2.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg94_2.json
 	docker rm -f pganalyze-collector-test
 	docker rmi pganalyze-collector-test
 	if [ "`jq '.collectorErrors' pg94_2.json | tr -d ' \n\r\t '`" != "null" ]; then \
 		jq '.collectorErrors' pg94_2.json; \
+		exit 1; \
+	fi
+	if jq '.relationReferences' pg94_2.json | grep --quiet pgbench_history; then \
+                echo "failed to ignore table according to IGNORE_SCHEMA_REGEXP=pgbench_history" \
+		jq '.relationReferences' pg94_2.json; \
 		exit 1; \
 	fi
 	jq '.queryInformations[].normalizedQuery' pg94_2.json | sort --version-sort -f > pg94.out
@@ -65,13 +80,18 @@ pg95:
 	sleep 10
 	docker exec pganalyze-collector-test pgbench -U postgres -i
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg95_1.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg95_1.json
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg95_2.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg95_2.json
 	docker rm -f pganalyze-collector-test
 	docker rmi pganalyze-collector-test
 	if [ "`jq '.collectorErrors' pg95_2.json | tr -d ' \n\r\t '`" != "null" ]; then \
 		jq '.collectorErrors' pg95_2.json; \
+		exit 1; \
+	fi
+	if jq '.relationReferences' pg95_2.json | grep --quiet pgbench_history; then \
+                echo "failed to ignore table according to IGNORE_SCHEMA_REGEXP=pgbench_history" \
+		jq '.relationReferences' pg95_2.json; \
 		exit 1; \
 	fi
 	jq '.queryInformations[].normalizedQuery' pg95_2.json | sort --version-sort -f > pg95.out
@@ -83,13 +103,18 @@ pg96:
 	sleep 10
 	docker exec pganalyze-collector-test pgbench -U postgres -i
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg96_1.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg96_1.json
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg96_2.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg96_2.json
 	docker rm -f pganalyze-collector-test
 	docker rmi pganalyze-collector-test
 	if [ "`jq '.collectorErrors' pg96_2.json | tr -d ' \n\r\t '`" != "null" ]; then \
 		jq '.collectorErrors' pg96_2.json; \
+		exit 1; \
+	fi
+	if jq '.relationReferences' pg96_2.json | grep --quiet pgbench_history; then \
+                echo "failed to ignore table according to IGNORE_SCHEMA_REGEXP=pgbench_history" \
+		jq '.relationReferences' pg96_2.json; \
 		exit 1; \
 	fi
 	jq '.queryInformations[].normalizedQuery' pg96_2.json | sort --version-sort -f > pg96.out
@@ -101,13 +126,18 @@ pg10:
 	sleep 10
 	docker exec pganalyze-collector-test pgbench -U postgres -i
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg10_1.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg10_1.json
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg10_2.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg10_2.json
 	docker rm -f pganalyze-collector-test
 	docker rmi pganalyze-collector-test
 	if [ "`jq '.collectorErrors' pg10_2.json | tr -d ' \n\r\t '`" != "null" ]; then \
 		jq '.collectorErrors' pg10_2.json; \
+		exit 1; \
+	fi
+	if jq '.relationReferences' pg10_2.json | grep --quiet pgbench_history; then \
+                echo "failed to ignore table according to IGNORE_SCHEMA_REGEXP=pgbench_history" \
+		jq '.relationReferences' pg10_2.json; \
 		exit 1; \
 	fi
 	jq '.queryInformations[].normalizedQuery' pg10_2.json | sort --version-sort -f > pg10.out
@@ -119,13 +149,18 @@ pg11:
 	sleep 10
 	docker exec pganalyze-collector-test pgbench -U postgres -i
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg11_1.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg11_1.json
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg11_2.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg11_2.json
 	docker rm -f pganalyze-collector-test
 	docker rmi pganalyze-collector-test
 	if [ "`jq '.collectorErrors' pg11_2.json | tr -d ' \n\r\t '`" != "null" ]; then \
 		jq '.collectorErrors' pg11_2.json; \
+		exit 1; \
+	fi
+	if jq '.relationReferences' pg11_2.json | grep --quiet pgbench_history; then \
+                echo "failed to ignore table according to IGNORE_SCHEMA_REGEXP=pgbench_history" \
+		jq '.relationReferences' pg11_2.json; \
 		exit 1; \
 	fi
 	jq '.queryInformations[].normalizedQuery' pg11_2.json | sort --version-sort -f > pg11.out
@@ -137,13 +172,18 @@ pg12:
 	sleep 10
 	docker exec pganalyze-collector-test pgbench -U postgres -i
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg12_1.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg12_1.json
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg12_2.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg12_2.json
 	docker rm -f pganalyze-collector-test
 	docker rmi pganalyze-collector-test
 	if [ "`jq '.collectorErrors' pg12_2.json | tr -d ' \n\r\t '`" != "null" ]; then \
 		jq '.collectorErrors' pg12_2.json; \
+		exit 1; \
+	fi
+	if jq '.relationReferences' pg12_2.json | grep --quiet pgbench_history; then \
+		echo "failed to ignore table according to IGNORE_SCHEMA_REGEXP=pgbench_history" \
+		jq '.relationReferences' pg12_2.json; \
 		exit 1; \
 	fi
 	jq '.queryInformations[].normalizedQuery' pg12_2.json | sort --version-sort -f > pg12.out
@@ -155,13 +195,18 @@ pg13:
 	sleep 10
 	docker exec pganalyze-collector-test pgbench -U postgres -i
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg13_1.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg13_1.json
 	docker exec pganalyze-collector-test pgbench -U postgres
-	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 pganalyze-collector --dry-run --force-state-update -v" > pg13_2.json
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg13_2.json
 	docker rm -f pganalyze-collector-test
 	docker rmi pganalyze-collector-test
 	if [ "`jq '.collectorErrors' pg13_2.json | tr -d ' \n\r\t '`" != "null" ]; then \
 		jq '.collectorErrors' pg13_2.json; \
+		exit 1; \
+	fi
+	if jq '.relationReferences' pg13_2.json | grep --quiet pgbench_history; then \
+                echo "failed to ignore table according to IGNORE_SCHEMA_REGEXP=pgbench_history" \
+		jq '.relationReferences' pg13_2.json; \
 		exit 1; \
 	fi
 	jq '.queryInformations[].normalizedQuery' pg13_2.json | sort --version-sort -f > pg13.out

--- a/output/transform/activity.go
+++ b/output/transform/activity.go
@@ -57,13 +57,17 @@ func ActivityStateToCompactActivitySnapshot(server state.Server, activityState s
 		}
 
 		vacuumInfo.DatabaseIdx, r.DatabaseReferences = upsertDatabaseReference(r.DatabaseReferences, vacuum.DatabaseName)
-		relationRef := snapshot.RelationReference{
-			DatabaseIdx:  vacuumInfo.DatabaseIdx,
-			SchemaName:   vacuum.SchemaName,
-			RelationName: vacuum.RelationName,
+		if vacuum.RelationName != "" {
+			relationRef := snapshot.RelationReference{
+				DatabaseIdx:  vacuumInfo.DatabaseIdx,
+				SchemaName:   vacuum.SchemaName,
+				RelationName: vacuum.RelationName,
+			}
+			vacuumInfo.RelationIdx = int32(len(r.RelationReferences))
+			r.RelationReferences = append(r.RelationReferences, &relationRef)
+		} else {
+			vacuumInfo.RelationIdx = -1
 		}
-		vacuumInfo.RelationIdx = int32(len(r.RelationReferences))
-		r.RelationReferences = append(r.RelationReferences, &relationRef)
 
 		vacuumInfo.StartedAt, _ = ptypes.TimestampProto(vacuum.StartedAt)
 

--- a/reports/bloat.go
+++ b/reports/bloat.go
@@ -32,7 +32,7 @@ func (report BloatReport) ReportType() string {
 func (report *BloatReport) Run(server state.Server, logger *util.Logger, connection *sql.DB) (err error) {
 	systemType := server.Config.SystemType
 
-	report.Data, err = postgres.GetBloatStats(logger, connection, systemType)
+	report.Data, err = postgres.GetBloatStats(logger, connection, systemType, server.Config.IgnoreSchemaRegexp)
 	if err != nil {
 		return
 	}

--- a/reports/buffercache.go
+++ b/reports/buffercache.go
@@ -33,7 +33,7 @@ func (report BuffercacheReport) ReportType() string {
 func (report *BuffercacheReport) Run(server state.Server, logger *util.Logger, connection *sql.DB) (err error) {
 	systemType := server.Config.SystemType
 
-	report.Data, err = postgres.GetBuffercache(logger, connection, systemType)
+	report.Data, err = postgres.GetBuffercache(logger, connection, systemType, server.Config.IgnoreSchemaRegexp)
 	if err != nil {
 		return
 	}

--- a/reports/vacuum.go
+++ b/reports/vacuum.go
@@ -30,7 +30,7 @@ func (report VacuumReport) ReportType() string {
 
 // Run the report
 func (report *VacuumReport) Run(server state.Server, logger *util.Logger, connection *sql.DB) (err error) {
-	report.Data, err = postgres.GetVacuumStats(logger, connection)
+	report.Data, err = postgres.GetVacuumStats(logger, connection, server.Config.IgnoreSchemaRegexp)
 	if err != nil {
 		return
 	}

--- a/runner/activity.go
+++ b/runner/activity.go
@@ -59,7 +59,7 @@ func processActivityForServer(server state.Server, globalCollectionOpts state.Co
 		return newState, false, errors.Wrap(err, "error collecting pg_stat_activity")
 	}
 
-	activity.Vacuums, err = postgres.GetVacuumProgress(logger, connection, activity.Version)
+	activity.Vacuums, err = postgres.GetVacuumProgress(logger, connection, activity.Version, server.Config.IgnoreSchemaRegexp)
 	if err != nil {
 		return newState, false, errors.Wrap(err, "error collecting pg_stat_vacuum_progress")
 	}


### PR DESCRIPTION
This is like `ignore_table_pattern`, but pushed down into the actual
stats-gathering queries to improve performance. This should work much
better on very large schemas.

We use a regular expression instead of the current glob-like matching
since the former is natively supported in Postgres.

Open items:

 * [x] (Updated to `ignore_schema_regexp` per discussion) ~Confirm the setting name (right now we filter schema name, table name, and function name, so `ignore_table_regexp` is not super accurate)~
 * [x] Filter the Citus-specific stats in `relation_stats_ext.go`
 * [x] Settle on handling of vacuum progress and stats
 * [x] Test. I don't believe `ignore_table_pattern` is tested right now, but its implementation is much simpler--it'd be great if we could exercise the filter in integration tests.