### PR TITLE
Add curl-able install script to streamline installation across systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,4 @@ jobs:
         make build OUTFILE=pganalyze-collector-linux-amd64
         make test
         make integration_test
+        shellcheck contrib/install.sh

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -177,6 +177,11 @@ else
   fail "unrecognized package kind: $pkg"
 fi
 
+if [ -n "$PGA_API_BASE_URL" ];
+then
+  $maybe_sudo sed -i "/^\[pganalyze\]$/a api_base_url = ${PGA_API_BASE_URL}" /etc/pganalyze-collector.conf
+fi
+
 if [ -n "$PGA_API_KEY" ];
 then
   $maybe_sudo sed -i "s/^#api_key = your_api_key$/api_key = ${PGA_API_KEY}/" /etc/pganalyze-collector.conf

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -88,8 +88,9 @@ if [ "$(id -u)" != "0" ]; then
     fail "not running as root and could not find sudo command"
   fi
 
-  echo "You will be prompted for your password by sudo"
-  # clear any previous sudo permission to avoid inadvertent 
+  echo "You may be prompted for your password by sudo"
+
+  # clear any previous sudo permission to avoid inadvertent confirmation
   $maybe_sudo -k
 fi
 

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+set -e
+
+fail () {
+  >&2 echo "Collector install failed: $1"
+  >&2 echo
+  >&2 echo "Please contact support@pganalyze.com for help and include information about your platform"
+  exit 1
+}
+
+distribution=''
+version=''
+pkg=''
+
+if ! test -r /etc/os-release;
+then
+  fail "cannot read /etc/os-release to determine distribution"
+fi
+
+arch=$(uname -m)
+if [ "$arch" != 'x86_64' ];
+then
+  fail "unsupported architecture: $arch"
+fi
+
+if grep -q '^ID="amzn"$' /etc/os-release && grep -q '^VERSION_ID="2"$' /etc/os-release;
+then
+  # Amazon Linux 2, based on RHEL7
+  pkg=yum
+  distribution=el
+  version=7
+elif grep -q '^ID="rhel"$' /etc/os-release;
+then
+  # RHEL
+  pkg=yum
+  distribution=el
+  version=$(grep VERSION_ID /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
+  if [ "$version" != 7 ] && [ "$version" != 8 ];
+  then
+    fail "unrecognized RHEL version: ${version}"
+  fi
+elif grep -q '^ID=fedora$' /etc/os-release;
+then
+  # Fedora
+  pkg=yum
+  distribution=fedora
+  version=$(grep VERSION_ID /etc/os-release | cut -d= -f2)
+
+  if [ "$version" != 30 ] && [ "$version" != 29 ];
+  then
+    fail "unrecognized Fedora version: ${version}"
+  fi
+elif grep -q '^ID=ubuntu$' /etc/os-release;
+then
+  # Ubuntu
+  pkg=deb
+  distribution=ubuntu
+  version=$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2)
+  if [ "$version" != focal ] && [ "$version" != bionic ] && [ "$version" != xenial ];
+  then
+    fail "unrecognized Ubuntu version: ${version}"
+  fi
+elif grep -q '^ID=debian$' /etc/os-release;
+then
+  # Debian
+  pkg=deb
+  distribution=debian
+  version=$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2)
+  if [ "$version" != buster ] && [ "$version" != stretch ];
+  then
+    fail "unrecognized Debian version: ${version}"
+  fi
+else
+  >&2 cat /etc/os-release
+  fail "unrecognized distribution: ${distribution}"
+fi
+
+# If we're already running as sudo or root, no need to do anything;
+# if we're not, set up sudo for relevant commands
+maybe_sudo=''
+if [ "$(id -u)" != "0" ]; then
+  maybe_sudo=$(which sudo)
+  echo "This script requires superuser access to install packages"
+
+  if [ -z "$maybe_sudo" ];
+  then
+    fail "not running as root and could not find sudo command"
+  fi
+
+  echo "You will be prompted for your password by sudo"
+  # clear any previous sudo permission to avoid inadvertent 
+  $maybe_sudo -k
+fi
+
+if [ "$pkg" = yum ];
+then
+  echo "[pganalyze_collector]
+name=pganalyze_collector
+baseurl=https://packages.pganalyze.com/${distribution}/${version}
+repo_gpgcheck=1
+enabled=1
+gpgkey=https://packages.pganalyze.com/pganalyze_signing_key.asc
+sslverify=1
+sslcacert=/etc/pki/tls/certs/ca-bundle.crt
+metadata_expire=300" | $maybe_sudo tee -a /etc/yum.repos.d/pganalyze_collector.repo
+  $maybe_sudo yum makecache
+  $maybe_sudo yum install pganalyze-collector
+elif [ "$pkg" = deb ];
+then
+  apt_source="deb [arch=amd64] https://packages.pganalyze.com/${distribution}/${version}/ stable main"
+  curl -L https://packages.pganalyze.com/pganalyze_signing_key.asc | $maybe_sudo apt-key add -
+  echo "$apt_source" | $maybe_sudo tee /etc/apt/sources.list.d/pganalyze_collector.list
+  $maybe_sudo apt-get update
+  $maybe_sudo apt-get install pganalyze-collector
+else
+  fail "unrecognized package kind: $pkg"
+fi
+
+# run to validate install
+pganalyze-collector --version
+
+echo "The pganalyze collector has been installed"

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -118,6 +118,11 @@ else
   fail "unrecognized package kind: $pkg"
 fi
 
