### PR TITLE
Update log location discovery

### DIFF
--- a/helper/main.go
+++ b/helper/main.go
@@ -5,12 +5,10 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
-	"syscall"
 )
 
 type helperStatus struct {
@@ -95,34 +93,15 @@ func getStatus() {
 	fmt.Printf("%s\n", out)
 }
 
-func getLogDirectory() {
-	postgresUser, err := user.Lookup("postgres")
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error retrieving postgres UID: %s", err)
-	}
-	postgresUID, _ := strconv.Atoi(postgresUser.Uid)
-
-	cmd := exec.Command("psql", "-t", "-A", "-c", "SHOW log_directory")
-	cmd.SysProcAttr = &syscall.SysProcAttr{Credential: &syscall.Credential{Uid: uint32(postgresUID)}}
-	logDirectory, err := cmd.Output()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error running psql: %s", err)
-	} else {
-		fmt.Printf("%s", logDirectory)
-	}
-}
-
 func main() {
 	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "Please pass a command to run as the first argument - valid choices are: status, log_directory\n")
+		fmt.Fprintf(os.Stderr, "Please pass a command to run as the first argument - valid choices are: status\n")
 		return
 	}
 
 	switch os.Args[1] {
 	case "status":
 		getStatus()
-	case "log_directory":
-		getLogDirectory()
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", os.Args[1])
 	}

--- a/input/system/selfhosted/log_receiver.go
+++ b/input/system/selfhosted/log_receiver.go
@@ -112,7 +112,7 @@ func DiscoverLogLocation(servers []*state.Server, globalCollectionOpts state.Col
 			if strings.HasPrefix(logDirectory, "/") {
 				prefixedLogger.PrintInfo("Found log location, add this to your pganalyze-collector.conf in the [%s] section:\ndb_log_location = %s", server.Config.SectionName, logDirectory)
 			} else {
-				prefixedLogger.PrintInfo("WARNING: found log location in data directory - please check our setup guide for instructions.\n")
+				prefixedLogger.PrintInfo("WARNING: Found log location in data directory - please check our setup guide for instructions\n")
 			}
 		} else { // assume stdout/stderr redirect to logfile, typical with postgresql-common on Ubuntu/Debian
 			prefixedLogger.PrintInfo("Discovering log directory using open files in postmaster (PID %d)...", status.PostmasterPid)

--- a/input/system/selfhosted/log_receiver.go
+++ b/input/system/selfhosted/log_receiver.go
@@ -112,7 +112,7 @@ func DiscoverLogLocation(servers []*state.Server, globalCollectionOpts state.Col
 			if strings.HasPrefix(logDirectory, "/") {
 				prefixedLogger.PrintInfo("Found log location, add this to your pganalyze-collector.conf in the [%s] section:\ndb_log_location = %s", server.Config.SectionName, logDirectory)
 			} else {
-				prefixedLogger.PrintInfo("WARNING: Found log location in data directory - please check our setup guide for instructions\n")
+				prefixedLogger.PrintInfo("WARNING: Found relative log location \"%s\" inside data directory - please check our setup guide for instructions\n", logDirectory)
 			}
 		} else { // assume stdout/stderr redirect to logfile, typical with postgresql-common on Ubuntu/Debian
 			prefixedLogger.PrintInfo("Discovering log directory using open files in postmaster (PID %d)...", status.PostmasterPid)


### PR DESCRIPTION
The helper fails on a default AL2 install since the binary is called
postmaster not postgres, and there's no apparent reason not to use the
GUCS directly. This lets us drop the helper subcommand entirely.

Also, do not show a db_log_location if the log directory is inside the
data directory: this is almost certain to cause permissions problems,
and instead we can direct users to address this in our setup guide.
