### PR TITLE
Enable log explain for all databases

### DIFF
--- a/input/logs.go
+++ b/input/logs.go
@@ -17,8 +17,8 @@ func DownloadLogs(server state.Server, prevLogState state.PersistedLogState, con
 	tls.CollectedAt = time.Now()
 	pls, tls.LogFiles, querySamples = system.DownloadLogFiles(prevLogState, server.Config, logger)
 
-	if server.Config.EnableLogExplain && connection != nil {
-		tls.QuerySamples = postgres.RunExplain(connection, server.Config.GetDbName(), querySamples)
+	if server.Config.EnableLogExplain {
+		tls.QuerySamples = postgres.RunExplain(server, querySamples, collectionOpts, logger)
 	} else {
 		tls.QuerySamples = querySamples
 	}

--- a/input/logs.go
+++ b/input/logs.go
@@ -1,7 +1,6 @@
 package input
 
 import (
-	"database/sql"
 	"time"
 
 	"github.com/pganalyze/collector/input/postgres"
@@ -11,7 +10,7 @@ import (
 )
 
 // DownloadLogs - Downloads a "logs" snapshot of log data we need on a regular interval
-func DownloadLogs(server state.Server, prevLogState state.PersistedLogState, connection *sql.DB, collectionOpts state.CollectionOpts, logger *util.Logger) (tls state.TransientLogState, pls state.PersistedLogState, err error) {
+func DownloadLogs(server state.Server, prevLogState state.PersistedLogState, collectionOpts state.CollectionOpts, logger *util.Logger) (tls state.TransientLogState, pls state.PersistedLogState, err error) {
 	var querySamples []state.PostgresQuerySample
 
 	tls.CollectedAt = time.Now()

--- a/input/postgres/explain.go
+++ b/input/postgres/explain.go
@@ -26,12 +26,15 @@ func RunExplain(server state.Server, inputs []state.PostgresQuerySample, collect
 	for dbName, dbSamples := range samplesByDb {
 		db, err := EstablishConnection(server, logger, collectionOpts, dbName)
 
-		if err == nil {
-			dbOutputs := runDbExplain(db, dbSamples)
-			outputs = append(outputs, dbOutputs...)
-
-			db.Close()
+		if err != nil {
+			logger.PrintVerbose("Could not connect to %s to run explain: %s; skipping", dbName, err)
+			continue
 		}
+
+		dbOutputs := runDbExplain(db, dbSamples)
+		db.Close()
+
+		outputs = append(outputs, dbOutputs...)
 	}
 	return
 }

--- a/input/postgres/explain.go
+++ b/input/postgres/explain.go
@@ -17,7 +17,8 @@ func RunExplain(server state.Server, inputs []state.PostgresQuerySample, collect
 	var samplesByDb = make(map[string]([]state.PostgresQuerySample))
 
 	skip := func(sample state.PostgresQuerySample) bool {
-		monitoredDb := sample.Database == server.Config.GetDbName() || server.Config.DbAllNames || contains(server.Config.DbExtraNames, sample.Database)
+		monitoredDb := sample.Database == "" || sample.Database == server.Config.GetDbName() ||
+			server.Config.DbAllNames || contains(server.Config.DbExtraNames, sample.Database)
 
 		return !monitoredDb ||
 			// EXPLAIN was already collected, e.g. from auto_explain

--- a/logs/stream/stream.go
+++ b/logs/stream/stream.go
@@ -230,11 +230,7 @@ func ProcessLogStream(server state.Server, logLines []state.LogLine, globalColle
 	}
 
 	if server.Config.EnableLogExplain && len(logState.QuerySamples) != 0 {
-		db, err := postgres.EstablishConnection(server, prefixedLogger, globalCollectionOpts, "")
-		if err == nil {
-			logState.QuerySamples = postgres.RunExplain(db, server.Config.GetDbName(), logState.QuerySamples)
-			db.Close()
-		}
+		logState.QuerySamples = postgres.RunExplain(server, logState.QuerySamples, globalCollectionOpts, prefixedLogger)
 	}
 
 	logState.LogFiles = []state.LogFile{logFile}

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -1,12 +1,10 @@
 package runner
 
 import (
-	"database/sql"
 	"sync"
 
 	"github.com/pganalyze/collector/grant"
 	"github.com/pganalyze/collector/input"
-	"github.com/pganalyze/collector/input/postgres"
 	"github.com/pganalyze/collector/input/system/azure"
 	"github.com/pganalyze/collector/input/system/google_cloudsql"
 	"github.com/pganalyze/collector/input/system/selfhosted"
@@ -33,17 +31,7 @@ func downloadLogsForServer(server state.Server, globalCollectionOpts state.Colle
 		return newLogState, false, nil
 	}
 
-	var connection *sql.DB
-	if server.Config.EnableLogExplain {
-		connection, err = postgres.EstablishConnection(server, logger, globalCollectionOpts, "")
-		if err != nil {
-			return newLogState, false, errors.Wrap(err, "failed to connect to database")
-		}
-
-		defer connection.Close()
-	}
-
-	transientLogState, persistedLogState, err := input.DownloadLogs(server, server.LogPrevState, connection, globalCollectionOpts, logger)
+	transientLogState, persistedLogState, err := input.DownloadLogs(server, server.LogPrevState, globalCollectionOpts, logger)
 	if err != nil {
 		transientLogState.Cleanup()
 		return newLogState, false, errors.Wrap(err, "could not collect logs")


### PR DESCRIPTION
Totally untested so far but it builds and doesn't break existing tests.

Fixes #910