+if [ -n "$PGA_API_KEY" ];
+then
+  $maybe_sudo sed -i "s/^#api_key = your_api_key$/api_key = ${PGA_API_KEY}/" /etc/pganalyze-collector.conf
+fi
+
 # run to validate install
 pganalyze-collector --version
 

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -3,15 +3,16 @@
 set -e
 
 fail () {
+  >&2 echo
   >&2 echo "Install failed: $1"
   >&2 echo
   >&2 echo "Please contact support@pganalyze.com for help and include information about your platform"
   exit 1
 }
 
+pkg=''
 distribution=''
 version=''
-pkg=''
 
 if ! test -r /etc/os-release;
 then

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -162,6 +162,7 @@ then
   then
     if confirm "The gnupg package is required to verify the collector package signature; install it now?";
     then
+      $maybe_sudo apt-get $apt_opts update <$user_input
       $maybe_sudo apt-get $apt_opts install gnupg <$user_input
     else
       fail "cannot install without gnupg"

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -32,7 +32,7 @@ confirm () {
 
   local confirmation
   # N.B.: default is always yes
-  read -r -n1 -p "$1 [Yn]" confirmation <$user_input
+  read -r -n1 -p "$1 [Y/n]" confirmation <$user_input
   [ -z "$confirmation" ] || [[ "$confirmation" =~ [Yy] ]]
 }
 

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -3,7 +3,7 @@
 set -e
 
 fail () {
-  >&2 echo "Collector install failed: $1"
+  >&2 echo "Install failed: $1"
   >&2 echo
   >&2 echo "Please contact support@pganalyze.com for help and include information about your platform"
   exit 1

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -159,10 +159,11 @@ then
   $maybe_sudo sed -i "s/^#api_key = your_api_key$/api_key = ${PGA_API_KEY}/" /etc/pganalyze-collector.conf
 fi
 
-# run to validate install
+echo "Checking install by running 'pganalyze-collector --version'"
 pganalyze-collector --version
+echo
 
-echo "The pganalyze collector has been installed"
+echo "The pganalyze collector was installed successfully"
 echo
 
 if [ -n "$PGA_GUIDED_SETUP" ];

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -38,7 +38,7 @@ then
   version=$(grep VERSION_ID /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
   if [ "$version" != 7 ] && [ "$version" != 8 ];
   then
-    read -r -n1 -p "Unsupported RHEL version; try RHEL8 package? [Yn]" confirm_rhel8 </dev/tty
+    read -r -n1 -p "Unsupported RHEL version; try RHEL8 package? [Y/n]" confirm_rhel8 </dev/tty
     if [ -z "$confirm_rhel8" ] || [[ "$confirm_rhel8" =~ [yY] ]];
     then
       version=8
@@ -55,7 +55,7 @@ then
 
   if [ "$version" != 30 ] && [ "$version" != 29 ];
   then
-    read -r -n1 -p "Unsupported Fedora version; try Fedora 30 package? [Yn]" confirm_fedora30 </dev/tty
+    read -r -n1 -p "Unsupported Fedora version; try Fedora 30 package? [Y/n]" confirm_fedora30 </dev/tty
     if [ -z "$confirm_fedora30" ] || [[ "$confirm_fedora30" =~ [yY] ]];
     then
       version=30
@@ -71,7 +71,7 @@ then
   version=$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2)
   if [ "$version" != focal ] && [ "$version" != bionic ] && [ "$version" != xenial ];
   then
-    read -r -n1 -p "Unsupported Ubuntu version; try Ubuntu Focal (20.04) package? [Yn]" confirm_ubuntu_focal </dev/tty
+    read -r -n1 -p "Unsupported Ubuntu version; try Ubuntu Focal (20.04) package? [Y/n]" confirm_ubuntu_focal </dev/tty
     if [ -z "$confirm_ubuntu_focal" ] || [[ "$confirm_ubuntu_focal" =~ [yY] ]];
     then
       version=focal
@@ -87,7 +87,7 @@ then
   version=$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2)
   if [ "$version" != buster ] && [ "$version" != stretch ];
   then
