### PR TITLE
EXPLAIN handling: Skip plans for databases that are not monitored

### DIFF
--- a/input/postgres/explain.go
+++ b/input/postgres/explain.go
@@ -28,11 +28,11 @@ func RunExplain(server *state.Server, inputs []state.PostgresQuerySample, collec
 	}
 
 	for _, sample := range inputs {
-		if sample.HasExplain { // EXPLAIN was already collected, e.g. from auto_explain
-			outputs = append(outputs, sample)
+		if skip(sample) {
 			continue
 		}
-		if skip(sample) {
+		if sample.HasExplain { // EXPLAIN was already collected, e.g. from auto_explain
+			outputs = append(outputs, sample)
 			continue
 		}
 		samplesByDb[sample.Database] = append(samplesByDb[sample.Database], sample)


### PR DESCRIPTION
This was an oversight in 1a68eb7e9f2ef37ae542cea6939ee4fd3ada0759
that caused auto_explain plans to be collected for all databases on a
server, instead of only those that are being monitored.