### PR TITLE
Include guided setup in systemd-flavored deb package build

### DIFF
--- a/packages/src/Dockerfile.build.deb-systemd
+++ b/packages/src/Dockerfile.build.deb-systemd
@@ -38,8 +38,10 @@ COPY ./packages $CODE_DIR/packages
 RUN mkdir -p $SOURCE_DIR/usr/bin/
 RUN cp $CODE_DIR/pganalyze-collector $SOURCE_DIR/usr/bin/
 RUN cp $CODE_DIR/pganalyze-collector-helper $SOURCE_DIR/usr/bin/
+RUN cp $CODE_DIR/pganalyze-collector-setup $SOURCE_DIR/usr/bin/
 RUN chmod +x $SOURCE_DIR/usr/bin/pganalyze-collector
 RUN chmod +x $SOURCE_DIR/usr/bin/pganalyze-collector-helper
+RUN chmod +x $SOURCE_DIR/usr/bin/pganalyze-collector-setup
 RUN mkdir -p $SOURCE_DIR/etc/
 RUN cp $CODE_DIR/contrib/pganalyze-collector.conf $SOURCE_DIR/etc/pganalyze-collector.conf
 RUN mkdir -p $SOURCE_DIR/usr/share/pganalyze-collector/sslrootcert


### PR DESCRIPTION
We missed this in the original guided setup patch. The program is
there if building from source, but not actually bundled into our
packages.