### PR TITLE
Use curl -s when fetching signing keys for debs

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -169,7 +169,7 @@ then
     fi
   fi
   apt_source="deb [arch=amd64] https://packages.pganalyze.com/${distribution}/${version}/ stable main"
-  curl -L https://packages.pganalyze.com/pganalyze_signing_key.asc | $maybe_sudo apt-key add -
+  curl -s -L https://packages.pganalyze.com/pganalyze_signing_key.asc | $maybe_sudo apt-key add -
   echo "$apt_source" | $maybe_sudo tee /etc/apt/sources.list.d/pganalyze_collector.list
   $maybe_sudo apt-get $apt_opts update <$user_input
   $maybe_sudo apt-get $apt_opts install pganalyze-collector <$user_input


### PR DESCRIPTION
Right now, we allow curl output to go to stdout, which means the
sudo prompt may be sandwiched between two different sets of curl output:

```
$ curl https://packages.pganalyze.com/collector-install.sh | env PGA_API_KEY=... PGA_GUIDED_SETUP=true bash
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5652  100  5652    0     0   8499      0 --:--:-- --:--:-- --:--:--  8512
This script requires superuser access to install packages
You may be prompted for your password by sudo
[sudo] password for maciek:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1625  100  1625    0     0   4737      0 --:--:-- --:--:-- --:--:--  4723
```

This is obviously pretty confusing. We don't really need the output
from the curl in the script, so silence it.
