### PR TITLE
Packages: Remove support for Debian Jessie (no longer supported)

### DIFF
--- a/packages/src/Dockerfile.build.deb-systemd
+++ b/packages/src/Dockerfile.build.deb-systemd
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 ENV GOPATH /go
 ENV GOVERSION 1.16

--- a/packages/test/Makefile
+++ b/packages/test/Makefile
@@ -6,7 +6,7 @@ docker_exec  = docker exec pga-collector-test $(1)
 docker_test  = docker exec pga-collector-test /root/$(1)_test.sh
 docker_clean = docker kill pga-collector-test && docker rm pga-collector-test && docker rmi -f pga-collector-test
 
-DISTROS=centos7 rhel8 fedora29 fedora30 ubuntu-xenial ubuntu-bionic ubuntu-focal debian-jessie debian-stretch debian-buster
+DISTROS=centos7 rhel8 fedora29 fedora30 ubuntu-xenial ubuntu-bionic ubuntu-focal debian-stretch debian-buster
 
 .PHONY: all $(DISTROS)
 


### PR DESCRIPTION
This avoids making the build more complicated, because the upstream Go
binaries are no longer compatible with older GCC releases, such as the
one used on Debian Jessie.