### PR TITLE
Add a skip_if_replica / SKIP_IF_REPLICA option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -143,6 +143,11 @@ type ServerConfig struct {
 	// the collector multiple times against the same database server
 	MaxCollectorConnections int `ini:"max_collector_connections"`
 
+	// Do not monitor this server while it is a replica (according to pg_is_in_recovery),
+	// but keep checking on standard snapshot intervals and automatically start monitoring
+	// once the server is promoted
+	SkipIfReplica bool `ini:"skip_if_replica"`
+
 	// Configuration for PII filtering
 	FilterLogSecret   string `ini:"filter_log_secret"`   // none/all/credential/parsing_error/statement_text/statement_parameter/table_data/ops/unidentified (comma separated)
 	FilterQuerySample string `ini:"filter_query_sample"` // none/all (defaults to "none")

--- a/config/read.go
+++ b/config/read.go
@@ -191,7 +191,7 @@ func getDefaultConfig() *ServerConfig {
 	if maxCollectorConnections := os.Getenv("MAX_COLLECTOR_CONNECTION"); maxCollectorConnections != "" {
 		config.MaxCollectorConnections, _ = strconv.Atoi(maxCollectorConnections)
 	}
-	if skipIfReplica := os.Getenv("MAX_COLLECTOR_CONNECTION"); skipIfReplica != "" && skipIfReplica != "0" {
+	if skipIfReplica := os.Getenv("SKIP_IF_REPLICA"); skipIfReplica != "" && skipIfReplica != "0" {
 		config.SkipIfReplica = true
 	}
 	if filterLogSecret := os.Getenv("FILTER_LOG_SECRET"); filterLogSecret != "" {

--- a/config/read.go
+++ b/config/read.go
@@ -191,6 +191,9 @@ func getDefaultConfig() *ServerConfig {
 	if maxCollectorConnections := os.Getenv("MAX_COLLECTOR_CONNECTION"); maxCollectorConnections != "" {
 		config.MaxCollectorConnections, _ = strconv.Atoi(maxCollectorConnections)
 	}
+	if skipIfReplica := os.Getenv("MAX_COLLECTOR_CONNECTION"); skipIfReplica != "" && skipIfReplica != "0" {
+		config.SkipIfReplica = true
+	}
 	if filterLogSecret := os.Getenv("FILTER_LOG_SECRET"); filterLogSecret != "" {
 		config.FilterLogSecret = filterLogSecret
 	}

--- a/input/full.go
+++ b/input/full.go
@@ -16,21 +16,7 @@ import (
 // CollectFull - Collects a "full" snapshot of all data we need on a regular interval
 func CollectFull(server *state.Server, connection *sql.DB, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (ps state.PersistedState, ts state.TransientState, err error) {
 	systemType := server.Config.SystemType
-
 	ps.CollectedAt = time.Now()
-
-	if server.Config.SkipIfReplica {
-		var isReplica bool
-		isReplica, err = postgres.GetIsReplica(logger, connection)
-		if err != nil {
-			logger.PrintError("Error checking replication status")
-			return
-		}
-		if isReplica {
-			err = state.ErrReplicaCollectionDisabled
-			return
-		}
-	}
 
 	ts.Version, err = postgres.GetPostgresVersion(logger, connection)
 	if err != nil {

--- a/input/postgres/replication.go
+++ b/input/postgres/replication.go
@@ -143,13 +143,13 @@ func GetReplication(logger *util.Logger, db *sql.DB, postgresVersion state.Postg
 func GetIsReplica(logger *util.Logger, db *sql.DB) (bool, error) {
 	isAwsAurora, err := GetIsAwsAurora(db)
 	if err != nil {
-		logger.PrintVerbose("Error collecting Postgres Version: %s", err)
+		logger.PrintVerbose("Error checking Postgres version: %s", err)
 		return false, err
 	}
 
 	if isAwsAurora {
-		// replication works differently in Aurora and is not currently supported
-		// by the skip_if_replica flag
+		// AWS Aurora is always considered a primary for purposes of the
+		// skip_if_replica flag
 		return false, nil
 	}
 

--- a/input/postgres/replication.go
+++ b/input/postgres/replication.go
@@ -139,3 +139,9 @@ func GetReplication(logger *util.Logger, db *sql.DB, postgresVersion state.Postg
 
 	return repl, nil
 }
+
+func GetIsReplica(logger *util.Logger, db *sql.DB) (bool, error) {
+	var isReplica bool
+	err := db.QueryRow(QueryMarkerSQL + "SELECT pg_catalog.pg_is_in_recovery()").Scan(&isReplica)
+	return isReplica, err
+}

--- a/input/postgres/settings.go
+++ b/input/postgres/settings.go
@@ -18,7 +18,7 @@ SELECT name,
 			 sourceline
 	FROM pg_catalog.pg_settings`
 
-func GetSettings(db *sql.DB, postgresVersion state.PostgresVersion) ([]state.PostgresSetting, error) {
+func GetSettings(db *sql.DB) ([]state.PostgresSetting, error) {
 	stmt, err := db.Prepare(QueryMarkerSQL + settingsSQL)
 	if err != nil {
 		err = fmt.Errorf("Settings/Prepare: %s", err)

--- a/input/system/heroku/log_receiver.go
+++ b/input/system/heroku/log_receiver.go
@@ -80,6 +80,12 @@ func processSystemMetrics(timestamp time.Time, content []byte, nameToServer map[
 		logger.PrintInfo("Ignoring system data since server can't be matched yet - if this keeps showing up you have a configuration error for %s", namespace+" / "+sourceName)
 		return
 	}
+	server.CollectionStatusMutex.Lock()
+	if server.CollectionStatus.CollectionDisabled {
+		server.CollectionStatusMutex.Unlock()
+		return
+	}
+	server.CollectionStatusMutex.Unlock()
 
 	prefixedLogger := logger.WithPrefix(server.Config.SectionName)
 

--- a/main.go
+++ b/main.go
@@ -546,9 +546,9 @@ func checkOneInitialCollectionStatus(server *state.Server, opts state.Collection
 		collectionDisabledReason = state.ErrReplicaCollectionDisabled.Error()
 	}
 	if isIgnoredReplica {
-		logger.PrintInfo("All monitoring disabled for this server: %s", collectionDisabledReason)
+		logger.PrintInfo("All monitoring suspended for this server: %s", collectionDisabledReason)
 	} else if logsDisabled {
-		logger.PrintInfo("Log collection disabled for this server: %s", logsDisabledReason)
+		logger.PrintInfo("Log collection suspended for this server: %s", logsDisabledReason)
 	}
 
 	server.CollectionStatusMutex.Lock()

--- a/main.go
+++ b/main.go
@@ -537,7 +537,7 @@ func checkOneInitialCollectionStatus(server *state.Server, opts state.Collection
 
 	var isIgnoredReplica bool
 	var collectionDisabledReason string
-	if !server.Config.SkipIfReplica {
+	if server.Config.SkipIfReplica {
 		isIgnoredReplica, err = postgres.GetIsReplica(logger, conn)
 		if err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -543,7 +543,9 @@ func checkOneInitialCollectionStatus(server *state.Server, opts state.Collection
 		if err != nil {
 			return err
 		}
-		collectionDisabledReason = state.ErrReplicaCollectionDisabled.Error()
+		if isIgnoredReplica {
+			collectionDisabledReason = state.ErrReplicaCollectionDisabled.Error()
+		}
 	}
 	if isIgnoredReplica {
 		logger.PrintInfo("All monitoring suspended for this server: %s", collectionDisabledReason)

--- a/runner/activity.go
+++ b/runner/activity.go
@@ -22,22 +22,6 @@ func processActivityForServer(server *state.Server, globalCollectionOpts state.C
 
 	newState := server.ActivityPrevState
 
-	if !globalCollectionOpts.ForceEmptyGrant {
-		newGrant, err = grant.GetDefaultGrant(server, globalCollectionOpts, logger)
-		if err != nil {
-			return newState, false, errors.Wrap(err, "could not get default grant for activity snapshot")
-		}
-
-		if !newGrant.Config.EnableActivity {
-			if globalCollectionOpts.TestRun {
-				logger.PrintError("  Failed - Activity snapshots disabled by pganalyze")
-			} else {
-				logger.PrintVerbose("Activity snapshots disabled by pganalyze, skipping")
-			}
-			return newState, false, nil
-		}
-	}
-
 	connection, err = postgres.EstablishConnection(server, logger, globalCollectionOpts, "")
 	if err != nil {
 		return newState, false, errors.Wrap(err, "failed to connect to database")
@@ -53,6 +37,22 @@ func processActivityForServer(server *state.Server, globalCollectionOpts state.C
 		}
 		if isReplica {
 			return newState, false, state.ErrReplicaCollectionDisabled
+		}
+	}
+
+	if !globalCollectionOpts.ForceEmptyGrant {
+		newGrant, err = grant.GetDefaultGrant(server, globalCollectionOpts, logger)
+		if err != nil {
+			return newState, false, errors.Wrap(err, "could not get default grant for activity snapshot")
+		}
+
+		if !newGrant.Config.EnableActivity {
+			if globalCollectionOpts.TestRun {
+				logger.PrintError("  Failed - Activity snapshots disabled by pganalyze")
+			} else {
+				logger.PrintVerbose("Activity snapshots disabled by pganalyze, skipping")
+			}
+			return newState, false, nil
 		}
 	}
 

--- a/runner/activity.go
+++ b/runner/activity.go
@@ -123,10 +123,14 @@ func CollectActivityFromAllServers(servers []*state.Server, globalCollectionOpts
 				}
 				server.CollectionStatusMutex.Unlock()
 
-				allSuccessful = false
-				prefixedLogger.PrintError("Could not collect activity for server: %s", err)
-				if !isIgnoredReplica && server.Config.ErrorCallback != "" {
-					go runCompletionCallback("error", server.Config.ErrorCallback, server.Config.SectionName, "activity", err, prefixedLogger)
+				if isIgnoredReplica {
+					prefixedLogger.PrintVerbose("All monitoring suspended while server is replica")
+				} else {
+					allSuccessful = false
+					prefixedLogger.PrintError("Could not collect activity for server: %s", err)
+					if !isIgnoredReplica && server.Config.ErrorCallback != "" {
+						go runCompletionCallback("error", server.Config.ErrorCallback, server.Config.SectionName, "activity", err, prefixedLogger)
+					}
 				}
 			} else {
 				server.ActivityPrevState = newState

--- a/runner/full.go
+++ b/runner/full.go
@@ -167,15 +167,29 @@ func CollectAllServers(servers []*state.Server, globalCollectionOpts state.Colle
 			if err != nil {
 				server.StateMutex.Unlock()
 				allSuccessful = false
+
+				server.CollectionStatusMutex.Lock()
+				isIgnoredReplica := err == state.ErrReplicaCollectionDisabled
+				if isIgnoredReplica {
+					reason := err.Error()
+					server.CollectionStatus = state.CollectionStatus{
+						CollectionDisabled:        true,
+						CollectionDisabledReason:  reason,
+						LogSnapshotDisabled:       true,
+						LogSnapshotDisabledReason: reason,
+					}
+				}
+				server.CollectionStatusMutex.Unlock()
+
 				prefixedLogger.PrintError("Could not process server: %s", err)
-				if grant.Valid && !globalCollectionOpts.TestRun && globalCollectionOpts.SubmitCollectedData {
+				if grant.Valid && !isIgnoredReplica && !globalCollectionOpts.TestRun && globalCollectionOpts.SubmitCollectedData {
 					server.Grant = grant
 					err = output.SendFailedFull(server, globalCollectionOpts, prefixedLogger)
 					if err != nil {
 						prefixedLogger.PrintWarning("Could not send error information to remote server: %s", err)
 					}
 				}
-				if server.Config.ErrorCallback != "" {
+				if !isIgnoredReplica && server.Config.ErrorCallback != "" {
 					go runCompletionCallback("error", server.Config.ErrorCallback, server.Config.SectionName, "full", err, prefixedLogger)
 				}
 			} else {

--- a/runner/queries.go
+++ b/runner/queries.go
@@ -23,8 +23,18 @@ func gatherQueryStatsForServer(server *state.Server, globalCollectionOpts state.
 	if err != nil {
 		return newState, errors.Wrap(err, "failed to connect to database")
 	}
-
 	defer connection.Close()
+
+	if server.Config.SkipIfReplica {
+		var isReplica bool
+		isReplica, err = postgres.GetIsReplica(logger, connection)
+		if err != nil {
+			return newState, err
+		}
+		if isReplica {
+			return newState, state.ErrReplicaCollectionDisabled
+		}
+	}
 
 	postgresVersion, err := postgres.GetPostgresVersion(logger, connection)
 	if err != nil {
@@ -77,6 +87,20 @@ func GatherQueryStatsFromAllServers(servers []*state.Server, globalCollectionOpt
 
 			if err != nil {
 				server.StateMutex.Unlock()
+
+				server.CollectionStatusMutex.Lock()
+				isIgnoredReplica := err == state.ErrReplicaCollectionDisabled
+				if isIgnoredReplica {
+					reason := err.Error()
+					server.CollectionStatus = state.CollectionStatus{
+						CollectionDisabled:        true,
+						CollectionDisabledReason:  reason,
+						LogSnapshotDisabled:       true,
+						LogSnapshotDisabledReason: reason,
+					}
+				}
+				server.CollectionStatusMutex.Unlock()
+
 				prefixedLogger.PrintError("Could not collect query stats for server: %s", err)
 				if server.Config.ErrorCallback != "" {
 					go runCompletionCallback("error", server.Config.ErrorCallback, server.Config.SectionName, "query_stats", err, prefixedLogger)

--- a/runner/queries.go
+++ b/runner/queries.go
@@ -101,9 +101,13 @@ func GatherQueryStatsFromAllServers(servers []*state.Server, globalCollectionOpt
 				}
 				server.CollectionStatusMutex.Unlock()
 
-				prefixedLogger.PrintError("Could not collect query stats for server: %s", err)
-				if server.Config.ErrorCallback != "" {
-					go runCompletionCallback("error", server.Config.ErrorCallback, server.Config.SectionName, "query_stats", err, prefixedLogger)
+				if isIgnoredReplica {
+					prefixedLogger.PrintVerbose("All monitoring suspended while server is replica")
+				} else {
+					prefixedLogger.PrintError("Could not collect query stats for server: %s", err)
+					if server.Config.ErrorCallback != "" {
+						go runCompletionCallback("error", server.Config.ErrorCallback, server.Config.SectionName, "query_stats", err, prefixedLogger)
+					}
 				}
 			} else {
 				server.PrevState = newState

--- a/state/errors.go
+++ b/state/errors.go
@@ -1,0 +1,5 @@
+package state
+
+import "errors"
+
+var ErrReplicaCollectionDisabled error = errors.New("monitored server is replica and replication collection disabled via config")

--- a/state/state.go
+++ b/state/state.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"errors"
 	"sync"
 	"time"
 
@@ -216,8 +215,6 @@ type GrantS3 struct {
 	S3URL    string            `json:"s3_url"`
 	S3Fields map[string]string `json:"s3_fields"`
 }
-
-var ErrReplicaCollectionDisabled error = errors.New("monitored server is replica and replication collection disabled via config")
 
 type CollectionStatus struct {
 	CollectionDisabled        bool

--- a/state/state.go
+++ b/state/state.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"errors"
 	"sync"
 	"time"
 
@@ -216,7 +217,11 @@ type GrantS3 struct {
 	S3Fields map[string]string `json:"s3_fields"`
 }
 
+var ErrReplicaCollectionDisabled error = errors.New("monitored server is replica and replication collection disabled via config")
+
 type CollectionStatus struct {
+	CollectionDisabled        bool
+	CollectionDisabledReason  string
 	LogSnapshotDisabled       bool
 	LogSnapshotDisabledReason string
 }


### PR DESCRIPTION
This allows users to configure the collector in a no-op mode on
replicas (we only query if the monitored database is a replica), and
automatically switch to active monitoring when the database is no
longer a replica.