### PR TITLE
Add pganalyze system user to adm group in Debian/Ubuntu packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       id: go
 
     - name: Set up protoc
-      uses: arduino/setup-protoc@v1.1.0
+      uses: arduino/setup-protoc@v1.1.2
       with:
         version: 3.x
 

--- a/packages/src/deb-systemd/after-install.sh
+++ b/packages/src/deb-systemd/after-install.sh
@@ -7,6 +7,10 @@ if ! getent group pganalyze > /dev/null; then
   usermod -g pganalyze pganalyze
 fi
 
+if ! groups pganalyze-collector | grep --quiet adm; then
+  usermod --append --groups adm pganalyze
+fi
+
 mkdir -p /var/lib/pganalyze-collector
 su -s /bin/sh pganalyze -c "test -O /var/lib/pganalyze-collector" || chown pganalyze /var/lib/pganalyze-collector
 

--- a/packages/src/deb-upstart/after-install.sh
+++ b/packages/src/deb-upstart/after-install.sh
@@ -7,6 +7,10 @@ if ! getent group pganalyze > /dev/null; then
   usermod -g pganalyze pganalyze
 fi
 
+if ! groups pganalyze-collector | grep --quiet adm; then
+  usermod --append --groups adm pganalyze
+fi
+
 mkdir -p /var/lib/pganalyze-collector
 su -s /bin/sh pganalyze -c "test -O /var/lib/pganalyze-collector" || chown pganalyze /var/lib/pganalyze-collector
 

--- a/packages/src/deb-upstart/after-upgrade.sh
+++ b/packages/src/deb-upstart/after-upgrade.sh
@@ -7,6 +7,10 @@ if ! getent group pganalyze > /dev/null; then
   usermod -g pganalyze pganalyze
 fi
 
+if ! groups pganalyze-collector | grep --quiet adm; then
+  usermod --append --groups adm pganalyze
+fi
+
 mkdir -p /var/lib/pganalyze-collector
 su -s /bin/sh pganalyze -c "test -O /var/lib/pganalyze-collector" || chown pganalyze /var/lib/pganalyze-collector
 


### PR DESCRIPTION
This gives it permission to read Postgres log files in a default
install, simplifying Log Insights setup.

The adm group according to the Debian wiki [1]:

  Group adm is used for system monitoring tasks. Members of this
  group can read many log files in /var/log, and can use xconsole

[1]: https://wiki.debian.org/SystemGroups