### PR TITLE
Log Insights: Improve regexp for "malformed array literal" log event

### DIFF
--- a/logs/analyze.go
+++ b/logs/analyze.go
@@ -840,11 +840,14 @@ var malformedArrayLiteral = analyzeGroup{
 	classification: pganalyze_collector.LogLineInformation_MALFORMED_ARRAY_LITERAL,
 	primary: match{
 		prefixes: []string{"malformed array literal"},
-		regexp:   regexp.MustCompile(`^malformed array literal: "([^"]+)"(?: at character \d+)?`),
+		regexp:   regexp.MustCompile(`^malformed array literal: "(.+)"(?: at character \d+)?`),
 		secrets:  []state.LogSecretKind{state.TableDataLogSecret},
 	},
 	detail: match{
-		prefixes: []string{"Array value must start with \"{\" or dimension information."},
+		prefixes: []string{
+			"Array value must start with \"{\" or dimension information.",
+			"Unexpected array element.",
+		},
 	},
 }
 var subqueryMissingAlias = analyzeGroup{

--- a/logs/analyze_test.go
+++ b/logs/analyze_test.go
@@ -2602,6 +2602,39 @@ var tests = []testpair{
 	},
 	{
 		[]state.LogLine{{
+			Content:  "malformed array literal: \"{\"{\\\"bad\\\":\\\"data\\\"}\"}\"",
+			LogLevel: pganalyze_collector.LogLineInformation_ERROR,
+			UUID:     uuid.UUID{1},
+		}, {
+			Content:  "Unexpected array element.",
+			LogLevel: pganalyze_collector.LogLineInformation_DETAIL,
+		}, {
+			Content:  "SELECT $1::text[]",
+			LogLevel: pganalyze_collector.LogLineInformation_STATEMENT,
+		}},
+		[]state.LogLine{{
+			LogLevel:           pganalyze_collector.LogLineInformation_ERROR,
+			Classification:     pganalyze_collector.LogLineInformation_MALFORMED_ARRAY_LITERAL,
+			UUID:               uuid.UUID{1},
+			Query:              "SELECT $1::text[]",
+			ReviewedForSecrets: true,
+			SecretMarkers: []state.LogSecretMarker{{
+				ByteStart: 26,
+				ByteEnd:   48,
+				Kind:      state.TableDataLogSecret,
+			}},
+		}, {
+			LogLevel:           pganalyze_collector.LogLineInformation_DETAIL,
+			ParentUUID:         uuid.UUID{1},
+			ReviewedForSecrets: true,
+		}, {
+			LogLevel:   pganalyze_collector.LogLineInformation_STATEMENT,
+			ParentUUID: uuid.UUID{1},
+		}},
+		nil,
+	},
+	{
+		[]state.LogLine{{
 			Content:  "subquery in FROM must have an alias at character 15",
 			LogLevel: pganalyze_collector.LogLineInformation_ERROR,
 			UUID:     uuid.UUID{1},


### PR DESCRIPTION
Previously we did not support a double quote showing up inside the array
content, and would instead detect the rest of the log line as unknown
data. This adjusts the regexp to correctly capture that data and mark
it as a table data log secret.

Additionally, adds the known DETAIL line "Unexpected array element.".