### PR TITLE
Docker builds: Increase stack size to 2MB to prevent rare crashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR $CODE_DIR
 RUN apk add --no-cache --virtual .build-deps make curl libc-dev gcc go git tar \
   && apk add --no-cache ca-certificates \
   && curl -o /usr/local/bin/gosu -sSL "https://github.com/tianon/gosu/releases/download/1.6/gosu-amd64" \
-  && make build_dist OUTFILE=$HOME_DIR/collector \
+  && make build_dist_alpine OUTFILE=$HOME_DIR/collector \
   && rm -rf $GOPATH \
 	&& apk del --purge .build-deps
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,13 @@ build_dist:
 	make -C helper OUTFILE=../pganalyze-collector-helper
 	make -C setup OUTFILE=../pganalyze-collector-setup
 
+build_dist_alpine:
+	# Increase stack size from Alpine's default of 80kb to 2mb - otherwise we see
+	# crashes on very complex queries, pg_query expects at least 100kb stack size
+	go build -o ${OUTFILE} -ldflags '-extldflags "-Wl,-z,stack-size=0x200000"'
+	make -C helper OUTFILE=../pganalyze-collector-helper
+	make -C setup OUTFILE=../pganalyze-collector-setup
+
 vendor:
 	GO111MODULE=on go mod tidy
 	# You might need to run "go get -u github.com/goware/modvendor"


### PR DESCRIPTION
Alpine has a very small stack size by default (80kb) which is less than
the default that Postgres expects (100kb). Since there is no good reason
to reduce it to such a small amount, increase to usually common Linux
default of 2MB stack size.

This would have surfaced as a hard crash of the Docker container with
error code 137 or 139, easily confused with out of memory errors, but
clearly distinct from it.