### PR TITLE
Use helper function for log-based EXPLAIN access if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,25 +90,27 @@ but from here onwards you can use the `pganalyze` user instead.
 The collector will automatically use the helper methods
 if they exist in the `pganalyze` schema - otherwise data will be fetched directly.
 
-If you use `enable_log_explain`:
+If you use `enable_log_explain`, create the pganalyze schema and this function on each
+database where EXPLAIN should run:
 
 ```
-CREATE OR REPLACE FUNCTION pganalyze.explain(query text, params text) RETURNS text AS
+CREATE OR REPLACE FUNCTION pganalyze.explain(query text, params text[]) RETURNS text AS
 $$
 DECLARE
   prepared_query text;
+  prepared_params text;
   result text;
 BEGIN
   SELECT regexp_replace(query, ';+\s*\Z', '') INTO prepared_query;
-  -- this is a check to minimize collector access to your data: it ensures that the
-  -- collector cannot piggyback other queries that could exfiltrate data
-  IF prepared_query LIKE '%;%' OR params LIKE '%;%' THEN
-    RAISE EXCEPTION 'cannot run EXPLAIN when query or parameters contain semicolon';
+  IF prepared_query LIKE '%;%' THEN
+    RAISE EXCEPTION 'cannot run EXPLAIN when query contains semicolon';
   END IF;
 
-  IF length(params) > 0 THEN
+  IF array_length(params, 1) > 0 THEN
+    SELECT string_agg(quote_literal(param) || '::unknown', ',') FROM unnest(params) p(param) INTO prepared_params;
+
     EXECUTE 'PREPARE pganalyze_explain AS ' || prepared_query;
-    EXECUTE 'EXPLAIN (VERBOSE, FORMAT JSON) EXECUTE pganalyze_explain(' || params || ')' INTO STRICT result;
+    EXECUTE 'EXPLAIN (VERBOSE, FORMAT JSON) EXECUTE pganalyze_explain(' || prepared_params || ')' INTO STRICT result;
     DEALLOCATE pganalyze_explain;
   ELSE
     EXECUTE 'EXPLAIN (VERBOSE, FORMAT JSON) ' || prepared_query INTO STRICT result;
@@ -118,6 +120,11 @@ BEGIN
 END
 $$ LANGUAGE plpgsql VOLATILE SECURITY DEFINER;
 ```
+
+Note that this function contains a check for semicolons in the query
+text. This is to minimize collector access to your data: it ensures
+that the collector cannot piggyback other queries that could
+exfiltrate data.
 
 If you are on Postgres 9.6 and use activity snapshots:
 

--- a/README.md
+++ b/README.md
@@ -96,20 +96,22 @@ If you use `enable_log_explain`:
 CREATE OR REPLACE FUNCTION pganalyze.explain(query text, params text) RETURNS text AS
 $$
 DECLARE
+  prepared_query text;
   result text;
 BEGIN
+  SELECT regexp_replace(query, ';+\s*\Z', '') INTO prepared_query;
   -- this is a check to minimize collector access to your data: it ensures that the
   -- collector cannot piggyback other queries that could exfiltrate data
-  IF query LIKE '%;%' OR params LIKE '%;%' THEN
+  IF prepared_query LIKE '%;%' OR params LIKE '%;%' THEN
     RAISE EXCEPTION 'cannot run EXPLAIN when query or parameters contain semicolon';
   END IF;
 
   IF length(params) > 0 THEN
-    EXECUTE '/* pganalyze-collector */ PREPARE pganalyze_explain AS ' || query;
-    EXECUTE '/* pganalyze-collector */ EXPLAIN (VERBOSE, FORMAT JSON) EXECUTE pganalyze_explain(' || params || ')' INTO STRICT result;
-    /* pganalyze-collector */ DEALLOCATE pganalyze_explain;
+    EXECUTE 'PREPARE pganalyze_explain AS ' || prepared_query;
+    EXECUTE 'EXPLAIN (VERBOSE, FORMAT JSON) EXECUTE pganalyze_explain(' || params || ')' INTO STRICT result;
+    DEALLOCATE pganalyze_explain;
   ELSE
