### PR TITLE
Triage Aurora utility statement I/O stats issue

### DIFF
--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -211,20 +211,7 @@ func GetStatements(server *state.Server, logger *util.Logger, db *sql.DB, global
 
 			statements[key] = stmt
 		}
-		if ignoreIOStats(postgresVersion, receivedQuery) {
-			stats.SharedBlksHit = 0
-			stats.SharedBlksRead = 0
-			stats.SharedBlksDirtied = 0
-			stats.SharedBlksWritten = 0
-
-			stats.LocalBlksHit = 0
-			stats.LocalBlksRead = 0
-			stats.LocalBlksDirtied = 0
-			stats.LocalBlksWritten = 0
-
-			stats.TempBlksRead = 0
-			stats.TempBlksWritten = 0
-
+		if ignoreIOTiming(postgresVersion, receivedQuery) {
 			stats.BlkReadTime = 0
 			stats.BlkWriteTime = 0
 		}
@@ -242,9 +229,9 @@ func GetStatements(server *state.Server, logger *util.Logger, db *sql.DB, global
 	return statements, statementTexts, statementStats, nil
 }
 
-func ignoreIOStats(postgresVersion state.PostgresVersion, receivedQuery null.String) bool {
+func ignoreIOTiming(postgresVersion state.PostgresVersion, receivedQuery null.String) bool {
 	// Currently, Aurora gives wildly incorrect blk_read_time and blk_write_time values
-	// for utility statements; ignore I/O stats for these altogether.
+	// for utility statements; ignore I/O timing in this situation.
 	if !postgresVersion.IsAwsAurora || !receivedQuery.Valid {
 		return false
 	}

--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -211,6 +211,23 @@ func GetStatements(server *state.Server, logger *util.Logger, db *sql.DB, global
 
 			statements[key] = stmt
 		}
+		if ignoreIOStats(postgresVersion, receivedQuery) {
+			stats.SharedBlksHit = 0
+			stats.SharedBlksRead = 0
+			stats.SharedBlksDirtied = 0
+			stats.SharedBlksWritten = 0
+
+			stats.LocalBlksHit = 0
+			stats.LocalBlksRead = 0
+			stats.LocalBlksDirtied = 0
+			stats.LocalBlksWritten = 0
+
+			stats.TempBlksRead = 0
+			stats.TempBlksWritten = 0
+
+			stats.BlkReadTime = 0
+			stats.BlkWriteTime = 0
+		}
 		statementStats[key] = stats
 	}
 	err = rows.Err()
@@ -223,4 +240,25 @@ func GetStatements(server *state.Server, logger *util.Logger, db *sql.DB, global
 	}
 
 	return statements, statementTexts, statementStats, nil
+}
+
+func ignoreIOStats(postgresVersion state.PostgresVersion, receivedQuery null.String) bool {
+	// Currently, Aurora gives wildly incorrect blk_read_time and blk_write_time values
+	// for utility statements; ignore I/O stats for these altogether.
+	if !postgresVersion.IsAwsAurora || !receivedQuery.Valid {
+		return false
+	}
+
+	isUtil, err := util.IsUtilityStmt(receivedQuery.String)
+	if err != nil {
+		return false
+	}
+
+	for _, isOneUtil := range isUtil {
+		if isOneUtil {
+			return true
+		}
+	}
+
+	return false
 }

--- a/util/is_utility.go
+++ b/util/is_utility.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	pg_query "github.com/lfittl/pg_query_go"
+	pg_query_nodes "github.com/lfittl/pg_query_go/nodes"
+)
+
+// IsUtilityStmt determines whether each statement in the query text is a
+// utility statement or a standard SELECT/INSERT/UPDATE/DELETE statement.
+func IsUtilityStmt(query string) ([]bool, error) {
+	var result []bool
+	parsetree, err := pg_query.Parse(query)
+	if err != nil {
+		return nil, err
+	}
+	for _, rawStmt := range parsetree.Statements {
+		stmt := rawStmt.(pg_query_nodes.RawStmt).Stmt
+		var isUtility bool
+		switch stmt.(type) {
+		case pg_query_nodes.SelectStmt, pg_query_nodes.InsertStmt, pg_query_nodes.UpdateStmt, pg_query_nodes.DeleteStmt:
+			isUtility = false
+		default:
+			isUtility = true
+		}
+		result = append(result, isUtility)
+	}
+	return result, nil
+}

--- a/util/is_utility_test.go
+++ b/util/is_utility_test.go
@@ -1,0 +1,72 @@
+package util_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pganalyze/collector/util"
+)
+
+var isUtilTests = []struct {
+	input     string
+	expected  []bool
+	expectErr bool
+}{
+	{
+		"SELECT 1",
+		[]bool{false},
+		false,
+	},
+	{
+		"INSERT INTO my_table VALUES(123)",
+		[]bool{false},
+		false,
+	},
+	{
+		"UPDATE my_table SET foo = 123",
+		[]bool{false},
+		false,
+	},
+	{
+		"DELETE FROM my_table",
+		[]bool{false},
+		false,
+	},
+	{
+		"SHOW fsync",
+		[]bool{true},
+		false,
+	},
+	{
+		"SET fsync = off",
+		[]bool{true},
+		false,
+	},
+	{
+		"SELECT 1; SELECT 2;",
+		[]bool{false, false},
+		false,
+	},
+	{
+		"SELECT 1; SHOW fsync;",
+		[]bool{false, true},
+		false,
+	},
+	{
+		"totally not valid sql",
+		nil,
+		true,
+	},
+}
+
+func TestIsUtilityStmt(t *testing.T) {
+	for _, test := range isUtilTests {
+		actual, err := util.IsUtilityStmt(test.input)
+		if (err != nil) != test.expectErr {
+			t.Errorf("IsUtilityStmt(%s): expected err: %t; actual: %s", test.input, test.expectErr, err)
+		}
+		if !reflect.DeepEqual(actual, test.expected) {
+			t.Errorf("IsUtilityStmt(%s): expected %v; actual %v", test.input, test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
These are bogus right now due to Aurora bugs, so zero them out to avoid distorting our graphs.

Strictly speaking, I think we've only seen `blk_read_time` and `blk_write_time` being off, ~but it's probably prudent to ignore all of them~ (we've reviewed the other stats and feel it's better to only ignore timing, since that may be handled as an Aurora extension whereas other stats are likely straight from Postgres). Also, since these are not nullable, I'm instead zeroing them out. I think this is better than the impossibly huge values we're seeing now, but let me know if you think we should approach this differently.