### PR TITLE
Allow keeping of unparsable query texts as an optional setting

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -137,7 +137,8 @@ type ServerConfig struct {
 
 	// Configuration for PII filtering
 	FilterLogSecret   string `ini:"filter_log_secret"`   // none/all/credential/parsing_error/statement_text/statement_parameter/table_data/ops/unidentified (comma separated)
-	FilterQuerySample string `ini:"filter_query_sample"` // none/all
+	FilterQuerySample string `ini:"filter_query_sample"` // none/all (defaults to "none")
+	FilterQueryText   string `ini:"filter_query_text"`   // none/unparsable (defaults to "unparsable")
 
 	// HTTP proxy overrides
 	HTTPProxy  string `ini:"http_proxy"`

--- a/config/read.go
+++ b/config/read.go
@@ -188,6 +188,9 @@ func getDefaultConfig() *ServerConfig {
 	if filterQuerySample := os.Getenv("FILTER_QUERY_SAMPLE"); filterQuerySample != "" {
 		config.FilterQuerySample = filterQuerySample
 	}
+	if filterQueryText := os.Getenv("FILTER_QUERY_TEXT"); filterQueryText != "" {
+		config.FilterQueryText = filterQueryText
+	}
 	if httpProxy := os.Getenv("HTTP_PROXY"); httpProxy != "" {
 		config.HTTPProxy = httpProxy
 	}

--- a/input/full.go
+++ b/input/full.go
@@ -44,7 +44,7 @@ func CollectFull(server state.Server, connection *sql.DB, globalCollectionOpts s
 
 	ps.LastStatementStatsAt = time.Now()
 	postgres.SetQueryTextStatementTimeout(connection, logger, server)
-	ts.Statements, ts.StatementTexts, ps.StatementStats, err = postgres.GetStatements(logger, connection, globalCollectionOpts, ts.Version, true, systemType)
+	ts.Statements, ts.StatementTexts, ps.StatementStats, err = postgres.GetStatements(server, logger, connection, globalCollectionOpts, ts.Version, true, systemType)
 	postgres.SetDefaultStatementTimeout(connection, logger, server)
 	if err != nil {
 		err = fmt.Errorf("Error collecting pg_stat_statements: %s", err)
@@ -59,7 +59,7 @@ func CollectFull(server state.Server, connection *sql.DB, globalCollectionOpts s
 			logger.PrintError("Error calling pg_stat_statements_reset() as requested: %s", err)
 			return
 		}
-		_, _, ts.ResetStatementStats, err = postgres.GetStatements(logger, connection, globalCollectionOpts, ts.Version, false, systemType)
+		_, _, ts.ResetStatementStats, err = postgres.GetStatements(server, logger, connection, globalCollectionOpts, ts.Version, false, systemType)
 		if err != nil {
 			err = fmt.Errorf("Error collecting pg_stat_statements: %s", err)
 			return

--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -78,7 +78,7 @@ func ResetStatements(logger *util.Logger, db *sql.DB, systemType string) error {
 	return nil
 }
 
-func GetStatements(logger *util.Logger, db *sql.DB, globalCollectionOpts state.CollectionOpts, postgresVersion state.PostgresVersion, showtext bool, systemType string) (state.PostgresStatementMap, state.PostgresStatementTextMap, state.PostgresStatementStatsMap, error) {
+func GetStatements(server state.Server, logger *util.Logger, db *sql.DB, globalCollectionOpts state.CollectionOpts, postgresVersion state.PostgresVersion, showtext bool, systemType string) (state.PostgresStatementMap, state.PostgresStatementTextMap, state.PostgresStatementStatsMap, error) {
 	var err error
 	var totalTimeField string
 	var optionalFields string
@@ -219,7 +219,7 @@ func GetStatements(logger *util.Logger, db *sql.DB, globalCollectionOpts state.C
 	}
 
 	for fp, text := range statementTexts {
-		statementTexts[fp] = util.NormalizeQuery(text)
+		statementTexts[fp] = util.NormalizeQuery(text, server.Config.FilterQueryText)
 	}
 
 	return statements, statementTexts, statementStats, nil

--- a/output/transform/activity.go
+++ b/output/transform/activity.go
@@ -29,6 +29,7 @@ func ActivityStateToCompactActivitySnapshot(server state.Server, activityState s
 
 		if backend.Query.Valid {
 			b.QueryIdx, r.QueryReferences, r.QueryInformations = upsertQueryReferenceAndInformationSimple(
+				server,
 				r.QueryReferences,
 				r.QueryInformations,
 				b.RoleIdx,

--- a/output/transform/postgres_query.go
+++ b/output/transform/postgres_query.go
@@ -58,7 +58,7 @@ func upsertQueryReferenceAndInformation(s *snapshot.FullSnapshot, statementTexts
 	return idx
 }
 
-func upsertQueryReferenceAndInformationSimple(refs []*snapshot.QueryReference, infos []*snapshot.QueryInformation, roleIdx int32, databaseIdx int32, originalQuery string) (int32, []*snapshot.QueryReference, []*snapshot.QueryInformation) {
+func upsertQueryReferenceAndInformationSimple(server state.Server, refs []*snapshot.QueryReference, infos []*snapshot.QueryInformation, roleIdx int32, databaseIdx int32, originalQuery string) (int32, []*snapshot.QueryReference, []*snapshot.QueryInformation) {
 	fingerprint := util.FingerprintQuery(originalQuery)
 
 	newRef := snapshot.QueryReference{
@@ -80,7 +80,7 @@ func upsertQueryReferenceAndInformationSimple(refs []*snapshot.QueryReference, i
 	// Information
 	queryInformation := snapshot.QueryInformation{
 		QueryIdx:        idx,
-		NormalizedQuery: util.NormalizeQuery(originalQuery),
+		NormalizedQuery: util.NormalizeQuery(originalQuery, server.Config.FilterQueryText),
 	}
 	infos = append(infos, &queryInformation)
 

--- a/runner/queries.go
+++ b/runner/queries.go
@@ -37,7 +37,7 @@ func gatherQueryStatsForServer(server state.Server, globalCollectionOpts state.C
 	}
 
 	newState.LastStatementStatsAt = time.Now()
-	_, _, newState.StatementStats, err = postgres.GetStatements(logger, connection, globalCollectionOpts, postgresVersion, false, systemType)
+	_, _, newState.StatementStats, err = postgres.GetStatements(server, logger, connection, globalCollectionOpts, postgresVersion, false, systemType)
 	if err != nil {
 		return newState, errors.Wrap(err, "error collecting pg_stat_statements")
 	}

--- a/util/normalize.go
+++ b/util/normalize.go
@@ -2,10 +2,14 @@ package util
 
 import pg_query "github.com/lfittl/pg_query_go"
 
-func NormalizeQuery(query string) string {
+func NormalizeQuery(query string, filterQueryText string) string {
 	normalizedQuery, err := pg_query.Normalize(query)
 	if err != nil {
-		normalizedQuery = "<truncated query>"
+		if filterQueryText == "none" {
+			normalizedQuery = query
+		} else {
+			normalizedQuery = "<unparsable query>"
+		}
 	}
 	return normalizedQuery
 }


### PR DESCRIPTION
By default we replace everything with `<unparsable query>` (renamed from the previous `<truncated query>` for clarity), to avoid leaking sensitive data that may be contained in query texts that couldn't be parsed and that Postgres itself doesn't mask correctly (e.g. utility statements).

However in some situations it may be desirable to have the original query texts instead, e.g. when the collector parser is outdated (right now the parser is Postgres version 10, and some newer Postgres 12 query syntax fails to parse).

To support this use case, a new `filter_query_text` / `FILTER_QUERY_TEXT` option is introduced which can be set to "none" to keep all query texts.