### PR TITLE
Allow pganalyze server to signal higher table limits being accepted

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -198,6 +198,8 @@ type GrantConfig struct {
 
 	EnableActivity bool `json:"enable_activity"`
 	EnableLogs     bool `json:"enable_logs"`
+
+	SchemaTableLimit int `json:"schema_table_limit"` // Maximum number of tables that can be monitored per server
 }
 
 type GrantFeatures struct {


### PR DESCRIPTION
For now this is targeted at pganalyze Enterprise Server use cases, where
customers can choose to monitor more than 5000 tables per server.

We may increase this limit for the cloud version in the future as well,
this commit future-proofs the codepath for both use cases.

Note that in any case the collector today does not enforce this limit,
rather it just outputs an informational message, with the actual
enforcement on the server side.