### PR TITLE
Docker: Use Docker's USER command to set user, to support running as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,11 @@ WORKDIR $CODE_DIR
 
 # We run this all in one layer to reduce the resulting image size
 RUN apk add --no-cache --virtual .build-deps make curl libc-dev gcc go git tar \
-  && apk add --no-cache ca-certificates \
-  && curl -o /usr/local/bin/gosu -sSL "https://github.com/tianon/gosu/releases/download/1.6/gosu-amd64" \
+  && apk add --no-cache ca-certificates setpriv \
   && make build_dist_alpine OUTFILE=$HOME_DIR/collector \
   && rm -rf $GOPATH \
 	&& apk del --purge .build-deps
 
-RUN chmod +x /usr/local/bin/gosu
 RUN chown pganalyze:pganalyze $HOME_DIR/collector
 
 RUN mkdir /state
@@ -29,6 +27,8 @@ COPY contrib/sslrootcert/rds-ca-2015-root.pem /usr/share/pganalyze-collector/ssl
 COPY contrib/sslrootcert/rds-ca-2019-root.pem /usr/share/pganalyze-collector/sslrootcert/
 COPY contrib/docker-entrypoint.sh $HOME_DIR
 RUN chmod +x $HOME_DIR/docker-entrypoint.sh
+
+USER pganalyze
 
 ENTRYPOINT ["/home/pganalyze/docker-entrypoint.sh"]
 

--- a/contrib/docker-entrypoint.sh
+++ b/contrib/docker-entrypoint.sh
@@ -2,12 +2,17 @@
 
 set -e
 
+CMD_PREFIX=exec
+if [ $(id -u) = 0 ]; then
+  CMD_PREFIX="exec setpriv --reuid=pganalyze --regid=pganalyze --inh-caps=-all --clear-groups"
+fi
+
 if [ "$1" = 'test' ]; then
-  exec /usr/local/bin/gosu pganalyze /home/pganalyze/collector --test --no-log-timestamps
+  eval $CMD_PREFIX /home/pganalyze/collector --test --no-log-timestamps
 fi
 
 if [ "$1" = 'collector' ]; then
-  exec /usr/local/bin/gosu pganalyze /home/pganalyze/collector --statefile=/state/pganalyze-collector.state --no-log-timestamps
+  eval $CMD_PREFIX /home/pganalyze/collector --statefile=/state/pganalyze-collector.state --no-log-timestamps
 fi
 
-exec /usr/local/bin/gosu pganalyze "$@"
+eval $CMD_PREFIX "$@"


### PR DESCRIPTION
This enables the collector container to run in environments that require the
whole container to run as a non-root user, which previously was not the case.

For compatibility reasons the container can still be run as root explicitly,
in which case the setpriv command is used to drop privileges. setpriv replaces
gosu since its available for installation in most distributions directly, and
fulfills the same purpose here.

---

**Docker tag:** ```docker pull quay.io/pganalyze/collector:hotfix-docker-user```