### PR TITLE
Log Insights: Add "invalid input syntax for type json" log event

### DIFF
--- a/logs/analyze.go
+++ b/logs/analyze.go
@@ -813,7 +813,12 @@ var invalidInputSyntax = analyzeGroup{
 	classification: pganalyze_collector.LogLineInformation_INVALID_INPUT_SYNTAX,
 	primary: match{
 		prefixes: []string{"invalid input syntax for"},
-		regexp:   regexp.MustCompile(`^invalid input syntax for [\w ]+: "([^"]+)"(?: at character \d+)?`),
+		regexp:   regexp.MustCompile(`^invalid input syntax for [\w ]+(?:: "([^"]+)")?(?: at character \d+)?`),
+		secrets:  []state.LogSecretKind{state.TableDataLogSecret},
+	},
+	detail: match{
+		prefixes: []string{"Escape sequence \""},
+		regexp:   regexp.MustCompile(`^Escape sequence "(.+)" is invalid\.`),
 		secrets:  []state.LogSecretKind{state.TableDataLogSecret},
 	},
 }
@@ -1116,6 +1121,11 @@ var otherContextPatterns = []match{
 		prefixes: []string{"while inserting index tuple"},
 		regexp:   regexp.MustCompile(`while inserting index tuple \(\d+,\d+\) in relation "([^"]+)"`),
 		secrets:  []state.LogSecretKind{0},
+	},
+	{
+		prefixes: []string{"JSON data, line "},
+		regexp:   regexp.MustCompile(`^JSON data, line (\d+): (.+)`),
+		secrets:  []state.LogSecretKind{0, state.TableDataLogSecret},
 	},
 }
 

--- a/logs/analyze_test.go
+++ b/logs/analyze_test.go
@@ -2511,6 +2511,51 @@ var tests = []testpair{
 	},
 	{
 		[]state.LogLine{{
+			Content:  "invalid input syntax for type json",
+			LogLevel: pganalyze_collector.LogLineInformation_ERROR,
+			UUID:     uuid.UUID{1},
+		}, {
+			Content:  "Escape sequence \"\\1\" is invalid.",
+			LogLevel: pganalyze_collector.LogLineInformation_DETAIL,
+		}, {
+			Content:  "JSON data, line 1: ...',n ''foobar: \\1...",
+			LogLevel: pganalyze_collector.LogLineInformation_CONTEXT,
+		}, {
+			Content:  "SELECT $1::json",
+			LogLevel: pganalyze_collector.LogLineInformation_STATEMENT,
+		}},
+		[]state.LogLine{{
+			LogLevel:           pganalyze_collector.LogLineInformation_ERROR,
+			Classification:     pganalyze_collector.LogLineInformation_INVALID_INPUT_SYNTAX,
+			UUID:               uuid.UUID{1},
+			Query:              "SELECT $1::json",
+			ReviewedForSecrets: true,
+		}, {
+			LogLevel:           pganalyze_collector.LogLineInformation_DETAIL,
+			ParentUUID:         uuid.UUID{1},
+			ReviewedForSecrets: true,
+			SecretMarkers: []state.LogSecretMarker{{
+				ByteStart: 17,
+				ByteEnd:   19,
+				Kind:      state.TableDataLogSecret,
+			}},
+		}, {
+			LogLevel:           pganalyze_collector.LogLineInformation_CONTEXT,
+			ParentUUID:         uuid.UUID{1},
+			ReviewedForSecrets: true,
+			SecretMarkers: []state.LogSecretMarker{{
+				ByteStart: 19,
+				ByteEnd:   41,
+				Kind:      state.TableDataLogSecret,
+			}},
+		}, {
+			LogLevel:   pganalyze_collector.LogLineInformation_STATEMENT,
+			ParentUUID: uuid.UUID{1},
+		}},
+		nil,
+	},
+	{
+		[]state.LogLine{{
 			Content:  "value too long for type character varying(3)",
 			LogLevel: pganalyze_collector.LogLineInformation_ERROR,
 			UUID:     uuid.UUID{1},


### PR DESCRIPTION
This is a variant of the existing invalid input syntax log event, with
a few additional details.