-    EXECUTE '/* pganalyze-collector */ EXPLAIN (VERBOSE, FORMAT JSON) ' || query INTO STRICT result;
+    EXECUTE 'EXPLAIN (VERBOSE, FORMAT JSON) ' || prepared_query INTO STRICT result;
   END IF;
 
   RETURN result;

--- a/README.md
+++ b/README.md
@@ -110,7 +110,12 @@ BEGIN
     SELECT string_agg(quote_literal(param) || '::unknown', ',') FROM unnest(params) p(param) INTO prepared_params;
 
     EXECUTE 'PREPARE pganalyze_explain AS ' || prepared_query;
-    EXECUTE 'EXPLAIN (VERBOSE, FORMAT JSON) EXECUTE pganalyze_explain(' || prepared_params || ')' INTO STRICT result;
+    BEGIN
+      EXECUTE 'EXPLAIN (VERBOSE, FORMAT JSON) EXECUTE pganalyze_explain(' || prepared_params || ')' INTO STRICT result;
+    EXCEPTION WHEN OTHERS THEN
+      DEALLOCATE pganalyze_explain;
+      RAISE;
+    END;
     DEALLOCATE pganalyze_explain;
   ELSE
     EXECUTE 'EXPLAIN (VERBOSE, FORMAT JSON) ' || prepared_query INTO STRICT result;

