### PR TITLE
EXPLAIN plans / Query samples: Support log line prefix without %d and %u

### DIFF
--- a/output/compact_logs.go
+++ b/output/compact_logs.go
@@ -21,7 +21,7 @@ func UploadAndSendLogs(server state.Server, grant state.GrantLogs, collectionOpt
 		logState.LogFiles = EncryptAndUploadLogfiles(server.Config.HTTPClient, grant.Logdata, grant.EncryptionKey, logger, logState.LogFiles)
 	}
 
-	ls, r := transform.LogStateToLogSnapshot(logState)
+	ls, r := transform.LogStateToLogSnapshot(server, logState)
 	s := pganalyze_collector.CompactSnapshot{
 		BaseRefs: &r,
 		Data:     &pganalyze_collector.CompactSnapshot_LogSnapshot{LogSnapshot: &ls},


### PR DESCRIPTION
Whilst not recommended, in some scenarios changing the log_line_prefix
is difficult, and we want to make it easy to get EXPLAIN data even in
those scenarios.

In case the log_line_prefix is missing the database (%d) and/or the user
(%u), we simply use the user and database of the collector connection.