### PR TITLE
Vendor protoc to keep the version consistent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up protoc
       uses: arduino/setup-protoc@v1.1.2
       with:
-        version: 3.x
+        version: 3.14.0
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up protoc
       uses: arduino/setup-protoc@v1.1.2
       with:
-        version: 3.x
+        version: 3.14.0
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ integration_test/*.out
 coverage.out
 bin/
 .idea/
+protoc/

--- a/Makefile
+++ b/Makefile
@@ -46,11 +46,16 @@ docker_latest:
 	docker push quay.io/pganalyze/collector:latest
 
 output/pganalyze_collector/snapshot.pb.go: $(PROTOBUF_FILES)
+ifdef PROTOC_VERSION
 	mkdir -p $(PWD)/bin
 	GOBIN=$(PWD)/bin go install github.com/golang/protobuf/protoc-gen-go
 	protoc --go_out=Mgoogle/protobuf/timestamp.proto=github.com/golang/protobuf/ptypes/timestamp:output/pganalyze_collector -I protobuf $(PROTOBUF_FILES)
+else
+	@echo 'Warning: protoc not found, skipping protocol buffer regeneration (to install protoc check Makefile instructions in install_protoc step)'
+endif
 
 install_protoc:
+ifdef PROTOC_VERSION
 ifeq (,$(findstring $(PROTOC_VERSION_NEEDED), $(PROTOC_VERSION)))
 	@echo "⚠️  protoc version needed: $(PROTOC_VERSION_NEEDED) vs $(PROTOC_VERSION) installed"
 	@echo "ℹ️  Please download the correct protobuf binary for your OS from https://github.com/protocolbuffers/protobuf/releases/tag/v${PROTOC_VERSION_NEEDED}"
@@ -58,4 +63,5 @@ ifeq (,$(findstring $(PROTOC_VERSION_NEEDED), $(PROTOC_VERSION)))
 	@echo "ℹ️  Copy the unzipped folder into this project, and rename it to \"protoc\""
 	@echo "ℹ️  If this is macOS, you will need to try running the binary yourself, then go to Security & Privacy to explicitly allow it."
 	exit 1
+endif
 endif


### PR DESCRIPTION
Since there isn't an easy way to keep us all on the same version of protobuf/protoc, I wrote a semi-automated script to do that for us.

Here's what you see when there's a version mismatch:

>⚠️  protoc version needed: 3.14.0 vs none installed
>ℹ️  Please download the correct protobuf binary for your OS from https://github.com/protocolbuffers/protobuf/releases/tag/v3.14.0
>ℹ️  Note the download's name will look like this: protoc-3.14.0-osx-x86_64.zip
>ℹ️  Copy the unzipped folder into this project, and rename it to "protoc"
>ℹ️  If this is macOS, you will need to try running the binary yourself, then go to Security & Privacy to explicitly allow it.