-    read -r -n1 -p "Unsupported Debian version; try Debian Buster (10) package? [Yn]" confirm_debian_buster </dev/tty
+    read -r -n1 -p "Unsupported Debian version; try Debian Buster (10) package? [Y/n]" confirm_debian_buster </dev/tty
     if [ -z "$confirm_debian_buster" ] || [[ "$confirm_debian_buster" =~ [yY] ]];
     then
       version=buster
@@ -137,7 +137,7 @@ then
   # it before trying to invoke it if necessary
   if ! dpkg --verify gnupg 2>/dev/null && ! dpkg --verify gnupg1 2>/dev/null && ! dpkg --verify gnupg2 2>/dev/null;
   then
-    read -r -n1 -p "The gnupg package is required to verify the collector package signature; install it now? [Yn]" confirm_gnupg </dev/tty
+    read -r -n1 -p "The gnupg package is required to verify the collector package signature; install it now? [Y/n]" confirm_gnupg </dev/tty
     if [ -z "$confirm_gnupg" ] || [[ "$confirm_gnupg" =~ [yY] ]];
     then
       $maybe_sudo apt-get install gnupg </dev/tty

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -105,15 +105,15 @@ gpgkey=https://packages.pganalyze.com/pganalyze_signing_key.asc
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 metadata_expire=300" | $maybe_sudo tee -a /etc/yum.repos.d/pganalyze_collector.repo
-  $maybe_sudo yum makecache < /dev/tty
-  $maybe_sudo yum install pganalyze-collector < /dev/tty
+  $maybe_sudo yum makecache </dev/tty
+  $maybe_sudo yum install pganalyze-collector </dev/tty
 elif [ "$pkg" = deb ];
 then
   apt_source="deb [arch=amd64] https://packages.pganalyze.com/${distribution}/${version}/ stable main"
   curl -L https://packages.pganalyze.com/pganalyze_signing_key.asc | $maybe_sudo apt-key add -
   echo "$apt_source" | $maybe_sudo tee /etc/apt/sources.list.d/pganalyze_collector.list
-  $maybe_sudo apt-get update < /dev/tty
-  $maybe_sudo apt-get install pganalyze-collector < /dev/tty
+  $maybe_sudo apt-get update </dev/tty
+  $maybe_sudo apt-get install pganalyze-collector </dev/tty
 else
   fail "unrecognized package kind: $pkg"
 fi

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -105,15 +105,15 @@ gpgkey=https://packages.pganalyze.com/pganalyze_signing_key.asc
 sslverify=1
 sslcacert=/etc/pki/tls/certs/ca-bundle.crt
 metadata_expire=300" | $maybe_sudo tee -a /etc/yum.repos.d/pganalyze_collector.repo
-  $maybe_sudo yum makecache
-  $maybe_sudo yum install pganalyze-collector
+  $maybe_sudo yum makecache < /dev/tty
+  $maybe_sudo yum install pganalyze-collector < /dev/tty
 elif [ "$pkg" = deb ];
 then
   apt_source="deb [arch=amd64] https://packages.pganalyze.com/${distribution}/${version}/ stable main"
   curl -L https://packages.pganalyze.com/pganalyze_signing_key.asc | $maybe_sudo apt-key add -
   echo "$apt_source" | $maybe_sudo tee /etc/apt/sources.list.d/pganalyze_collector.list
-  $maybe_sudo apt-get update
-  $maybe_sudo apt-get install pganalyze-collector
+  $maybe_sudo apt-get update < /dev/tty
+  $maybe_sudo apt-get install pganalyze-collector < /dev/tty
 else
   fail "unrecognized package kind: $pkg"
 fi

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -127,3 +127,11 @@ fi
 pganalyze-collector --version
 
 echo "The pganalyze collector has been installed"
