### PR TITLE
Stop pretty-printing indexdefs on collection

### DIFF
--- a/input/postgres/relation_bloat.go
+++ b/input/postgres/relation_bloat.go
@@ -148,7 +148,7 @@ index_item_sizes AS (
 		FROM pg_catalog.pg_attribute a
 		JOIN btree_index_atts AS ia ON (a.attrelid = ia.indexrelid AND a.attnum = ia.attnum)
 		JOIN %s s ON (s.schemaname = ia.nspname
-				          AND ((s.tablename = ia.tablename AND s.attname = pg_catalog.pg_get_indexdef(a.attrelid, a.attnum, TRUE))
+				          AND ((s.tablename = ia.tablename AND s.attname = pg_catalog.pg_get_indexdef(a.attrelid, a.attnum, FALSE))
 				               OR (s.tablename = ia.index_name AND s.attname = a.attname)))
 		WHERE a.attnum > 0
 		GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9

--- a/input/postgres/relations.go
+++ b/input/postgres/relations.go
@@ -86,7 +86,7 @@ SELECT c.oid,
 			 i.indisprimary,
 			 i.indisunique,
 			 i.indisvalid,
-			 pg_catalog.pg_get_indexdef(i.indexrelid, 0, TRUE),
+			 pg_catalog.pg_get_indexdef(i.indexrelid, 0, FALSE),
 			 pg_catalog.pg_get_constraintdef(con.oid, TRUE),
 			 c2.reloptions,
 			 (SELECT a.amname FROM pg_catalog.pg_am a JOIN pg_catalog.pg_opclass o ON (a.oid = o.opcmethod) WHERE o.oid = i.indclass[0])


### PR DESCRIPTION
Pretty printing includes omitting the schema *if* the index relation's
schema is in the current search_path. This means we may capture an
incomplete index definition.

There's also other similar functions we can consider updating:

 - pg_get_ruledef
 - pg_get_viewdef
 - pg_get_constraintdef

We don't use `pg_get_ruledef` so that's moot right now.

For `pg_get_viewdef`, the pretty printing flag does *not* actually
affect whether the printed view definition uses fully-qualified
objects. The objects are *only* fully qualified if the current
search_path does *not* contain their schema. We could address this by
recommending a search path of only pg_catalog for the monitoring user,
but setting a different search_path can help with log-based EXPLAIN if
using schemas. Alternately, we could always set the search_path to
just pg_catalog for the pg_get_viewdef query only.

I still need to investigate the behavior of `pg_get_constraintdef`.

Thoughts?