### PR TITLE
Selfhosted: Support running log discovery with non-localhost db_host settings

### DIFF
--- a/input/system/selfhosted/log_receiver.go
+++ b/input/system/selfhosted/log_receiver.go
@@ -65,8 +65,7 @@ func DiscoverLogLocation(servers []*state.Server, globalCollectionOpts state.Col
 		prefixedLogger := logger.WithPrefix(server.Config.SectionName)
 
 		if server.Config.DbHost != "localhost" && server.Config.DbHost != "127.0.0.1" {
-			prefixedLogger.PrintError("ERROR - Detected remote server - Log Insights requires the collector to run on the database server directly for self-hosted systems")
-			continue
+			prefixedLogger.PrintWarning("WARNING - Database hostname is not localhost - Log Insights requires the collector to run on the database server directly for self-hosted systems")
 		}
 
 		logDestination, err := getPostgresSetting("log_destination", server, globalCollectionOpts, prefixedLogger)


### PR DESCRIPTION
We still output a warning in this case, but there are legitimate use cases
where someone uses a different local IP address than 127.0.0.1 and wants
to discover the log directory.