### PR TITLE
Fix log tailing error printing logic

### DIFF
--- a/input/system/selfhosted/log_receiver.go
+++ b/input/system/selfhosted/log_receiver.go
@@ -163,18 +163,17 @@ func tailFile(ctx context.Context, path string, out chan<- string, prefixedLogge
 
 	go func() {
 		defer t.Close()
+	TailLoop:
 		for {
 			select {
 			case line := <-t.Lines():
 				out <- line.String()
 			case <-ctx.Done():
 				prefixedLogger.PrintVerbose("Stopping log tail for %s (stop requested)", path)
-				t.Close()
-				return
+				break TailLoop
 			}
 		}
 		if t.Err() != nil {
-			t.Close()
 			prefixedLogger.PrintError("Failed log file tail: %s", t.Err())
 		}
 	}()


### PR DESCRIPTION
Right now, we print errors only after the loop completes, but the loop
never completes because the existing control flow prevents that.

Instead, break from the loop when the context closes and print the
error, if any. Also avoid redundant Close calls that already happen
with the defer we have in place.

Noticed this when investigating a support issue.
