### PR TITLE
Don't run log test for Heroku, instead provide info message

### DIFF
--- a/logs/parse.go
+++ b/logs/parse.go
@@ -79,6 +79,8 @@ var RsyslogHostnameRegxp = `(\S+)`
 var RsyslogProcessNameRegexp = `(\w+)`
 var RsyslogRegexp = regexp.MustCompile(`^` + RsyslogTimeRegexp + ` ` + RsyslogHostnameRegxp + ` ` + RsyslogProcessNameRegexp + `\[` + PidRegexp + `\]: ` + SyslogSequenceAndSplitRegexp + ` ` + RsyslogLevelAndContentRegexp)
 
+// The Heroku log_line_prefix is handled directly in the Heroku log receiver, included here for reference only
+var HerokuLogLinePrefix = " sql_error_code = %e "
 var HerokuPostgresDebugRegexp = regexp.MustCompile(`^(\w+ \d+ \d+:\d+:\d+ \w+ app\[postgres\] \w+ )?\[(\w+)\] \[\d+-\d+\] ( sql_error_code = ` + SqlstateRegexp + ` (\w+):  )?(.+)`)
 
 func IsSupportedPrefix(prefix string) bool {

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -105,7 +105,7 @@ func TestLogsForAllServers(servers []*state.Server, globalCollectionOpts state.C
 			prefixedLogger.PrintError("ERROR - Could not check log_line_prefix for server: %s", err)
 			hasFailedServers = true
 			continue
-		} else if !logs.IsSupportedPrefix(logLinePrefix) {
+		} else if !logs.IsSupportedPrefix(logLinePrefix) && !(server.Config.SystemType == "heroku" && logLinePrefix == logs.HerokuLogLinePrefix) {
 			prefixedLogger.PrintError("ERROR - Unsupported log_line_prefix setting: '%s'", logLinePrefix)
 			hasFailedServers = true
 			continue
@@ -148,6 +148,8 @@ func TestLogsForAllServers(servers []*state.Server, globalCollectionOpts state.C
 			} else {
 				prefixedLogger.PrintInfo("  Log test successful")
 			}
+		} else if server.Config.SystemType == "heroku" {
+			prefixedLogger.PrintInfo("NOTICE - To confirm Log Insights config, setup Heroku log drain per docs (https://pganalyze.com/docs/log-insights/setup/heroku-postgres) and verify data shows up in pganalyze app.")
 		}
 	}
 


### PR DESCRIPTION
This also fixes a related problem with the log_line_prefix check erroring
out, which we can ignore since the Heroku log_line_prefix is special
cased and not handled in the regular logic.