### PR TITLE
pg_stat_statements: Ignore "insufficient privilege" queries w/o queryid

### DIFF
--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -184,7 +184,7 @@ func GetStatements(server *state.Server, logger *util.Logger, db *sql.DB, global
 
 		if queryID.Valid {
 			key.QueryID = queryID.Int64
-		} else if receivedQuery.Valid {
+		} else if receivedQuery.Valid && receivedQuery.String != "<insufficient privilege>" {
 			// Note: This is a heuristic for old Postgres versions and will not work for duplicate queries (e.g. when tables are dropped and recreated)
 			h := fnv.New64a()
 			h.Write([]byte(receivedQuery.String))


### PR DESCRIPTION
There is no way to correctly diff these kinds of queries, because Postgres
will report one entry for each query, but won't let us see the text or
the queryid.

For Postgres 10 and newer, the pg_monitor role should be used, which
avoids this problem altogether. On older Postgres releases, we only
support monitoring a single role (that which owns the monitoring helper
function).