### PR TITLE
RDS logs: Support long log events, handle errors better

### DIFF
--- a/input/logs.go
+++ b/input/logs.go
@@ -14,7 +14,10 @@ func DownloadLogs(server *state.Server, prevLogState state.PersistedLogState, co
 	var querySamples []state.PostgresQuerySample
 
 	tls.CollectedAt = time.Now()
-	pls, tls.LogFiles, querySamples = system.DownloadLogFiles(prevLogState, server.Config, logger)
+	pls, tls.LogFiles, querySamples, err = system.DownloadLogFiles(prevLogState, server.Config, logger)
+	if err != nil {
+		return
+	}
 
 	if server.Config.EnableLogExplain {
 		tls.QuerySamples = postgres.RunExplain(server, querySamples, collectionOpts, logger)

--- a/input/system/system.go
+++ b/input/system/system.go
@@ -11,9 +11,12 @@ import (
 )
 
 // DownloadLogFiles - Downloads all new log files for the remote system and returns them
-func DownloadLogFiles(prevState state.PersistedLogState, config config.ServerConfig, logger *util.Logger) (psl state.PersistedLogState, files []state.LogFile, querySamples []state.PostgresQuerySample) {
+func DownloadLogFiles(prevState state.PersistedLogState, config config.ServerConfig, logger *util.Logger) (psl state.PersistedLogState, files []state.LogFile, querySamples []state.PostgresQuerySample, err error) {
 	if config.SystemType == "amazon_rds" {
-		psl, files, querySamples = rds.DownloadLogFiles(prevState, config, logger)
+		psl, files, querySamples, err = rds.DownloadLogFiles(prevState, config, logger)
+		if err != nil {
+			return
+		}
 	} else {
 		psl = prevState
 	}

--- a/state/logs.go
+++ b/state/logs.go
@@ -30,8 +30,11 @@ type TransientLogState struct {
 }
 
 type PersistedLogState struct {
-	AwsFilename string
-	AwsMarker   string
+	// Markers for pagination of RDS log files
+	//
+	// We only remember markers for files that have received recent writes,
+	// all other markers are discarded
+	AwsMarkers map[string]string
 }
 
 // LogFile - Log file that we are uploading for reference in log line metadata

--- a/state/state.go
+++ b/state/state.go
@@ -147,7 +147,7 @@ type DiffState struct {
 }
 
 // StateOnDiskFormatVersion - Increment this when an old state preserved to disk should be ignored
-const StateOnDiskFormatVersion = 5
+const StateOnDiskFormatVersion = 6
 
 type StateOnDisk struct {
 	FormatVersion uint


### PR DESCRIPTION
This changes the RDS log download logic to only analyze log lines after
they have been downloaded and stitched. To prevent running out of
memory when the collector first starts (where the marker is not set yet)
we now explicitly restrict to the last 10 megabytes in the file.

In passing improve the error handling to return errors to the caller
instead of calling the logger directly.

With this change very long EXPLAIN plans can be successfully parsed,
such as for this query, which causes a plan to exceed 10k lines with
full auto_explain configuration:

```
SELECT 1 FROM pg_sleep(5) UNION SELECT 1 --- repeat "UNION SELECT 1" 414 more times
```