### PR TITLE
Restore trailing newlines for GCP and self-hosted log streams

### DIFF
--- a/input/system/google_cloudsql/log_receiver.go
+++ b/input/system/google_cloudsql/log_receiver.go
@@ -46,8 +46,11 @@ func logReceiver(ctx context.Context, servers []*state.Server, in <-chan LogStre
 				}
 
 				// We ignore failures here since we want the per-backend stitching logic
-				// that runs later on (and any other parsing errors will just be ignored)
-				logLine, _ := logs.ParseLogLineWithPrefix("", in.Content)
+				// that runs later on (and any other parsing errors will just be ignored).
+				// Note that we need to restore the original trailing newlines since
+				// ProcessLogStream below expects them and they are not present in the GCP
+				// log stream.
+				logLine, _ := logs.ParseLogLineWithPrefix("", in.Content+"\n")
 				logLine.CollectedAt = time.Now()
 				logLine.OccurredAt = in.OccurredAt
 				logLine.UUID = uuid.NewV4()

--- a/input/system/selfhosted/log_receiver.go
+++ b/input/system/selfhosted/log_receiver.go
@@ -383,7 +383,10 @@ func logReceiver(ctx context.Context, server *state.Server, globalCollectionOpts
 
 				// We ignore failures here since we want the per-backend stitching logic
 				// that runs later on (and any other parsing errors will just be ignored)
-				logLine, _ := logs.ParseLogLineWithPrefix("", line)
+				// Note that we need to restore the original trailing newlines since
+				// ProcessLogStream below expects them and they are not present in the tail
+				// log stream.
+				logLine, _ := logs.ParseLogLineWithPrefix("", line+"\n")
 				logLine.CollectedAt = time.Now()
 				logLine.UUID = uuid.NewV4()
 

--- a/logs/stream/stream.go
+++ b/logs/stream/stream.go
@@ -250,6 +250,8 @@ func LogTestNone(server *state.Server, logFile state.LogFile, logTestSucceeded c
 
 // ProcessLogStream - Accepts one or more log lines to be analyzed and processed
 //
+// Note that input log lines are expected to preserve their trailing newlines.
+//
 // Note that this returns the lines that were not processed, based on the
 // time-based buffering logic. These lines should be passed in again with
 // the next call.


### PR DESCRIPTION
Right now, log streams for GCP (via Pub/Sub) and self-hosted systems
(via local file tails) strip trailing newlines, which can lead to
issues parsing some multi-line queries for log-based EXPLAIN when
those newlines are semantically significant.

One known issue is for single-line comments. A query like this:

  SELECT now() -- current timestamp
    , a FROM my_table

would be parsed as

  SELECT now() -- current timestamp   , a FROM my_table

which is a different query entirely. This can lead to an incorrect
EXPLAIN plan being generated, or (more likely) failure to generate a
plan entirely due to broken syntax or an incorrect number of
parameters.

Note that RDS and Heroku Postgres log processing does not have this
issue. Azure will be verified separately.
