### PR TITLE
Log file cleanup: Only delete temporary file if it was created

### DIFF
--- a/state/logs.go
+++ b/state/logs.go
@@ -163,8 +163,10 @@ type LogLine struct {
 }
 
 func (logFile LogFile) Cleanup() {
-	logFile.TmpFile.Close()
-	os.Remove(logFile.TmpFile.Name())
+	if logFile.TmpFile != nil {
+		logFile.TmpFile.Close()
+		os.Remove(logFile.TmpFile.Name())
+	}
 }
 
 func (ls TransientLogState) Cleanup() {


### PR DESCRIPTION
Due to the change in dc4a65638c2d169af90c224cf9ee2300fa88f491 we may
enter cleanup in cases where the TmpFile wasn't actually initialized.

In such cases, we should just do nothing in cleanup.