### PR TITLE
Change schema collection message to warning

### DIFF
--- a/input/postgres/schema.go
+++ b/input/postgres/schema.go
@@ -37,7 +37,12 @@ func CollectAllSchemas(server *state.Server, collectionOpts state.CollectionOpts
 		collected[dbName] = true
 		psNext, tsNext, databaseOid, err := collectOneSchema(server, collectionOpts, logger, ps, ts, dbName, ts.Version, systemType)
 		if err != nil {
-			logger.PrintWarning("Failed to collect schema metadata for database %s: %s", dbName, err)
+			warning := "Failed to collect schema metadata for database %s: %s"
+			if collectionOpts.TestRun {
+				logger.PrintWarning(warning, dbName, err)
+			} else {
+				logger.PrintVerbose(warning, dbName, err)
+			}
 			continue
 		}
 		ps = psNext

--- a/input/postgres/schema.go
+++ b/input/postgres/schema.go
@@ -37,7 +37,7 @@ func CollectAllSchemas(server *state.Server, collectionOpts state.CollectionOpts
 		collected[dbName] = true
 		psNext, tsNext, databaseOid, err := collectOneSchema(server, collectionOpts, logger, ps, ts, dbName, ts.Version, systemType)
 		if err != nil {
-			logger.PrintVerbose("Failed to collect schema metadata for database %s: %s", dbName, err)
+			logger.PrintWarning("Failed to collect schema metadata for database %s: %s", dbName, err)
 			continue
 		}
 		ps = psNext


### PR DESCRIPTION
If we fail to collect schema metadata, a database can remain
permanently hidden and a lot of in-app functionality does not
work. Since verbose logs are not likely to be turned on for a running
collector, hiding this message makes this situation difficult to
discover.

Elevate the message to a warning.
