### PR TITLE
Don't use pganalyze query marker for "--test-explain" command

### DIFF
--- a/logs/emit_test_lines.go
+++ b/logs/emit_test_lines.go
@@ -27,7 +27,10 @@ func EmitTestExplain(server *state.Server, globalCollectionOpts state.Collection
 	defer db.Close()
 	// Emit a query that's slow enough to trigger an explain if a log_min_duration is
 	// configured (either through auto_explain or the standard one)
-	_, err = db.Exec(postgres.QueryMarkerSQL + `WITH naptime(value) AS (
+	//
+	// Note that we intentionally don't use the pganalyze collector query marker here,
+	// since we want the EXPLAIN plan to show up in the pganalyze user interface
+	_, err = db.Exec(`WITH naptime(value) AS (
 SELECT
 	COALESCE(pg_catalog.max(setting::float), 0) / 1000 * 1.2
 FROM


### PR DESCRIPTION
The marker means the resulting query gets hidden from the EXPLAIN plan
list, which is what we don't want for this test query - its intentional
that we can see the EXPLAIN plan we're generating for the test.