### PR TITLE
Change <unidentified queryid> marker to clarify cause

### DIFF
--- a/output/transform/postgres_query.go
+++ b/output/transform/postgres_query.go
@@ -39,8 +39,8 @@ func upsertQueryReferenceAndInformation(s *snapshot.FullSnapshot, statementTexts
 
 	// Information
 	normalizedQuery := ""
-	if value.statement.Unidentified {
-		normalizedQuery = "<unidentified queryid>"
+	if value.statement.QueryTextUnavailable {
+		normalizedQuery = "<query text unavailable>"
 	} else if value.statement.InsufficientPrivilege {
 		normalizedQuery = "<insufficient privilege>"
 	} else if value.statement.Collector {

--- a/output/transform/postgres_statements.go
+++ b/output/transform/postgres_statements.go
@@ -15,7 +15,7 @@ func groupStatements(statements state.PostgresStatementMap, statementTexts state
 	for sKey, stats := range statsMap {
 		statement, exist := statements[sKey]
 		if !exist {
-			statement = state.PostgresStatement{Unidentified: true, Fingerprint: util.FingerprintQuery("<unidentified queryid>")}
+			statement = state.PostgresStatement{QueryTextUnavailable: true, Fingerprint: util.FingerprintQuery("<query text unavailable>")}
 		}
 
 		key := statementKey{

--- a/state/postgres_statement.go
+++ b/state/postgres_statement.go
@@ -10,7 +10,7 @@ import (
 // on the PostgreSQL server.
 type PostgresStatement struct {
 	Fingerprint           [21]byte // Fingerprint for a specific statement
-	Unidentified          bool     // True if this represents an unidentified statement without query text
+	QueryTextUnavailable  bool     // True if this represents a statement without query text
 	InsufficientPrivilege bool     // True if we're missing permissions to see the statement
 	Collector             bool     // True if this statement was produced by the pganalyze collector
 }


### PR DESCRIPTION
Right now, if pg_stat_statements.max is too low for a given query
workload, we may end up capturing stats for queries whose text is no
longer available to us. We flag this situation by using the string
`<unidentified queryid>` as the query text, but this is fairly opaque.
We have a change in progress to improve the display of this in-app,
but changing the actual marker string used here can help clarify
things as well.

Instead of `<unidentified queryid>`, this patch changes the text for
queries like this to `<query text unavailable>`, which describes the
situation more accurately.
