### PR TITLE
Table processing: Ensure we use -1 index for unknown parent/FK tables

### DIFF
--- a/output/transform/postgres_relations.go
+++ b/output/transform/postgres_relations.go
@@ -22,12 +22,14 @@ func transformPostgresRelations(s snapshot.FullSnapshot, newState state.Persiste
 
 	for _, relation := range newState.Relations {
 		relationIdx := relationOidToIdx.Get(relation.DatabaseOid, relation.Oid)
+		if relationIdx == -1 {
+			// This should not happen, but if it does just skip over the bad data
+			continue
+		}
 
-		parentRelationIdx := int32(0)
-		hasParentRelation := false
+		parentRelationIdx := int32(-1)
 		if relation.ParentTableOid != 0 {
 			parentRelationIdx = relationOidToIdx.Get(relation.DatabaseOid, relation.ParentTableOid)
-			hasParentRelation = true
 		}
 
 		var partStrat snapshot.RelationInformation_PartitionStrategy
@@ -54,7 +56,7 @@ func transformPostgresRelations(s snapshot.FullSnapshot, newState state.Persiste
 			FrozenXid:              uint32(relation.FrozenXID),
 			MinimumMultixactXid:    uint32(relation.MinimumMultixactXID),
 			ParentRelationIdx:      parentRelationIdx,
-			HasParentRelation:      hasParentRelation,
+			HasParentRelation:      parentRelationIdx != -1,
 			PartitionBoundary:      relation.PartitionBoundary,
 			PartitionStrategy:      partStrat,
 			PartitionColumns:       relation.PartitionColumns,

--- a/state/util.go
+++ b/state/util.go
@@ -15,7 +15,11 @@ func (m OidToIdxMap) Put(dbOid, objOid Oid, idx int32) {
 
 func (m OidToIdxMap) Get(dbOid, objOid Oid) int32 {
 	if _, ok := m[dbOid]; !ok {
-		return 0
+		return -1
 	}
-	return m[dbOid][objOid]
+	idx, ok := m[dbOid][objOid]
+	if !ok {
+		return -1
+	}
+	return idx
 }


### PR DESCRIPTION
Previously we would sometimes use 0 in these situations, which is a valid
index when referencing the very first table in the list.

Note that whilst its not always clear why bad references here happen, as
they should only happen when the schema_table_regexp logic is active,
its better to not send bogus data to the server.