### PR TITLE
Hoist log_line_prefix check in logs test

### DIFF
--- a/input/system/google_cloudsql/log_receiver.go
+++ b/input/system/google_cloudsql/log_receiver.go
@@ -2,11 +2,9 @@ package google_cloudsql
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/pganalyze/collector/config"
-	"github.com/pganalyze/collector/input/postgres"
 	"github.com/pganalyze/collector/logs"
 	"github.com/pganalyze/collector/logs/stream"
 	"github.com/pganalyze/collector/state"
@@ -91,26 +89,4 @@ func logReceiver(ctx context.Context, servers []state.Server, in <-chan LogStrea
 			}
 		}
 	}()
-}
-
-const settingValueSQL string = `
-SELECT setting
-	FROM pg_settings
- WHERE name = '%s'`
-
-func getPostgresSetting(settingName string, server state.Server, globalCollectionOpts state.CollectionOpts, prefixedLogger *util.Logger) (string, error) {
-	var value string
-
-	db, err := postgres.EstablishConnection(server, prefixedLogger, globalCollectionOpts, "")
-	if err != nil {
-		return "", fmt.Errorf("Could not connect to database to retrieve \"%s\": %s", settingName, err)
-	}
-
-	err = db.QueryRow(postgres.QueryMarkerSQL + fmt.Sprintf(settingValueSQL, settingName)).Scan(&value)
-	db.Close()
-	if err != nil {
-		return "", fmt.Errorf("Could not read \"%s\" setting: %s", settingName, err)
-	}
-
-	return value, nil
 }

--- a/input/system/google_cloudsql/test_run.go
+++ b/input/system/google_cloudsql/test_run.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/pganalyze/collector/input/postgres"
-	"github.com/pganalyze/collector/logs"
 	"github.com/pganalyze/collector/state"
 	"github.com/pganalyze/collector/util"
 )
@@ -15,22 +14,13 @@ import (
 func LogTestRun(server state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) error {
 	cctx, cancel := context.WithCancel(context.Background())
 
-	logLinePrefix, err := getPostgresSetting("log_line_prefix", server, globalCollectionOpts, logger)
-	if err != nil {
-		cancel()
-		return err
-	} else if !logs.IsSupportedPrefix(logLinePrefix) {
-		cancel()
-		return fmt.Errorf("Unsupported log_line_prefix setting: '%s'", logLinePrefix)
-	}
-
 	// We're testing one server at a time during the test run for now
 	servers := []state.Server{server}
 
 	logTestSucceeded := make(chan bool, 1)
 	gcpLogStream := make(chan LogStreamItem, 500)
 	wg := sync.WaitGroup{}
-	err = SetupLogSubscriber(cctx, &wg, globalCollectionOpts, logger, servers, gcpLogStream)
+	err := SetupLogSubscriber(cctx, &wg, globalCollectionOpts, logger, servers, gcpLogStream)
 	if err != nil {
 		cancel()
 		return err


### PR DESCRIPTION
This lets us ensure we have a valid prefix on all platforms.

