### PR TITLE
Improve self-test output

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,6 +98,7 @@ func run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 	// We intentionally don't do a test-run in the normal mode, since we're fine with
 	// a later SIGHUP that fixes the config (or a temporarily unreachable server at start)
 	if globalCollectionOpts.TestRun {
+		logger.PrintInfo("Running collector test with %s", util.CollectorNameAndVersion)
 		if globalCollectionOpts.TestReport != "" {
 			runner.RunTestReport(servers, globalCollectionOpts, logger)
 			return

--- a/runner/full.go
+++ b/runner/full.go
@@ -33,6 +33,9 @@ func collectDiffAndSubmit(server *state.Server, globalCollectionOpts state.Colle
 		connection.Close()
 		return newState, state.CollectionStatus{}, err
 	}
+	if globalCollectionOpts.TestRun {
+		logger.PrintInfo("  Test collection successful for %s", transientState.Version.Full)
+	}
 
 	// This is the easiest way to avoid opening multiple connections to different databases on the same instance
 	connection.Close()

--- a/runner/full.go
+++ b/runner/full.go
@@ -180,7 +180,7 @@ func CollectAllServers(servers []*state.Server, globalCollectionOpts state.Colle
 				server.PrevState = newState
 				server.StateMutex.Unlock()
 				server.CollectionStatusMutex.Lock()
-				if newCollectionStatus.LogSnapshotDisabled {
+				if newCollectionStatus.LogSnapshotDisabled && !globalCollectionOpts.TestRun {
 					warning := fmt.Sprintf("Skipping logs: %s", newCollectionStatus.LogSnapshotDisabledReason)
 					prefixedLogger.PrintWarning(warning)
 				}

--- a/runner/full.go
+++ b/runner/full.go
@@ -181,7 +181,7 @@ func CollectAllServers(servers []*state.Server, globalCollectionOpts state.Colle
 				server.StateMutex.Unlock()
 				server.CollectionStatusMutex.Lock()
 				if newCollectionStatus.LogSnapshotDisabled {
-					warning := fmt.Sprintf("Skipping logs: %s", server.CollectionStatus.LogSnapshotDisabledReason)
+					warning := fmt.Sprintf("Skipping logs: %s", newCollectionStatus.LogSnapshotDisabledReason)
 					prefixedLogger.PrintWarning(warning)
 				}
 				server.CollectionStatus = newCollectionStatus


### PR DESCRIPTION
Add the collector version and the Postgres version of every monitored
server to collector test output. This makes it easier to diagnose
customer issues if they report collector test problems, since both of
the above are often very useful in debugging issues.

Output is now like this:

```
2020/10/20 17:52:02 I Running collector test with pganalyze-collector 0.33.1
2020/10/20 17:52:02 I [server1] Testing statistics collection...
2020/10/20 17:52:04 I [server1]   Test collection successful for PostgreSQL 11.9 (Ubuntu 11.9-1.pgdg20.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 9.3.0-10ubuntu2) 9.3.0, 64-bit
2020/10/20 17:52:06 I [server1]   Test submission successful (1.34 MB received, server 6ayj3psrubag7gwuzv7sbwnq7a)
2020/10/20 17:52:06 I [server1] Testing activity snapshots...
2020/10/20 17:52:06 I [server1]   Test submission successful (4.25 KB received, server 6ayj3psrubag7gwuzv7sbwnq7a)
2020/10/20 17:52:06 W [server1] WARNING - Configuration issue: log_statement is set to unsupported value 'all'
2020/10/20 17:52:06 W [server1]   Log collection will be disabled for this server
```

Also improve test output and fix a log output issue for when log
collection is disabled.