### PR TITLE
Add support for assuming instance roles

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -62,6 +62,7 @@ type ServerConfig struct {
 	AwsDbInstanceID    string `ini:"aws_db_instance_id"`
 	AwsAccessKeyID     string `ini:"aws_access_key_id"`
 	AwsSecretAccessKey string `ini:"aws_secret_access_key"`
+	AwsAssumeRole      string `ini:"aws_assume_role"`
 
 	// Support for custom AWS endpoints
 	// See https://docs.aws.amazon.com/sdk-for-go/api/aws/endpoints/

--- a/config/read.go
+++ b/config/read.go
@@ -111,6 +111,9 @@ func getDefaultConfig() *ServerConfig {
 	if awsSecretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY"); awsSecretAccessKey != "" {
 		config.AwsSecretAccessKey = awsSecretAccessKey
 	}
+	if awsAssumeRole := os.Getenv("AWS_ASSUME_ROLE"); awsAssumeRole != "" {
+		config.AwsAssumeRole = awsAssumeRole
+	}
 	if awsEndpointSigningRegion := os.Getenv("AWS_ENDPOINT_SIGNING_REGION"); awsEndpointSigningRegion != "" {
 		config.AwsEndpointSigningRegion = awsEndpointSigningRegion
 	}


### PR DESCRIPTION
Set the role to be assumed using the new "aws_assume_role" / AWS_ASSUME_ROLE
configuration setting. This is useful when the collector runs in a different
AWS account than your database.

See https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html