### PR TITLE
Ignore internal admin databases for GCP and Azure

### DIFF
--- a/input/postgres/schema.go
+++ b/input/postgres/schema.go
@@ -12,7 +12,7 @@ func CollectAllSchemas(server state.Server, collectionOpts state.CollectionOpts,
 
 	if server.Config.DbAllNames {
 		for _, database := range ts.Databases {
-			if !database.IsTemplate && database.AllowConnections && !(systemType == "amazon_rds" && database.Name == "rdsadmin") {
+			if !database.IsTemplate && database.AllowConnections && !isCloudInternalDatabase(systemType, database.Name) {
 				schemaDbNames = append(schemaDbNames, database.Name)
 			}
 		}

--- a/input/postgres/superuser.go
+++ b/input/postgres/superuser.go
@@ -54,6 +54,19 @@ func connectedAsSuperUser(db *sql.DB, systemType string) bool {
 	return enabled
 }
 
+func isCloudInternalDatabase(systemType string, databaseName string) bool {
+	if systemType == "amazon_rds" {
+		return databaseName == "rdsadmin"
+	}
+	if systemType == "azure_database" {
+		return databaseName == "azure_maintenance"
+	}
+	if systemType == "google_cloudsql" {
+		return databaseName == "cloudsqladmin"
+	}
+	return false
+}
+
 const connectedAsMonitoringRoleSQL string = `
 SELECT pg_has_role(oid, 'MEMBER') FROM pg_roles WHERE rolname = 'pg_monitor'
 `


### PR DESCRIPTION
This avoids collecting data from these internal databases, which produces
unnecessary errors when using the all databases setting.