### PR TITLE
Fix citus relation stats sql query typo

### DIFF
--- a/input/postgres/relation_stats_ext.go
+++ b/input/postgres/relation_stats_ext.go
@@ -11,7 +11,7 @@ const citusRelationSizeSQL = `
 SELECT logicalrelid::oid,
        pg_catalog.citus_table_size(logicalrelid)
 	FROM pg_catalog.pg_dist_partition dp
-			 INNER JOIN pg_catalog.pg_class c ON (dp.logicalrelid::oid == c.oid)
+			 INNER JOIN pg_catalog.pg_class c ON (dp.logicalrelid::oid = c.oid)
 			 INNER JOIN pg_catalog.pg_namespace n ON (c.relnamespace = n.oid)
  WHERE ($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)
 `


### PR DESCRIPTION
This typo was causing failure for pganalyze table stats when used on DBs with citus extension enabled.
New release would be appreciated with this fix in, we can't see any stats in pganalyze due to this issue.