--- a/input/postgres/explain.go
+++ b/input/postgres/explain.go
@@ -77,7 +77,7 @@ func runDbExplain(db *sql.DB, inputs []state.PostgresQuerySample, useHelper bool
 			sample.ExplainFormat = pganalyze_collector.QuerySample_JSON_EXPLAIN_FORMAT
 
 			if useHelper {
-				err = db.QueryRow(QueryMarkerSQL+"SELECT pganalyze.explain($1, $2)", sample.Query, sample.Parameters).Scan(&sample.ExplainOutput)
+				err = db.QueryRow(QueryMarkerSQL+"SELECT pganalyze.explain($1, $2)", sample.Query, pq.Array(sample.Parameters)).Scan(&sample.ExplainOutput)
 				if err != nil {
 					sample.ExplainError = fmt.Sprintf("%s", err)
 				}

--- a/input/postgres/explain.go
+++ b/input/postgres/explain.go
@@ -44,8 +44,16 @@ func RunExplain(server state.Server, inputs []state.PostgresQuerySample, collect
 			logger.PrintVerbose("Could not connect to %s to run explain: %s; skipping", dbName, err)
 			continue
 		}
+		useHelper := statsHelperExists(db, "explain")
+		if useHelper {
+			logger.PrintVerbose("Found pganalyze.explain() stats helper")
+		} else {
+			logger.PrintInfo("Warning: pganalyze.explain() helper function not found. Please set up" +
+				" the monitoring helper functions (https://github.com/pganalyze/collector#setting-up-a-restricted-monitoring-user)" +
+				" to avoid permissions issues when running log-based EXPLAIN.")
+		}
 
-		dbOutputs := runDbExplain(db, dbSamples)
+		dbOutputs := runDbExplain(db, dbSamples, useHelper)
 		db.Close()
 
 		outputs = append(outputs, dbOutputs...)
@@ -53,19 +61,28 @@ func RunExplain(server state.Server, inputs []state.PostgresQuerySample, collect
 	return
 }
 
-func runDbExplain(db *sql.DB, inputs []state.PostgresQuerySample) (outputs []state.PostgresQuerySample) {
+func runDbExplain(db *sql.DB, inputs []state.PostgresQuerySample, useHelper bool) (outputs []state.PostgresQuerySample) {
 	for _, sample := range inputs {
 		// To be on the safe side never EXPLAIN a statement that can't be parsed,
 		// or multiple statements in one (leading to accidental execution)
 		parsetree, err := pg_query.Parse(sample.Query)
-		if err == nil && len(parsetree.Statements) == 1 {
-			stmt := parsetree.Statements[0].(pg_query_nodes.RawStmt).Stmt
-			switch stmt.(type) {
-			case pg_query_nodes.SelectStmt, pg_query_nodes.InsertStmt, pg_query_nodes.UpdateStmt, pg_query_nodes.DeleteStmt:
-				sample.HasExplain = true
-				sample.ExplainSource = pganalyze_collector.QuerySample_STATEMENT_LOG_EXPLAIN_SOURCE
-				sample.ExplainFormat = pganalyze_collector.QuerySample_JSON_EXPLAIN_FORMAT
+		if err != nil || len(parsetree.Statements) != 1 {
+			continue
+		}
+		stmt := parsetree.Statements[0].(pg_query_nodes.RawStmt).Stmt
+		switch stmt.(type) {
+		case pg_query_nodes.SelectStmt, pg_query_nodes.InsertStmt, pg_query_nodes.UpdateStmt, pg_query_nodes.DeleteStmt:
+			sample.HasExplain = true
+			sample.ExplainSource = pganalyze_collector.QuerySample_STATEMENT_LOG_EXPLAIN_SOURCE
+			sample.ExplainFormat = pganalyze_collector.QuerySample_JSON_EXPLAIN_FORMAT
 
+			if useHelper {
+				paramStr := getQuotedParamsStr(sample.Parameters)
+				err = db.QueryRow(QueryMarkerSQL+"SELECT pganalyze.explain($1, $2)", sample.Query, paramStr).Scan(&sample.ExplainOutput)
+				if err != nil {
+					sample.ExplainError = fmt.Sprintf("%s", err)
+				}
+			} else {
 				if len(sample.Parameters) > 0 {
 					_, err = db.Exec(QueryMarkerSQL + "PREPARE pganalyze_explain AS " + sample.Query)
 					if err != nil {
@@ -73,11 +90,8 @@ func runDbExplain(db *sql.DB, inputs []state.PostgresQuerySample) (outputs []sta
 						continue
 					}
 
-					params := []string{}
-					for i := 0; i < len(sample.Parameters); i++ {
-						params = append(params, pq.QuoteLiteral(sample.Parameters[i]))
-					}
-					err = db.QueryRow(QueryMarkerSQL + "EXPLAIN (VERBOSE, FORMAT JSON) EXECUTE pganalyze_explain(" + strings.Join(params, ", ") + ")").Scan(&sample.ExplainOutput)
+					paramStr := getQuotedParamsStr(sample.Parameters)
+					err = db.QueryRow(QueryMarkerSQL + "EXPLAIN (VERBOSE, FORMAT JSON) EXECUTE pganalyze_explain(" + paramStr + ")").Scan(&sample.ExplainOutput)
 					if err != nil {
 						sample.ExplainError = fmt.Sprintf("%s", err)
 					}
@@ -105,4 +119,12 @@ func contains(strs []string, val string) bool {
 		}
 	}
 	return false
+}
+
+func getQuotedParamsStr(parameters []string) string {
+	params := []string{}
+	for i := 0; i < len(parameters); i++ {
+		params = append(params, pq.QuoteLiteral(parameters[i]))
+	}
+	return strings.Join(params, ", ")
 }


### PR DESCRIPTION
This works with the big caveat that more queries may contain semicolons than we expected: I was testing by submitting queries in psql, and things there need to end in a semicolon. That's probably not a common use case, but a lot of larger heredoc-style queries embedded in apps often end in semicolons out of habit. Should we strip trailing semicolons? Trailing semicolons and whitespace? ~Or is that all stripped out via `pg_query.Parse`?~ I realize it's *not* stripped out because that's exactly what I ran into it. I'll try to regexp_replace it.

This will also need docs, but this part should probably come first.