### PR TITLE
Ignore duplicate dbnames when collecting

### DIFF
--- a/input/postgres/schema.go
+++ b/input/postgres/schema.go
@@ -27,7 +27,12 @@ func CollectAllSchemas(server *state.Server, collectionOpts state.CollectionOpts
 	ps.SchemaStats = make(map[state.Oid]*state.SchemaStats)
 	ps.Functions = []state.PostgresFunction{}
 
+	collected := make(map[string]bool)
 	for _, dbName := range schemaDbNames {
+		if _, ok := collected[dbName]; ok {
+			continue
+		}
+		collected[dbName] = true
 		psNext, databaseOid, err := collectOneSchema(server, collectionOpts, logger, ps, dbName, ts.Version)
 		if err != nil {
 			logger.PrintVerbose("Failed to collect schema metadata for database %s: %s", dbName, err)


### PR DESCRIPTION
If a database is specified multiple times via dbname, we collect its
schema information multiple times, but fail to correctly assemble a
snapshot due to identified collisions. The inconsistent snapshots are
sent off correctly, but can cause problems when processing.

Instead, only collect each database once to avoid the issue.

We could potentially warn when this happens, but the intent is clear
so being overparticular here seems of little benefit.
