### PR TITLE
Update docs on CREATE EXTENSION to match website

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ to run as a superuser, you can setup a separate monitoring user like this:
 ```
 CREATE SCHEMA pganalyze;
 
-CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
 
 CREATE OR REPLACE FUNCTION pganalyze.get_stat_statements(showtext boolean = true) RETURNS SETOF pg_stat_statements AS
 $$
@@ -102,7 +102,7 @@ $$ LANGUAGE sql VOLATILE SECURITY DEFINER;
 If you are using the Buffer Cache report in pganalyze, you will also need to create this additional helper method:
 
 ```
-CREATE EXTENSION IF NOT EXISTS pg_buffercache;
+CREATE EXTENSION IF NOT EXISTS pg_buffercache WITH SCHEMA public;
 CREATE OR REPLACE FUNCTION pganalyze.get_buffercache() RETURNS SETOF public.pg_buffercache AS
 $$
   /* pganalyze-collector */ SELECT * FROM public.pg_buffercache;


### PR DESCRIPTION
I noticed that the [instructions on pganalyze.com][1] recommend the explicit public schema when
creating the `pg_stat_statements` extension, but this README does not. Makes sense for them to be
consistent?

Also, probably makes sense to do the same for `pg_buffercache`?

[1]: https://pganalyze.com/docs/install/amazon_rds/02_create_monitoring_user