### PR TITLE
Fix broken relation stats diff

### DIFF
--- a/output/transform/postgres_relations.go
+++ b/output/transform/postgres_relations.go
@@ -129,8 +129,9 @@ func transformPostgresRelations(s snapshot.FullSnapshot, newState state.Persiste
 		s.RelationInformations = append(s.RelationInformations, &info)
 
 		// Statistic
-		if schemaStatsExist {
-			stats, exists := schemaStats.RelationStats[relation.Oid]
+		diffedSchemaStats, diffedSchemaStatsExist := diffState.SchemaStats[relation.DatabaseOid]
+		if diffedSchemaStatsExist {
+			stats, exists := diffedSchemaStats.RelationStats[relation.Oid]
 			if exists {
 				statistic := snapshot.RelationStatistic{
 					RelationIdx:    relationIdx,


### PR DESCRIPTION
#192 had accidentally removed the usage of `diffState` for these stats. Note that `LastAnalyze` should still work even though this PR changes its code to source the value from `diffState`, because the diff includes the data we need without modifying it: https://github.com/pganalyze/collector/blob/3d35db61b55ae84c53e46850829fc15bfe5405e0/state/postgres_relation_stats.go#L90-L91