### PR TITLE
Validate db_url/DB_URL, if set, when initially reading config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -168,7 +168,10 @@ func (config ServerConfig) GetPqOpenString(dbNameOverride string) string {
 	var dbPort int
 
 	if config.DbURL != "" {
-		u, _ := url.Parse(config.DbURL)
+		u, err := url.Parse(config.DbURL)
+		if err != nil {
+			return ""
+		}
 
 		if u.User != nil {
 			dbUsername = u.User.Username()
@@ -297,7 +300,10 @@ func (config ServerConfig) GetPqOpenString(dbNameOverride string) string {
 // GetDbHost - Gets the database hostname from the given configuration
 func (config ServerConfig) GetDbHost() string {
 	if config.DbURL != "" {
-		u, _ := url.Parse(config.DbURL)
+		u, err := url.Parse(config.DbURL)
+		if err != nil {
+			return ""
+		}
 		parts := strings.Split(u.Host, ":")
 		return parts[0]
 	}
@@ -322,7 +328,10 @@ func (config ServerConfig) GetDbURLRedacted() string {
 // GetDbPort - Gets the database port from the given configuration
 func (config ServerConfig) GetDbPort() int {
 	if config.DbURL != "" {
-		u, _ := url.Parse(config.DbURL)
+		u, err := url.Parse(config.DbURL)
+		if err != nil {
+			return 5432
+		}
 		parts := strings.Split(u.Host, ":")
 
 		if len(parts) == 2 {
@@ -339,7 +348,10 @@ func (config ServerConfig) GetDbPort() int {
 // GetDbUsername - Gets the database hostname from the given configuration
 func (config ServerConfig) GetDbUsername() string {
 	if config.DbURL != "" {
-		u, _ := url.Parse(config.DbURL)
+		u, err := url.Parse(config.DbURL)
+		if err != nil {
+			return ""
+		}
 		if u != nil && u.User != nil {
 			return u.User.Username()
 		}
@@ -351,7 +363,10 @@ func (config ServerConfig) GetDbUsername() string {
 // GetDbName - Gets the database name from the given configuration
 func (config ServerConfig) GetDbName() string {
 	if config.DbURL != "" {
-		u, _ := url.Parse(config.DbURL)
+		u, err := url.Parse(config.DbURL)
+		if err != nil {
+			return ""
+		}
 		if len(u.Path) > 0 {
 			return u.Path[1:len(u.Path)]
 		}

--- a/config/read.go
+++ b/config/read.go
@@ -420,6 +420,14 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 					conf.Servers = append(conf.Servers, *config)
 				}
 			}
+
+			if config.DbURL != "" {
+				_, err := url.Parse(config.DbURL)
+				if err != nil {
+					prefixedLogger := logger.WithPrefix(config.SectionName)
+					prefixedLogger.PrintError("Could not parse db_url")
+				}
+			}
 		}
 
 		if len(conf.Servers) == 0 {

--- a/config/read.go
+++ b/config/read.go
@@ -369,7 +369,7 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 	var err error
 
 	if _, err = os.Stat(filename); err == nil {
-		configFile, err := ini.Load(filename)
+		configFile, err := ini.LoadSources(ini.LoadOptions{SpaceBeforeInlineComment: true}, filename)
 		if err != nil {
 			return conf, err
 		}

--- a/config/read.go
+++ b/config/read.go
@@ -425,7 +425,7 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 				_, err := url.Parse(config.DbURL)
 				if err != nil {
 					prefixedLogger := logger.WithPrefix(config.SectionName)
-					prefixedLogger.PrintError("Could not parse db_url")
+					prefixedLogger.PrintError("Could not parse db_url; check URL format and note that any special characters must be percent-encoded")
 				}
 			}
 		}


### PR DESCRIPTION
Right now, we do not validate it, so if set to an invalid URL, it can
crash some of our helper functions with a segfault due to a nil
pointer reference.

Validate at startup, but allow to continue to avoid retrofitting error
handling across helpers that right now cannot return errors. The helpers
return dummy/default values which will fail authentication.

See #124 (this is not a fix for that, since go-ini does not parse
comments correctly, but at least it will give users a proper error
message instead of a segfault.
