### PR TITLE
Change panic stack trace logging from Verbose to Warning

### DIFF
--- a/runner/full.go
+++ b/runner/full.go
@@ -125,7 +125,7 @@ func processServer(server *state.Server, globalCollectionOpts state.CollectionOp
 	}
 	if panicErr != nil {
 		err = fmt.Errorf("%s", panicErr)
-		logger.PrintVerbose("Panic: %s\n%s", err, stackTrace)
+		logger.PrintWarning("Panic: %s\n%s", err, stackTrace)
 	}
 
 	return newState, newGrant, collectionStatus, err


### PR DESCRIPTION
These panics are by definitions things that should not happen, so
having more context as to why they happened is always useful.