### PR TITLE
Vacuum activity: Correctly handle output transform of duplicate tables

### DIFF
--- a/output/transform/activity.go
+++ b/output/transform/activity.go
@@ -60,13 +60,7 @@ func ActivityStateToCompactActivitySnapshot(server *state.Server, activityState 
 
 		vacuumInfo.DatabaseIdx, r.DatabaseReferences = upsertDatabaseReference(r.DatabaseReferences, vacuum.DatabaseName)
 		if vacuum.RelationName != "" {
-			relationRef := snapshot.RelationReference{
-				DatabaseIdx:  vacuumInfo.DatabaseIdx,
-				SchemaName:   vacuum.SchemaName,
-				RelationName: vacuum.RelationName,
-			}
-			vacuumInfo.RelationIdx = int32(len(r.RelationReferences))
-			r.RelationReferences = append(r.RelationReferences, &relationRef)
+			vacuumInfo.RelationIdx, r.RelationReferences = upsertRelationReference(r.RelationReferences, vacuumInfo.DatabaseIdx, vacuum.SchemaName, vacuum.RelationName)
 		} else {
 			vacuumInfo.RelationIdx = -1
 		}

--- a/output/transform/logs.go
+++ b/output/transform/logs.go
@@ -17,51 +17,6 @@ func LogStateToLogSnapshot(server *state.Server, logState state.TransientLogStat
 	return s, r
 }
 
-func upsertRoleReference(refs []*snapshot.RoleReference, roleName string) (int32, []*snapshot.RoleReference) {
-	newRef := snapshot.RoleReference{Name: roleName}
-
-	for idx, ref := range refs {
-		if ref.Name == newRef.Name {
-			return int32(idx), refs
-		}
-	}
-
-	idx := int32(len(refs))
-	refs = append(refs, &newRef)
-
-	return idx, refs
-}
-
-func upsertDatabaseReference(refs []*snapshot.DatabaseReference, databaseName string) (int32, []*snapshot.DatabaseReference) {
-	newRef := snapshot.DatabaseReference{Name: databaseName}
-
-	for idx, ref := range refs {
-		if ref.Name == newRef.Name {
-			return int32(idx), refs
-		}
-	}
-
-	idx := int32(len(refs))
-	refs = append(refs, &newRef)
-
-	return idx, refs
-}
-
-func upsertRelationReference(refs []*snapshot.RelationReference, databaseIdx int32, schemaName string, relationName string) (int32, []*snapshot.RelationReference) {
-	newRef := snapshot.RelationReference{DatabaseIdx: databaseIdx, SchemaName: schemaName, RelationName: relationName}
-
-	for idx, ref := range refs {
-		if ref.DatabaseIdx == newRef.DatabaseIdx && ref.SchemaName == newRef.SchemaName && ref.RelationName == newRef.RelationName {
-			return int32(idx), refs
-		}
-	}
-
-	idx := int32(len(refs))
-	refs = append(refs, &newRef)
-
-	return idx, refs
-}
-
 func transformPostgresQuerySamples(server *state.Server, s snapshot.CompactLogSnapshot, r snapshot.CompactSnapshot_BaseRefs, logState state.TransientLogState) (snapshot.CompactLogSnapshot, snapshot.CompactSnapshot_BaseRefs) {
 	for _, sampleIn := range logState.QuerySamples {
 		occurredAt, _ := ptypes.TimestampProto(sampleIn.OccurredAt)

--- a/output/transform/util.go
+++ b/output/transform/util.go
@@ -91,3 +91,48 @@ func upsertQueryReferenceAndInformationSimple(server *state.Server, refs []*snap
 
 	return idx, refs, infos
 }
+
+func upsertRoleReference(refs []*snapshot.RoleReference, roleName string) (int32, []*snapshot.RoleReference) {
+	newRef := snapshot.RoleReference{Name: roleName}
+
+	for idx, ref := range refs {
+		if ref.Name == newRef.Name {
+			return int32(idx), refs
+		}
+	}
+
+	idx := int32(len(refs))
+	refs = append(refs, &newRef)
+
+	return idx, refs
+}
+
+func upsertDatabaseReference(refs []*snapshot.DatabaseReference, databaseName string) (int32, []*snapshot.DatabaseReference) {
+	newRef := snapshot.DatabaseReference{Name: databaseName}
+
+	for idx, ref := range refs {
+		if ref.Name == newRef.Name {
+			return int32(idx), refs
+		}
+	}
+
+	idx := int32(len(refs))
+	refs = append(refs, &newRef)
+
+	return idx, refs
+}
+
+func upsertRelationReference(refs []*snapshot.RelationReference, databaseIdx int32, schemaName string, relationName string) (int32, []*snapshot.RelationReference) {
+	newRef := snapshot.RelationReference{DatabaseIdx: databaseIdx, SchemaName: schemaName, RelationName: relationName}
+
+	for idx, ref := range refs {
+		if ref.DatabaseIdx == newRef.DatabaseIdx && ref.SchemaName == newRef.SchemaName && ref.RelationName == newRef.RelationName {
+			return int32(idx), refs
+		}
+	}
+
+	idx := int32(len(refs))
+	refs = append(refs, &newRef)
+
+	return idx, refs
+}


### PR DESCRIPTION
This previously used a simplistic model where we assumed we only ever
have one vacuum run referencing a certain table. However this is not
correct when the TOAST relation of a table is being vacuumed at the same
time as the table itself. In that case we'll have the same relation twice,
requiring the use of the more correct upsertRelationReference helper.

In passing, move the upsert helper functions into a combined util.go file.