### PR TITLE
Check whether pg_stat_statements exists in a different schema

### DIFF
--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -131,7 +131,7 @@ func GetStatements(server *state.Server, logger *util.Logger, db *sql.DB, global
 		var e *pq.Error
 		if !usingStatsHelper && errors.As(err, &e) && (e.Code == "42P01" || e.Code == "42883") { // undefined_table / undefined_function
 			var pgssSchema string
-			err = db.QueryRow("SELECT extnamespace::regnamespace::text FROM pg_extension WHERE extname = 'pg_stat_statements'").Scan(&pgssSchema)
+			err = db.QueryRow("SELECT nspname FROM pg_extension pge INNER JOIN pg_namespace pgn ON pge.extnamespace = pgn.oid WHERE pge.extname = 'pg_stat_statements'").Scan(&pgssSchema)
 			if err == nil && pgssSchema != "public" {
 				return nil, nil, nil, fmt.Errorf("pg_stat_statements must be created in schema \"public\"; found in schema \"%s\"", pgssSchema)
 			}


### PR DESCRIPTION
Right now, we require the pg_stat_statements extension to be installed
in the public schema, and try to create it if it does not exist.
However, we only look for it in the public schema, and run the create
with IF NOT EXISTS, which will be a no-op if it does exist in a
different schema. At this point, assuming we created it successfully,
we'll try to query pg_stat_statements again, and get a confusing
"pg_stat_statements does not exist" message.

Instead, check to see if the extension exists in another schema first,
and give a more appropriate error message.
