### PR TITLE
Fix oid aliasing when constructing snapshot

### DIFF
--- a/input/postgres/schema.go
+++ b/input/postgres/schema.go
@@ -23,7 +23,7 @@ func CollectAllSchemas(server state.Server, collectionOpts state.CollectionOpts,
 
 	ps.Relations = []state.PostgresRelation{}
 
-	ps.DBStats = make(map[state.Oid]state.DBStats)
+	ps.DBStats = make(map[state.Oid]*state.DBStats)
 	ps.Functions = []state.PostgresFunction{}
 
 	for _, dbName := range schemaDbNames {
@@ -40,7 +40,7 @@ func CollectAllSchemas(server state.Server, collectionOpts state.CollectionOpts,
 			continue
 		}
 
-		ps.DBStats[databaseOid] = state.DBStats{
+		ps.DBStats[databaseOid] = &state.DBStats{
 			RelationStats: make(state.PostgresRelationStatsMap),
 			IndexStats:    make(state.PostgresIndexStatsMap),
 		}

--- a/input/postgres/schema.go
+++ b/input/postgres/schema.go
@@ -23,7 +23,7 @@ func CollectAllSchemas(server state.Server, collectionOpts state.CollectionOpts,
 
 	ps.Relations = []state.PostgresRelation{}
 
-	ps.DBStats = make(map[state.Oid]*state.DBStats)
+	ps.SchemaStats = make(map[state.Oid]*state.SchemaStats)
 	ps.Functions = []state.PostgresFunction{}
 
 	for _, dbName := range schemaDbNames {
@@ -40,7 +40,7 @@ func CollectAllSchemas(server state.Server, collectionOpts state.CollectionOpts,
 			continue
 		}
 
-		ps.DBStats[databaseOid] = &state.DBStats{
+		ps.SchemaStats[databaseOid] = &state.SchemaStats{
 			RelationStats: make(state.PostgresRelationStatsMap),
 			IndexStats:    make(state.PostgresIndexStatsMap),
 		}
@@ -72,7 +72,7 @@ func collectSchemaData(collectionOpts state.CollectionOpts, logger *util.Logger,
 			return ps
 		}
 		for k, v := range newRelationStats {
-			ps.DBStats[databaseOid].RelationStats[k] = v
+			ps.SchemaStats[databaseOid].RelationStats[k] = v
 		}
 
 		newIndexStats, err := GetIndexStats(db, postgresVersion, ignoreRegexp)
@@ -81,7 +81,7 @@ func collectSchemaData(collectionOpts state.CollectionOpts, logger *util.Logger,
 			return ps
 		}
 		for k, v := range newIndexStats {
-			ps.DBStats[databaseOid].IndexStats[k] = v
+			ps.SchemaStats[databaseOid].IndexStats[k] = v
 		}
 	}
 

--- a/output/transform/postgres_functions.go
+++ b/output/transform/postgres_functions.go
@@ -58,7 +58,7 @@ func transformPostgresFunctions(s snapshot.FullSnapshot, newState state.Persiste
 		s.FunctionInformations = append(s.FunctionInformations, &info)
 
 		// Statistic
-		stats, exists := diffState.FunctionStats[function.Oid]
+		stats, exists := diffState.DBStats[function.DatabaseOid].FunctionStats[function.Oid]
 		if exists {
 			statistic := snapshot.FunctionStatistic{
 				FunctionIdx: idx,

--- a/output/transform/postgres_functions.go
+++ b/output/transform/postgres_functions.go
@@ -58,7 +58,7 @@ func transformPostgresFunctions(s snapshot.FullSnapshot, newState state.Persiste
 		s.FunctionInformations = append(s.FunctionInformations, &info)
 
 		// Statistic
-		stats, exists := diffState.DBStats[function.DatabaseOid].FunctionStats[function.Oid]
+		stats, exists := diffState.SchemaStats[function.DatabaseOid].FunctionStats[function.Oid]
 		if exists {
 			statistic := snapshot.FunctionStatistic{
 				FunctionIdx: idx,

--- a/output/transform/postgres_relations.go
+++ b/output/transform/postgres_relations.go
@@ -101,7 +101,7 @@ func transformPostgresRelations(s snapshot.FullSnapshot, newState state.Persiste
 		s.RelationInformations = append(s.RelationInformations, &info)
 
 		// Statistic
-		stats, exists := diffState.RelationStats[relation.Oid]
+		stats, exists := diffState.DBStats[relation.DatabaseOid].RelationStats[relation.Oid]
 		if exists {
 			statistic := snapshot.RelationStatistic{
 				RelationIdx:    relationIdx,
@@ -168,7 +168,7 @@ func transformPostgresRelations(s snapshot.FullSnapshot, newState state.Persiste
 			s.IndexInformations = append(s.IndexInformations, &indexInfo)
 
 			// Statistic
-			indexStats, exists := diffState.IndexStats[index.IndexOid]
+			indexStats, exists := diffState.DBStats[relation.DatabaseOid].IndexStats[index.IndexOid]
 			if exists {
 				statistic := snapshot.IndexStatistic{
 					IndexIdx:    indexIdx,

--- a/output/transform/postgres_relations.go
+++ b/output/transform/postgres_relations.go
@@ -7,28 +7,8 @@ import (
 	"github.com/pganalyze/collector/state"
 )
 
-type OidMapByDB map[state.Oid](map[state.Oid]int32)
-
-func MakeOidMap() OidMapByDB {
-	return make(map[state.Oid](map[state.Oid]int32))
-}
-
-func (m OidMapByDB) Put(dbOid, objOid state.Oid, idx int32) {
-	if _, ok := m[dbOid]; !ok {
-		m[dbOid] = make(map[state.Oid]int32)
-	}
-	m[dbOid][objOid] = idx
-}
-
-func (m OidMapByDB) Get(dbOid, objOid state.Oid) int32 {
-	if _, ok := m[dbOid]; !ok {
-		return 0
-	}
-	return m[dbOid][objOid]
-}
-
 func transformPostgresRelations(s snapshot.FullSnapshot, newState state.PersistedState, diffState state.DiffState, roleOidToIdx OidToIdx, databaseOidToIdx OidToIdx) snapshot.FullSnapshot {
-	relationOidToIdx := MakeOidMap()
+	relationOidToIdx := state.MakeOidToIdxMap()
 	for _, relation := range newState.Relations {
 		ref := snapshot.RelationReference{
 			DatabaseIdx:  databaseOidToIdx[relation.DatabaseOid],

--- a/output/transform/postgres_relations.go
+++ b/output/transform/postgres_relations.go
@@ -7,8 +7,28 @@ import (
 	"github.com/pganalyze/collector/state"
 )
 
+type OidMapByDB map[state.Oid](map[state.Oid]int32)
+
+func MakeOidMap() OidMapByDB {
+	return make(map[state.Oid](map[state.Oid]int32))
+}
+
+func (m OidMapByDB) Put(dbOid, objOid state.Oid, idx int32) {
+	if _, ok := m[dbOid]; !ok {
+		m[dbOid] = make(map[state.Oid]int32)
+	}
+	m[dbOid][objOid] = idx
+}
+
+func (m OidMapByDB) Get(dbOid, objOid state.Oid) int32 {
+	if _, ok := m[dbOid]; !ok {
+		return 0
+	}
+	return m[dbOid][objOid]
+}
+
 func transformPostgresRelations(s snapshot.FullSnapshot, newState state.PersistedState, diffState state.DiffState, roleOidToIdx OidToIdx, databaseOidToIdx OidToIdx) snapshot.FullSnapshot {
-	relationOidToIdx := make(map[state.Oid]int32)
+	relationOidToIdx := MakeOidMap()
 	for _, relation := range newState.Relations {
 		ref := snapshot.RelationReference{
 			DatabaseIdx:  databaseOidToIdx[relation.DatabaseOid],
@@ -17,16 +37,16 @@ func transformPostgresRelations(s snapshot.FullSnapshot, newState state.Persiste
 		}
 		idx := int32(len(s.RelationReferences))
 		s.RelationReferences = append(s.RelationReferences, &ref)
-		relationOidToIdx[relation.Oid] = idx
+		relationOidToIdx.Put(relation.DatabaseOid, relation.Oid, idx)
 	}
 
 	for _, relation := range newState.Relations {
-		relationIdx := relationOidToIdx[relation.Oid]
+		relationIdx := relationOidToIdx.Get(relation.DatabaseOid, relation.Oid)
 
 		parentRelationIdx := int32(0)
 		hasParentRelation := false
 		if relation.ParentTableOid != 0 {
-			parentRelationIdx = relationOidToIdx[relation.ParentTableOid]
+			parentRelationIdx = relationOidToIdx.Get(relation.DatabaseOid, relation.ParentTableOid)
 			hasParentRelation = true
 		}
 
@@ -88,7 +108,7 @@ func transformPostgresRelations(s snapshot.FullSnapshot, newState state.Persiste
 				ForeignMatchType:  constraint.ForeignMatchType,
 			}
 			if constraint.ForeignOid != 0 {
-				sConstraint.ForeignRelationIdx = relationOidToIdx[constraint.ForeignOid]
+				sConstraint.ForeignRelationIdx = relationOidToIdx.Get(relation.DatabaseOid, constraint.ForeignOid)
 			}
 			for _, column := range constraint.Columns {
 				sConstraint.Columns = append(sConstraint.Columns, int32(column))

--- a/output/transform/postgres_relations.go
+++ b/output/transform/postgres_relations.go
@@ -101,7 +101,7 @@ func transformPostgresRelations(s snapshot.FullSnapshot, newState state.Persiste
 		s.RelationInformations = append(s.RelationInformations, &info)
 
 		// Statistic
-		stats, exists := diffState.DBStats[relation.DatabaseOid].RelationStats[relation.Oid]
+		stats, exists := diffState.SchemaStats[relation.DatabaseOid].RelationStats[relation.Oid]
 		if exists {
 			statistic := snapshot.RelationStatistic{
 				RelationIdx:    relationIdx,
@@ -168,7 +168,7 @@ func transformPostgresRelations(s snapshot.FullSnapshot, newState state.Persiste
 			s.IndexInformations = append(s.IndexInformations, &indexInfo)
 
 			// Statistic
-			indexStats, exists := diffState.DBStats[relation.DatabaseOid].IndexStats[index.IndexOid]
+			indexStats, exists := diffState.SchemaStats[relation.DatabaseOid].IndexStats[index.IndexOid]
 			if exists {
 				statistic := snapshot.IndexStatistic{
 					IndexIdx:    indexIdx,

--- a/runner/diff.go
+++ b/runner/diff.go
@@ -7,10 +7,10 @@ import (
 
 func diffState(logger *util.Logger, prevState state.PersistedState, newState state.PersistedState, collectedIntervalSecs uint32) (diffState state.DiffState) {
 	diffState.StatementStats = diffStatements(newState.StatementStats, prevState.StatementStats)
-	diffState.DBStats = make(map[state.Oid]*state.DiffedDBStats)
-	for dbOid := range newState.DBStats {
-		newDbStats := newState.DBStats[dbOid]
-		prevDbStats := prevState.DBStats[dbOid]
+	diffState.SchemaStats = make(map[state.Oid]*state.DiffedSchemaStats)
+	for dbOid := range newState.SchemaStats {
+		newDbStats := newState.SchemaStats[dbOid]
+		prevDbStats := prevState.SchemaStats[dbOid]
 		var prevRelStats state.PostgresRelationStatsMap
 		var prevIdxStats state.PostgresIndexStatsMap
 		if prevDbStats != nil {
@@ -20,7 +20,7 @@ func diffState(logger *util.Logger, prevState state.PersistedState, newState sta
 			prevRelStats = make(state.PostgresRelationStatsMap)
 			prevIdxStats = make(state.PostgresIndexStatsMap)
 		}
-		diffState.DBStats[dbOid] = &state.DiffedDBStats{
+		diffState.SchemaStats[dbOid] = &state.DiffedSchemaStats{
 			RelationStats: diffRelationStats(newDbStats.RelationStats, prevRelStats),
 			IndexStats:    diffIndexStats(newDbStats.IndexStats, prevIdxStats),
 		}

--- a/runner/diff.go
+++ b/runner/diff.go
@@ -7,8 +7,16 @@ import (
 
 func diffState(logger *util.Logger, prevState state.PersistedState, newState state.PersistedState, collectedIntervalSecs uint32) (diffState state.DiffState) {
 	diffState.StatementStats = diffStatements(newState.StatementStats, prevState.StatementStats)
-	diffState.RelationStats = diffRelationStats(newState.RelationStats, prevState.RelationStats)
-	diffState.IndexStats = diffIndexStats(newState.IndexStats, prevState.IndexStats)
+	diffState.DBStats = make(map[state.Oid]state.DiffedDBStats)
+	for dbOid := range newState.DBStats {
+		newDbStats := newState.DBStats[dbOid]
+		// TODO: what if this is nil?
+		prevDbStats := prevState.DBStats[dbOid]
+		diffState.DBStats[dbOid] = state.DiffedDBStats{
+			RelationStats: diffRelationStats(newDbStats.RelationStats, prevDbStats.RelationStats),
+			IndexStats:    diffIndexStats(newDbStats.IndexStats, prevDbStats.IndexStats),
+		}
+	}
 	diffState.SystemCPUStats = diffSystemCPUStats(newState.System.CPUStats, prevState.System.CPUStats)
 	diffState.SystemNetworkStats = diffSystemNetworkStats(newState.System.NetworkStats, prevState.System.NetworkStats, collectedIntervalSecs)
 	diffState.SystemDiskStats = diffSystemDiskStats(newState.System.DiskStats, prevState.System.DiskStats, collectedIntervalSecs)

--- a/state/state.go
+++ b/state/state.go
@@ -83,7 +83,7 @@ type DiffState struct {
 }
 
 // StateOnDiskFormatVersion - Increment this when an old state preserved to disk should be ignored
-const StateOnDiskFormatVersion = 3
+const StateOnDiskFormatVersion = 4
 
 type StateOnDisk struct {
 	FormatVersion uint

--- a/state/state.go
+++ b/state/state.go
@@ -19,7 +19,7 @@ type PersistedState struct {
 	CollectedAt time.Time
 
 	StatementStats PostgresStatementStatsMap
-	DBStats        map[Oid]DBStats
+	DBStats        map[Oid]*DBStats
 
 	Relations []PostgresRelation
 	Functions []PostgresFunction
@@ -73,7 +73,7 @@ type DiffedDBStats struct {
 // DiffState - Result of diff-ing two persistent state structs
 type DiffState struct {
 	StatementStats DiffedPostgresStatementStatsMap
-	DBStats        map[Oid]DiffedDBStats
+	DBStats        map[Oid]*DiffedDBStats
 
 	SystemCPUStats     DiffedSystemCPUStatsMap
 	SystemNetworkStats DiffedNetworkStatsMap

--- a/state/state.go
+++ b/state/state.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pganalyze/collector/config"
 )
 
-type DBStats struct {
+type SchemaStats struct {
 	RelationStats PostgresRelationStatsMap
 	IndexStats    PostgresIndexStatsMap
 	FunctionStats PostgresFunctionStatsMap
@@ -19,7 +19,7 @@ type PersistedState struct {
 	CollectedAt time.Time
 
 	StatementStats PostgresStatementStatsMap
-	DBStats        map[Oid]*DBStats
+	SchemaStats    map[Oid]*SchemaStats
 
 	Relations []PostgresRelation
 	Functions []PostgresFunction
@@ -64,7 +64,7 @@ type TransientState struct {
 	SentryClient *raven.Client
 }
 
-type DiffedDBStats struct {
+type DiffedSchemaStats struct {
 	RelationStats DiffedPostgresRelationStatsMap
 	IndexStats    DiffedPostgresIndexStatsMap
 	FunctionStats DiffedPostgresFunctionStatsMap
@@ -73,7 +73,7 @@ type DiffedDBStats struct {
 // DiffState - Result of diff-ing two persistent state structs
 type DiffState struct {
 	StatementStats DiffedPostgresStatementStatsMap
-	DBStats        map[Oid]*DiffedDBStats
+	SchemaStats    map[Oid]*DiffedSchemaStats
 
 	SystemCPUStats     DiffedSystemCPUStatsMap
 	SystemNetworkStats DiffedNetworkStatsMap

--- a/state/state.go
+++ b/state/state.go
@@ -8,14 +8,18 @@ import (
 	"github.com/pganalyze/collector/config"
 )
 
+type DBStats struct {
+	RelationStats PostgresRelationStatsMap
+	IndexStats    PostgresIndexStatsMap
+	FunctionStats PostgresFunctionStatsMap
+}
+
 // PersistedState - State thats kept across collector runs to be used for diffs
 type PersistedState struct {
 	CollectedAt time.Time
 
 	StatementStats PostgresStatementStatsMap
-	RelationStats  PostgresRelationStatsMap
-	IndexStats     PostgresIndexStatsMap
-	FunctionStats  PostgresFunctionStatsMap
+	DBStats        map[Oid]DBStats
 
 	Relations []PostgresRelation
 	Functions []PostgresFunction
@@ -60,12 +64,16 @@ type TransientState struct {
 	SentryClient *raven.Client
 }
 
+type DiffedDBStats struct {
+	RelationStats DiffedPostgresRelationStatsMap
+	IndexStats    DiffedPostgresIndexStatsMap
+	FunctionStats DiffedPostgresFunctionStatsMap
+}
+
 // DiffState - Result of diff-ing two persistent state structs
 type DiffState struct {
 	StatementStats DiffedPostgresStatementStatsMap
-	RelationStats  DiffedPostgresRelationStatsMap
-	IndexStats     DiffedPostgresIndexStatsMap
-	FunctionStats  DiffedPostgresFunctionStatsMap
+	DBStats        map[Oid]DiffedDBStats
 
 	SystemCPUStats     DiffedSystemCPUStatsMap
 	SystemNetworkStats DiffedNetworkStatsMap

--- a/state/util.go
+++ b/state/util.go
@@ -1,0 +1,21 @@
+package state
+
+type OidToIdxMap map[Oid](map[Oid]int32)
+
+func MakeOidToIdxMap() OidToIdxMap {
+	return make(map[Oid](map[Oid]int32))
+}
+
+func (m OidToIdxMap) Put(dbOid, objOid Oid, idx int32) {
+	if _, ok := m[dbOid]; !ok {
+		m[dbOid] = make(map[Oid]int32)
+	}
+	m[dbOid][objOid] = idx
+}
+
+func (m OidToIdxMap) Get(dbOid, objOid Oid) int32 {
+	if _, ok := m[dbOid]; !ok {
+		return 0
+	}
+	return m[dbOid][objOid]
+}


### PR DESCRIPTION
Relation oids are not necessarily unique across databases, but we
assume they are, which can cause issues where we clobber some relation
references in our mapping.

Track the mapping per-database instead to avoid this.

~We may need to take a similar approach to other database objects, but I
think a similar pattern should work.~ (I don't think any other code paths are
affected--see below).

I've now tried this in dev and I can't think of a good way to test the issue this
is intended to fix, but it does not break anything.