### PR TITLE
Log processing: Explicitly close temporary files

### DIFF
--- a/logs/stream/stream.go
+++ b/logs/stream/stream.go
@@ -269,6 +269,8 @@ func ProcessLogStream(server *state.Server, logLines []state.LogLine, globalColl
 		return tooFreshLogLines
 	}
 
+	logState.LogFiles = []state.LogFile{logFile}
+
 	// Nothing to send, so just skip getting the grant and other work
 	if len(logFile.LogLines) == 0 && len(logState.QuerySamples) == 0 {
 		logState.Cleanup()
@@ -278,8 +280,6 @@ func ProcessLogStream(server *state.Server, logLines []state.LogLine, globalColl
 	if server.Config.EnableLogExplain && len(logState.QuerySamples) != 0 {
 		logState.QuerySamples = postgres.RunExplain(server, logState.QuerySamples, globalCollectionOpts, prefixedLogger)
 	}
-
-	logState.LogFiles = []state.LogFile{logFile}
 
 	if globalCollectionOpts.DebugLogs {
 		prefixedLogger.PrintInfo("Would have sent log state:\n")

--- a/state/logs.go
+++ b/state/logs.go
@@ -163,6 +163,7 @@ type LogLine struct {
 }
 
 func (logFile LogFile) Cleanup() {
+	logFile.TmpFile.Close()
 	os.Remove(logFile.TmpFile.Name())
 }
 


### PR DESCRIPTION
We've previously relied on Go's finalizer logic to close the file handle
after the associated object expired, but this can cause problems with
keeping files around for too long, even after they are already deleted.

This changes the logic to instead close the temporary files right before
they are deleted. It also fixes one instance where we possibly didn't
clean up files, though in practice this is unlikely to have occurred.