### PR TITLE
Self-managed server log tail: Speed improvements, handle multi-line logs correctly

### DIFF
--- a/input/system/selfhosted/log_receiver.go
+++ b/input/system/selfhosted/log_receiver.go
@@ -395,7 +395,6 @@ func logReceiver(ctx context.Context, server state.Server, globalCollectionOpts 
 				}
 
 				logLines = append(logLines, logLine)
-				logLines = stream.ProcessLogStream(server, logLines, globalCollectionOpts, prefixedLogger, logTestSucceeded, stream.LogTestCollectorIdentify)
 			case <-timeout:
 				if len(logLines) > 0 {
 					logLines = stream.ProcessLogStream(server, logLines, globalCollectionOpts, prefixedLogger, logTestSucceeded, stream.LogTestCollectorIdentify)

--- a/logs/stream/stream_test.go
+++ b/logs/stream/stream_test.go
@@ -192,6 +192,69 @@ var tests = []testpair{
 		[]state.LogLine{},
 		nil,
 	},
+	// Multiple lines not concatenated yet (use case for self-managed systems)
+	{
+		[]state.LogLine{
+			{
+				CollectedAt: now.Add(-10 * time.Second),
+				OccurredAt:  now.Add(-10 * time.Second),
+				LogLevel:    pganalyze_collector.LogLineInformation_LOG,
+				BackendPid:  80,
+				Content:     "zero\n",
+			},
+			{
+				CollectedAt: now.Add(-5 * time.Second),
+				OccurredAt:  now.Add(-5 * time.Second),
+				LogLevel:    pganalyze_collector.LogLineInformation_LOG,
+				BackendPid:  42,
+				Content:     "first\n",
+			},
+			{
+				CollectedAt: now.Add(-5 * time.Second),
+				Content:     "second\n",
+			},
+			{
+				CollectedAt: now.Add(-3 * time.Second),
+				OccurredAt:  now.Add(-3 * time.Second),
+				LogLevel:    pganalyze_collector.LogLineInformation_ERROR,
+				BackendPid:  77,
+				Content:     "third\n",
+			},
+		},
+		state.TransientLogState{},
+		state.LogFile{
+			LogLines: []state.LogLine{
+				{
+					CollectedAt: now.Add(-10 * time.Second),
+					OccurredAt:  now.Add(-10 * time.Second),
+					LogLevel:    pganalyze_collector.LogLineInformation_LOG,
+					ByteEnd:     5,
+					BackendPid:  80,
+				},
+				{
+					CollectedAt:      now.Add(-5 * time.Second),
+					OccurredAt:       now.Add(-5 * time.Second),
+					LogLevel:         pganalyze_collector.LogLineInformation_LOG,
+					ByteStart:        5,
+					ByteContentStart: 5,
+					ByteEnd:          18,
+					BackendPid:       42,
+				},
+				{
+					CollectedAt:      now.Add(-3 * time.Second),
+					OccurredAt:       now.Add(-3 * time.Second),
+					LogLevel:         pganalyze_collector.LogLineInformation_ERROR,
+					ByteStart:        18,
+					ByteContentStart: 18,
+					ByteEnd:          24,
+					BackendPid:       77,
+				},
+			},
+		},
+		"zero\nfirst\nsecond\nthird\n",
+		[]state.LogLine{},
+		nil,
+	},
 	//{
 	// There should be a test for this method
 	// - Pass in two logLines, one at X, one at X + 2, and assume the time is x + 3


### PR DESCRIPTION
```
Self-managed server: Process logs every 3 seconds, instead of on-demand

This reduces the amount of overall log snapshots generated, and also
helps with the overall efficiency of the code if there are many lines
that are not ready yet (the typical case on a busy system).
```

```
Log stream: Optimize stitching logic to allocate one large string

Previously we kept resizing the string, leading to many small allocations.
Since we have all the strings that we need already allocated, instead do
one new allocation once, for the final size of the string.

Note that there is further optimization potential here, but this aims to
reduce the biggest current problem point.
```

```
Log stream: Handle streams with missing PID/timestamps/etc correctly

Previously we would sort lines by PID, even when some of the lines do
not have a PID assigned, such as multi-line logs from when we process a
log tail from a self-managed server.

In those situations that lead to incorrect output. Instead, only consider
these characteristics when everything in the stream has the PID/timestamp
assigned.
```