+echo
+
+if [ -n "$PGA_GUIDED_SETUP" ];
+then
+  $maybe_sudo pganalyze-collector-setup </dev/tty
+else
+  echo "Please continue with setup instructions in-app or at https://pganalyze.com/docs/install"
+fi

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -80,7 +80,7 @@ fi
 # if we're not, set up sudo for relevant commands
 maybe_sudo=''
 if [ "$(id -u)" != "0" ]; then
-  maybe_sudo=$(which sudo)
+  maybe_sudo=$(command -v sudo)
   echo "This script requires superuser access to install packages"
 
   if [ -z "$maybe_sudo" ];

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -38,7 +38,13 @@ then
   version=$(grep VERSION_ID /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
   if [ "$version" != 7 ] && [ "$version" != 8 ];
   then
-    fail "unrecognized RHEL version: ${version}"
+    read -r -n1 -p "Unsupported RHEL version; try RHEL8 package? [Yn]" confirm_rhel8 </dev/tty
+    if [ -z "$confirm_rhel8" ] || [[ "$confirm_rhel8" =~ [yY] ]];
+    then
+      version=8
+    else
+      fail "unrecognized RHEL version: ${version}"
+    fi
   fi
 elif grep -q '^ID=fedora$' /etc/os-release;
 then
@@ -49,7 +55,13 @@ then
 
   if [ "$version" != 30 ] && [ "$version" != 29 ];
   then
-    fail "unrecognized Fedora version: ${version}"
+    read -r -n1 -p "Unsupported Fedora version; try Fedora 30 package? [Yn]" confirm_fedora30 </dev/tty
+    if [ -z "$confirm_fedora30" ] || [[ "$confirm_fedora30" =~ [yY] ]];
+    then
+      version=30
+    else
+      fail "unrecognized Fedora version: ${version}"
+    fi
   fi
 elif grep -q '^ID=ubuntu$' /etc/os-release;
 then
@@ -59,7 +71,13 @@ then
   version=$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2)
   if [ "$version" != focal ] && [ "$version" != bionic ] && [ "$version" != xenial ];
   then
-    fail "unrecognized Ubuntu version: ${version}"
+    read -r -n1 -p "Unsupported Ubuntu version; try Ubuntu Focal (20.04) package? [Yn]" confirm_ubuntu_focal </dev/tty
+    if [ -z "$confirm_ubuntu_focal" ] || [[ "$confirm_ubuntu_focal" =~ [yY] ]];
+    then
+      version=focal
+    else
+      fail "unrecognized Ubuntu version: ${version}"
+    fi
   fi
 elif grep -q '^ID=debian$' /etc/os-release;
 then
@@ -69,7 +87,13 @@ then
   version=$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2)
   if [ "$version" != buster ] && [ "$version" != stretch ];
   then
-    fail "unrecognized Debian version: ${version}"
+    read -r -n1 -p "Unsupported Debian version; try Debian Buster (10) package? [Yn]" confirm_debian_buster </dev/tty
+    if [ -z "$confirm_debian_buster" ] || [[ "$confirm_debian_buster" =~ [yY] ]];
+    then
+      version=buster
+    else
+      fail "unrecognized Debian version: ${version}"
+    fi
   fi
 else
   >&2 cat /etc/os-release

--- a/integration_test/Makefile
+++ b/integration_test/Makefile
@@ -10,9 +10,9 @@ DOCKER_RUN_CMD = docker run --name pganalyze-collector-test \
   -d \
   pganalyze-collector-test
 
-.PHONY: pg93 pg94 pg95 pg96 pg10 pg11 pg12 pg13 guided-setup
+.PHONY: pg93 pg94 pg95 pg96 pg10 pg11 pg12 pg13 guided-setup installer
 
-all: pg93 pg94 pg95 pg96 pg10 pg11 pg12 pg13 guided-setup
+all: pg93 pg94 pg95 pg96 pg10 pg11 pg12 pg13 guided-setup installer
 
 pg93:
 	docker build -f Dockerfile.test-pg93 $(DOCKER_BUILD_OPTS)
