### PR TITLE
Fix error handling if last guided setup step fails

### DIFF
--- a/setup/state/state.go
+++ b/setup/state/state.go
@@ -249,7 +249,7 @@ func (state *SetupState) ReportLastStep(step *Step, stepErr error) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("Accept", "application/json,text/plain")
 
-	resp, _ := client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		// again, ignoring errors
 		return


### PR DESCRIPTION
We intend to ignore errors reporting setup progress, but we do need to
short-circuit when there *is* an error.
