### PR TITLE
Packages: Check official PGP key URL instead of Keybase URL

### DIFF
--- a/packages/repo/sync_rpm.sh
+++ b/packages/repo/sync_rpm.sh
@@ -8,7 +8,7 @@ printf "key 1\ndelkey\ny\nkey 1\ndelkey\ny\nsave\n" | gpg --batch --command-fd 0
 rpm --addsign /rpm/systemd/$RPM_PACKAGE
 
 # Verify that we've actually correctly signed the packages
-rpm --import https://keybase.io/pganalyze/key.asc
+rpm --import https://packages.pganalyze.com/pganalyze_signing_key.asc
 rpm --checksig /rpm/systemd/$RPM_PACKAGE
 
 mkdir -p /repo/el/7/RPMS


### PR DESCRIPTION
This is only used in the build process to verify we issued the correct signature. Keybase seems to have changed their URLs (or there is some other service issue), thus the change to verify what we publicly document on https://packages.pganalyze.com/