### PR TITLE
Normalize query: Keep using "<truncated query>" for pg_stat_activity

### DIFF
--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -219,7 +219,7 @@ func GetStatements(server *state.Server, logger *util.Logger, db *sql.DB, global
 	}
 
 	for fp, text := range statementTexts {
-		statementTexts[fp] = util.NormalizeQuery(text, server.Config.FilterQueryText)
+		statementTexts[fp] = util.NormalizeQuery(text, server.Config.FilterQueryText, -1)
 	}
 
 	return statements, statementTexts, statementStats, nil

--- a/output/transform/activity.go
+++ b/output/transform/activity.go
@@ -35,6 +35,7 @@ func ActivityStateToCompactActivitySnapshot(server *state.Server, activityState 
 				b.RoleIdx,
 				b.DatabaseIdx,
 				backend.Query.String,
+				activityState.TrackActivityQuerySize,
 			)
 			b.HasQueryIdx = true
 			b.QueryText = backend.Query.String

--- a/output/transform/logs.go
+++ b/output/transform/logs.go
@@ -90,6 +90,7 @@ func transformPostgresQuerySamples(server *state.Server, s snapshot.CompactLogSn
 			roleIdx,
 			databaseIdx,
 			sampleIn.Query,
+			-1,
 		)
 
 		var parameters []*snapshot.NullString
@@ -213,6 +214,7 @@ func transformSystemLogLine(server *state.Server, r *snapshot.CompactSnapshot_Ba
 			logLine.RoleIdx,
 			logLine.DatabaseIdx,
 			logLineIn.Query,
+			-1,
 		)
 		logLine.HasQueryIdx = true
 	}

--- a/output/transform/postgres_query.go
+++ b/output/transform/postgres_query.go
@@ -58,7 +58,7 @@ func upsertQueryReferenceAndInformation(s *snapshot.FullSnapshot, statementTexts
 	return idx
 }
 
-func upsertQueryReferenceAndInformationSimple(server *state.Server, refs []*snapshot.QueryReference, infos []*snapshot.QueryInformation, roleIdx int32, databaseIdx int32, originalQuery string) (int32, []*snapshot.QueryReference, []*snapshot.QueryInformation) {
+func upsertQueryReferenceAndInformationSimple(server *state.Server, refs []*snapshot.QueryReference, infos []*snapshot.QueryInformation, roleIdx int32, databaseIdx int32, originalQuery string, trackActivityQuerySize int) (int32, []*snapshot.QueryReference, []*snapshot.QueryInformation) {
 	fingerprint := util.FingerprintQuery(originalQuery)
 
 	newRef := snapshot.QueryReference{
@@ -80,7 +80,7 @@ func upsertQueryReferenceAndInformationSimple(server *state.Server, refs []*snap
 	// Information
 	queryInformation := snapshot.QueryInformation{
 		QueryIdx:        idx,
-		NormalizedQuery: util.NormalizeQuery(originalQuery, server.Config.FilterQueryText),
+		NormalizedQuery: util.NormalizeQuery(originalQuery, server.Config.FilterQueryText, trackActivityQuerySize),
 	}
 	infos = append(infos, &queryInformation)
 

--- a/runner/activity.go
+++ b/runner/activity.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"database/sql"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -61,6 +62,16 @@ func processActivityForServer(server *state.Server, globalCollectionOpts state.C
 			return newState, false, errors.Wrap(err, "failed to connect to database")
 		}
 		defer connection.Close()
+	}
+
+	trackActivityQuerySize, err := postgres.GetPostgresSetting("track_activity_query_size", server, globalCollectionOpts, logger)
+	if err != nil {
+		activity.TrackActivityQuerySize = -1
+	} else {
+		activity.TrackActivityQuerySize, err = strconv.Atoi(trackActivityQuerySize)
+		if err != nil {
+			activity.TrackActivityQuerySize = -1
+		}
 	}
 
 	activity.Version, err = postgres.GetPostgresVersion(logger, connection)

--- a/state/activity.go
+++ b/state/activity.go
@@ -5,6 +5,8 @@ import "time"
 type TransientActivityState struct {
 	CollectedAt time.Time
 
+	TrackActivityQuerySize int
+
 	Version  PostgresVersion
 	Backends []PostgresBackend
 

--- a/util/normalize.go
+++ b/util/normalize.go
@@ -1,12 +1,16 @@
 package util
 
-import pg_query "github.com/lfittl/pg_query_go"
+import (
+	pg_query "github.com/lfittl/pg_query_go"
+)
 
-func NormalizeQuery(query string, filterQueryText string) string {
+func NormalizeQuery(query string, filterQueryText string, trackActivityQuerySize int) string {
 	normalizedQuery, err := pg_query.Normalize(query)
 	if err != nil {
 		if filterQueryText == "none" {
 			normalizedQuery = query
+		} else if len(query) == trackActivityQuerySize-1 {
+			normalizedQuery = "<truncated query>"
 		} else {
 			normalizedQuery = "<unparsable query>"
 		}


### PR DESCRIPTION
When a query is cutoff due to pg_stat_activity limit being reached,
instead of showing `<unparsable query>`, show `<truncated query>`, to make
it clear that increasing track_activity_query_size would solve the issue.