@@ -230,3 +230,18 @@ guided-setup:
 		exit 1; \
 	fi
 	diff -Nau guided-setup.snapshot-subset.json.expected guided-setup.snapshot-subset.json.out && echo 'success'
+
+installer:
+	docker build -f Dockerfile.test-guided-setup $(DOCKER_BUILD_OPTS)
+	$(DOCKER_RUN_CMD)
+	sleep 10
+
+	docker exec --privileged pganalyze-collector-test env PGA_INSTALL_NONINTERACTIVE=true PGA_API_KEY=abc123 bash -c '</collector/contrib/install.sh bash' >install.out
+	docker rm -f pganalyze-collector-test
+	docker rmi pganalyze-collector-test
+
+	if ! grep -q 'The pganalyze collector was installed successfully' install.out; then \
+		echo "expected installer to install latest published package; test failed:"; \
+		cat install.out; \
+		exit 1; \
+	fi

--- a/packages/repo/Makefile
+++ b/packages/repo/Makefile
@@ -5,7 +5,7 @@ REPO_DIR=$(TMP_DIR)/repo
 
 docker_clean = docker kill pga-collector-repo && docker rm pga-collector-repo && docker rmi -f pga-collector-repo
 
-.PHONY: update_rpm_repo push_packages_release push_packages_latest copy_install_script
+.PHONY: all download_repo upload_repo copy_install_script update_rpm update_deb
 
 all: download_repo update_rpm update_deb copy_install_script upload_repo
 

--- a/packages/repo/Makefile
+++ b/packages/repo/Makefile
@@ -5,9 +5,9 @@ REPO_DIR=$(TMP_DIR)/repo
 
 docker_clean = docker kill pga-collector-repo && docker rm pga-collector-repo && docker rmi -f pga-collector-repo
 
-.PHONY: update_rpm_repo push_packages_release push_packages_latest
+.PHONY: update_rpm_repo push_packages_release push_packages_latest copy_install_script
 
-all: download_repo update_rpm update_deb upload_repo
+all: download_repo update_rpm update_deb copy_install_script upload_repo
 
 download_repo:
 	rm -rf $(REPO_DIR)
@@ -16,6 +16,9 @@ download_repo:
 
 upload_repo:
 	aws s3 sync --acl public-read --cache-control no-cache $(REPO_DIR) s3://packages.pganalyze.com/
+
+copy_install_script:
+  cp ../../contrib/install.sh $(REPO_DIR)/collector-install.sh
 
 update_rpm:
 	cp $(TMP_DIR)/$(RPM_SYSTEMD_PACKAGE) .


### PR DESCRIPTION
Add a one-step install script for the collector. This lets us simplify package installation instructions to something like

```
curl https://packages.pganalyze.com/collector-install.sh | bash
```

This uses sudo (prompting if necessary) if not already running as root and will install the correct package based on system type. If an unrecognized version of a supported distribution is detected, we prompt whether the user would like to install the latest available package for that distribution instead.

The script supports several environment variables:

 - `PGA_INSTALL_NONINTERACTIVE`: if non-empty, do not prompt for user input and assume `y` to all prompts
 - `PGA_API_BASEURL`: if non-empty, api_base_url to add to collector config as part of install
 - `PGA_API_KEY`: if non-empty, pganalyze API key to write to collector config file as part of install
 - `PGA_GUIDED_SETUP`: if non-empty, run guided setup immediately after install (if `PGA_INSTALL_NONINTERACTIVE` is also set, guided setup is non-interactive and uses recommended settings)
   - `DB_NAME`: if the above `PGA_GUIDED_SETUP` is set, `db_name` to write to collector config file as part of install (ignored otherwise); if this is not set, `db_name` defaults to 'postgres'

These can be passed to the script like this:

```
curl https://packages.pganalyze.com/collector-install.sh | env VAR1=foo VAR2=bar bash
```

TODO:
 - [x] add shellcheck linting to CI
 - [x] actually run through script in CI?
 - [x] ~prompt for confirmation if passwordless sudo is enabled~
   - on second thought, this is not necessary: we run `sudo -k` to clear previous authorization, but an additional prompt is not necessary
 - [x] link to install instructions and/or run guided setup after installation
 - [x] determine deployment process
   - we'll put this in packages.pganalyze.com
 - [x] test Ubuntu install works
 - [x] fix Debian install [1]
 - [x] fix AL2 install [2]
 - [x] fix Fedora install [3]
 - [x] fix RHEL install [4]
 - [x] manually retest install on supported distributions
   - [x] AL2
   - [x] RHEL8
   - [x] Fedora 33 (falls back to Fedora 30 package)
   - [x] Ubuntu Focal (20.04)
   - [x] Debian Buster (10) (requires gnupg install to be confirmed)
 - [x] ~copy and validate package fingerprints?~
   - on second thought, this is tricky to do automatically, and it's probably better to have fingerprint verification happen in a system more operationally isolated from the install packages (i.e., have the user do it based on fingerprints listed in the documentation)

