### PR TITLE
Output transform: Correctly report index for replication statistics

### DIFF
--- a/output/transform/postgres_replication.go
+++ b/output/transform/postgres_replication.go
@@ -59,7 +59,8 @@ func transformPostgresReplication(s snapshot.FullSnapshot, transientState state.
 		s.Replication.StandbyInformations = append(s.Replication.StandbyInformations, info)
 
 		stats := snapshot.StandbyStatistic{
-			State: standby.State,
+			StandbyIdx: idx,
+			State:      standby.State,
 		}
 		if standby.SentLocation.Valid {
 			stats.SentLocation = standby.SentLocation.String


### PR DESCRIPTION
This was previously not setting the StandbyIdx on the statistics values
for replication followers, causing all statistics to incorrectly be
associated to the first follower (since 0 is the default for the field).