### PR TITLE
Redact primary_conninfo setting if present and readable

### DIFF
--- a/input/postgres/settings.go
+++ b/input/postgres/settings.go
@@ -9,7 +9,10 @@ import (
 
 const settingsSQL string = `
 SELECT name,
-			 setting AS current_value,
+			 CASE name
+				 WHEN 'primary_conninfo' THEN regexp_replace(setting, '.', 'X', 'g')
+				 ELSE setting
+			 END AS current_value,
 			 unit,
 			 boot_val AS boot_value,
 			 reset_val AS reset_value,


### PR DESCRIPTION
This can contain sensitive information (full connection string to the
primary), and pganalyze does not do anything with it right now. In the
future, we may partially redact this and use primary hostname
information, but for now, just fully redact it.
