### PR TITLE
Add support for CentOS to install script

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -57,19 +57,19 @@ then
   pkg=yum
   distribution=el
   version=7
-elif grep -q '^ID="rhel"$' /etc/os-release;
+elif grep -q '^ID="\(rhel\|centos\)"$' /etc/os-release;
 then
-  # RHEL
+  # RHEL and CentOS
   pkg=yum
   distribution=el
   version=$(grep VERSION_ID /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
   if [ "$version" != 7 ] && [ "$version" != 8 ];
   then
-    if confirm "Unsupported RHEL version; try RHEL8 package?";
+    if confirm "Unsupported RHEL or CentOS version; try RHEL8 package?";
     then
       version=8
     else
-      fail "unrecognized RHEL version: ${version}"
+      fail "unrecognized RHEL or CentOS version: ${version}"
     fi
   fi
 elif grep -q '^ID=fedora$' /etc/os-release;


### PR DESCRIPTION
Assume we can treat it exactly like RHEL and install those packages.

Tried copying the script to a CentOS 7 instance, where the problem was
originally reported, and the collector installs fine with these
changes.