### PR TITLE
Fail fast when pganalyze section is missing in config file

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -376,9 +376,13 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 
 		defaultConfig := getDefaultConfig()
 
-		err = configFile.Section("pganalyze").MapTo(defaultConfig)
+		pgaSection, err := configFile.GetSection("pganalyze")
 		if err != nil {
-			logger.PrintVerbose("Failed to map pganalyze section: %s", err)
+			return conf, fmt.Errorf("Failed to find [pganalyze] section in config: %s", err)
+		}
+		err = pgaSection.MapTo(defaultConfig)
+		if err != nil {
+			return conf, fmt.Errorf("Failed to map [pganalyze] section in config: %s", err)
 		}
 
 		sections := configFile.Sections()


### PR DESCRIPTION
Right now, if the pganalyze section is missing, we ignore this issue
and proceed with an empty api_key (and default api_base_url). If
there's a typo in the section name or a config structure issue (e.g.,
API key in the default section instead of the pganalyze section), it
can be hard to figure out why an API key is being rejected.

Instead, fail fast when reading the config if the [pganalyze] section
is missing or cannot be mapped onto the config struct.