[1]: currently this fails on `apt-key add`:
```
$ curl https://raw.githubusercontent.com/pganalyze/collector/f5cede1af633f8b35a843b2644564ecd5d24a704/contrib/install.sh | bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3318  100  3318    0     0   140k      0 --:--:-- --:--:-- --:--:--  140k
This script requires superuser access to install packages
You will be prompted for your password by sudo
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1625  100  1625    0     0  16752      0 --:--:-- --:--:-- --:--:-- 16752
E: gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation
```

[2]: current failure (the confirmation prompt is ignored so script fails):
```
Retrieving key from https://packages.pganalyze.com/pganalyze_signing_key.asc
Importing GPG key 0xA2B5F2F9:
 Userid     : "pganalyze <team@pganalyze.com>"
 Fingerprint: c09b 2cab 0db3 78f6 e7fd 93f1 0e6d ec71 a2b5 f2f9
 From       : https://packages.pganalyze.com/pganalyze_signing_key.asc
pganalyze_collector/signature                                                                                                                                                       | 2.9 kB  00:00:00 !!! 
https://packages.pganalyze.com/el/7/repodata/repomd.xml: [Errno -1] Gpg Keys not imported, cannot verify repomd.xml for repo pganalyze_collector
Trying other mirror.


 One of the configured repositories failed (pganalyze_collector),
 and yum doesn't have enough cached data to continue. At this point the only
 safe thing yum can do is fail. There are a few ways to work "fix" this:

     1. Contact the upstream for the repository and get them to fix the problem.

     2. Reconfigure the baseurl/etc. for the repository, to point to a working
        upstream. This is most often useful if you are using a newer
        distribution release than is supported by the repository (and the
        packages for the previous distribution release still work).

     3. Run the command with the repository temporarily disabled
            yum --disablerepo=pganalyze_collector ...

     4. Disable the repository permanently, so yum won't use it by default. Yum
        will then just ignore the repository until you permanently enable it
        again or use --enablerepo for temporary usage:

            yum-config-manager --disable pganalyze_collector
        or
            subscription-manager repos --disable=pganalyze_collector

     5. Configure the failing repository to be skipped, if it is unavailable.
        Note that yum will try to contact the repo. when it runs most commands,
        so will have to try and fail each time (and thus. yum will be be much
        slower). If it is a very temporary problem though, this is often a nice
        compromise:

            yum-config-manager --save --setopt=pganalyze_collector.skip_if_unavailable=true

failure: repodata/repomd.xml from pganalyze_collector: [Errno 256] No more mirrors to try.
https://packages.pganalyze.com/el/7/repodata/repomd.xml: [Errno -1] Gpg Keys not imported, cannot verify repomd.xml for repo pganalyze_collector
```

[3]: current failure (just need to configure package?)
```
$ curl https://raw.githubusercontent.com/pganalyze/collector/f5cede1af633f8b35a843b2644564ecd5d24a704/contrib/install.sh | bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3318  100  3318    0     0  36461      0 --:--:-- --:--:-- --:--:-- 36866
Collector install failed: unrecognized Fedora version: 33

Please contact support@pganalyze.com for help and include information about your platform
```

[4]: current failure (similar to AL2 failure)
```
Importing GPG key 0xA2B5F2F9:
 Userid     : "pganalyze <team@pganalyze.com>"
 Fingerprint: C09B 2CAB 0DB3 78F6 E7FD 93F1 0E6D EC71 A2B5 F2F9
 From       : https://packages.pganalyze.com/pganalyze_signing_key.asc
Is this ok [y/N]: pganalyze_collector                                                                    [   ===                                                                           ] ---  B/s |   0pganalyze_collector                                                                                                                                                        3.3 kB/s | 836  B     00:00    
Error: Failed to download metadata for repo 'pganalyze_collector': repomd.xml GPG signature verification error: Bad GPG signature
```