### PR TITLE
Ignore CSV log files

### DIFF
--- a/input/system/selfhosted/log_receiver.go
+++ b/input/system/selfhosted/log_receiver.go
@@ -202,7 +202,7 @@ func isAcceptableLogFile(fileName string, fileNameFilter string) bool {
 		return false
 	}
 
-	if strings.HasSuffix(fileName, ".gz") || strings.HasSuffix(fileName, ".bz2") {
+	if strings.HasSuffix(fileName, ".gz") || strings.HasSuffix(fileName, ".bz2") || strings.HasSuffix(fileName, ".csv") {
 		return false
 	}
 


### PR DESCRIPTION
Some Postgres installations are configured to log both standard-format
log files and CSV log files to the same directory, but the collector
currently reads all files specified in a db_log_location, which works
poorly with this setup.

Since we already ignore some files (zipped log files), and we do not
support parsing CSV files, add CSV log files to the ignore list.

Fixes #83
