### PR TITLE
Update URLs for Go binary downloads in integration_test/packages

### DIFF
--- a/integration_test/Dockerfile.test-guided-setup
+++ b/integration_test/Dockerfile.test-guided-setup
@@ -17,7 +17,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-amd64.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-pg10
+++ b/integration_test/Dockerfile.test-pg10
@@ -8,7 +8,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-amd64.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-pg11
+++ b/integration_test/Dockerfile.test-pg11
@@ -8,7 +8,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-amd64.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-pg12
+++ b/integration_test/Dockerfile.test-pg12
@@ -8,7 +8,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-amd64.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-pg13
+++ b/integration_test/Dockerfile.test-pg13
@@ -8,7 +8,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-amd64.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-pg93
+++ b/integration_test/Dockerfile.test-pg93
@@ -8,7 +8,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-amd64.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-pg94
+++ b/integration_test/Dockerfile.test-pg94
@@ -8,7 +8,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-amd64.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-pg95
+++ b/integration_test/Dockerfile.test-pg95
@@ -8,7 +8,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-amd64.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-pg96
+++ b/integration_test/Dockerfile.test-pg96
@@ -8,7 +8,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-amd64.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/packages/src/Dockerfile.build.deb-systemd
+++ b/packages/src/Dockerfile.build.deb-systemd
@@ -17,7 +17,7 @@ RUN gem install git -v 1.7.0 # Last release supporting Ruby 1.9
 RUN gem install fpm -v 1.11.0 # 1.12.0 has a bug https://github.com/jordansissel/fpm/issues/1749
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-amd64.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build arguments

--- a/packages/src/Dockerfile.build.rpm-systemd
+++ b/packages/src/Dockerfile.build.rpm-systemd
@@ -16,7 +16,7 @@ RUN gem install git -v 1.7.0 # Last release supporting Ruby 1.9
 RUN gem install fpm -v 1.11.0 # 1.12.0 has a bug https://github.com/jordansissel/fpm/issues/1749 (match RPM to DEB build)
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://storage.googleapis.com/golang/go${GOVERSION}.linux-amd64.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-amd64.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build arguments


### PR DESCRIPTION
Looks like upstream has stopped supporting the storage.googleapis.com
URLs, lets use the URL of the official download page instead.