### PR TITLE
Cache RDS server IDs to reduce API requests

### DIFF
--- a/input/system/rds/logs.go
+++ b/input/system/rds/logs.go
@@ -34,7 +34,7 @@ func DownloadLogFiles(prevState state.PersistedLogState, config config.ServerCon
 
 	rdsSvc := rds.New(sess)
 
-	instance, err := awsutil.FindRdsInstance(config, sess)
+	identifier, err := awsutil.FindRdsIdentifier(config, sess)
 	if err != nil {
 		err = fmt.Errorf("Error finding RDS instance: %s", err)
 		return prevState, nil, nil, err
@@ -46,7 +46,7 @@ func DownloadLogFiles(prevState state.PersistedLogState, config config.ServerCon
 	lastWritten := linesNewerThan.Unix() * 1000
 
 	params := &rds.DescribeDBLogFilesInput{
-		DBInstanceIdentifier: instance.DBInstanceIdentifier,
+		DBInstanceIdentifier: &identifier,
 		FileLastWritten:      &lastWritten,
 	}
 
@@ -78,7 +78,7 @@ func DownloadLogFiles(prevState state.PersistedLogState, config config.ServerCon
 
 		for {
 			resp, err := rdsSvc.DownloadDBLogFilePortion(&rds.DownloadDBLogFilePortionInput{
-				DBInstanceIdentifier: instance.DBInstanceIdentifier,
+				DBInstanceIdentifier: &identifier,
 				LogFileName:          rdsLogFile.LogFileName,
 				Marker:               lastMarker, // This is not set for the initial call, so we only get the most recent lines
 			})

--- a/util/awsutil/rds.go
+++ b/util/awsutil/rds.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pganalyze/collector/util"
 )
 
-var IdentifierMap *util.TTLMap = util.NewTTLMap(5*60, 30)
+var IdentifierMap *util.TTLMap = util.NewTTLMap(5*60)
 
 func FindRdsIdentifier(config config.ServerConfig, sess *session.Session) (identifier string, err error) {
 	identifier = IdentifierMap.Get(config.AwsDbInstanceID)

--- a/util/awsutil/rds.go
+++ b/util/awsutil/rds.go
@@ -11,6 +11,20 @@ import (
 	"github.com/pganalyze/collector/util"
 )
 
+var IdentifierMap *util.TTLMap = util.NewTTLMap(5 * 60, 30)
+
+func FindRdsIdentifier(config config.ServerConfig, sess *session.Session) (identifier string, err error) {
+	identifier = IdentifierMap.Get(config.AwsDbInstanceID)
+	if identifier == "" {
+		instance, err := FindRdsInstance(config, sess)
+		if err != nil {
+			identifier = *instance.DBInstanceIdentifier
+			IdentifierMap.Put(config.AwsDbInstanceID, identifier)
+		}
+	}
+	return
+}
+
 func FindRdsInstance(config config.ServerConfig, sess *session.Session) (instance *rds.DBInstance, err error) {
 	var resp *rds.DescribeDBInstancesOutput
 

--- a/util/awsutil/rds.go
+++ b/util/awsutil/rds.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pganalyze/collector/util"
 )
 
-var IdentifierMap *util.TTLMap = util.NewTTLMap(5 * 60, 30)
+var IdentifierMap *util.TTLMap = util.NewTTLMap(5*60, 30)
 
 func FindRdsIdentifier(config config.ServerConfig, sess *session.Session) (identifier string, err error) {
 	identifier = IdentifierMap.Get(config.AwsDbInstanceID)

--- a/util/awsutil/rds.go
+++ b/util/awsutil/rds.go
@@ -12,8 +12,8 @@ import (
 	"github.com/pganalyze/collector/util"
 )
 
-var IdentifierMap *util.TTLMap = util.NewTTLMap(5*60)
-var ErrorCache *util.TTLMap = util.NewTTLMap(10*60)
+var IdentifierMap *util.TTLMap = util.NewTTLMap(5 * 60)
+var ErrorCache *util.TTLMap = util.NewTTLMap(10 * 60)
 
 func FindRdsIdentifier(config config.ServerConfig, sess *session.Session) (identifier string, err error) {
 	identifier = IdentifierMap.Get(config.AwsDbInstanceID)

--- a/util/awsutil/rds.go
+++ b/util/awsutil/rds.go
@@ -1,6 +1,7 @@
 package awsutil
 
 import (
+	"errors"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,15 +13,26 @@ import (
 )
 
 var IdentifierMap *util.TTLMap = util.NewTTLMap(5*60)
+var ErrorCache *util.TTLMap = util.NewTTLMap(10*60)
 
 func FindRdsIdentifier(config config.ServerConfig, sess *session.Session) (identifier string, err error) {
 	identifier = IdentifierMap.Get(config.AwsDbInstanceID)
-	if identifier == "" {
-		instance, err := FindRdsInstance(config, sess)
-		if err != nil {
-			identifier = *instance.DBInstanceIdentifier
-			IdentifierMap.Put(config.AwsDbInstanceID, identifier)
-		}
+	if identifier != "" {
+		return
+	}
+
+	cachedError := ErrorCache.Get(config.AwsDbInstanceID)
+	if cachedError != "" {
+		err = errors.New(cachedError)
+		return
+	}
+
+	instance, err := FindRdsInstance(config, sess)
+	if err == nil {
+		identifier = *instance.DBInstanceIdentifier
+		IdentifierMap.Put(config.AwsDbInstanceID, identifier)
+	} else {
+		ErrorCache.Put(config.AwsDbInstanceID, err.Error())
 	}
 	return
 }

--- a/util/ttl_map.go
+++ b/util/ttl_map.go
@@ -1,0 +1,56 @@
+package util
+
+import (
+    "sync"
+    "time"
+)
+
+type item struct {
+    value     string
+    createdAt int64
+}
+
+type TTLMap struct {
+    m map[string]*item
+    l sync.Mutex
+}
+
+func NewTTLMap(maxTTL int64, checkFrequency int64) (m *TTLMap) {
+    m = &TTLMap{ m: make(map[string]*item) }
+    go func() {
+        for now := range time.Tick(time.Second * time.Duration(checkFrequency)) {
+            m.l.Lock()
+            for k, v := range m.m {
+                if now.Unix() - v.createdAt > maxTTL {
+                    delete(m.m, k)
+                }
+            }
+            m.l.Unlock()
+        }
+    }()
+    return
+}
+
+func (m *TTLMap) Len() int {
+    return len(m.m)
+}
+
+func (m *TTLMap) Put(k, v string) {
+    m.l.Lock()
+    it, ok := m.m[k]
+    if !ok {
+        it = &item{value: v}
+        m.m[k] = it
+    }
+    it.createdAt = time.Now().Unix()
+    m.l.Unlock()
+}
+
+func (m *TTLMap) Get(k string) (v string) {
+    m.l.Lock()
+    if it, ok := m.m[k]; ok {
+        v = it.value
+    }
+    m.l.Unlock()
+    return
+}

--- a/util/ttl_map.go
+++ b/util/ttl_map.go
@@ -1,56 +1,56 @@
 package util
 
 import (
-    "sync"
-    "time"
+	"sync"
+	"time"
 )
 
 type item struct {
-    value     string
-    createdAt int64
+	value     string
+	createdAt int64
 }
 
 type TTLMap struct {
-    m map[string]*item
-    l sync.Mutex
+	m map[string]*item
+	l sync.Mutex
 }
 
 func NewTTLMap(maxTTL int64, checkFrequency int64) (m *TTLMap) {
-    m = &TTLMap{ m: make(map[string]*item) }
-    go func() {
-        for now := range time.Tick(time.Second * time.Duration(checkFrequency)) {
-            m.l.Lock()
-            for k, v := range m.m {
-                if now.Unix() - v.createdAt > maxTTL {
-                    delete(m.m, k)
-                }
-            }
-            m.l.Unlock()
-        }
-    }()
-    return
+	m = &TTLMap{ m: make(map[string]*item) }
+	go func() {
+		for now := range time.Tick(time.Second * time.Duration(checkFrequency)) {
+			m.l.Lock()
+			for k, v := range m.m {
+				if now.Unix() - v.createdAt > maxTTL {
+					delete(m.m, k)
+				}
+			}
+			m.l.Unlock()
+		}
+	}()
+	return
 }
 
 func (m *TTLMap) Len() int {
-    return len(m.m)
+	return len(m.m)
 }
 
 func (m *TTLMap) Put(k, v string) {
-    m.l.Lock()
-    it, ok := m.m[k]
-    if !ok {
-        it = &item{value: v}
-        m.m[k] = it
-    }
-    it.createdAt = time.Now().Unix()
-    m.l.Unlock()
+	m.l.Lock()
+	it, ok := m.m[k]
+	if !ok {
+		it = &item{value: v}
+		m.m[k] = it
+	}
+	it.createdAt = time.Now().Unix()
+	m.l.Unlock()
 }
 
 func (m *TTLMap) Get(k string) (v string) {
-    m.l.Lock()
-    if it, ok := m.m[k]; ok {
-        v = it.value
-    }
-    m.l.Unlock()
-    return
+	m.l.Lock()
+	if it, ok := m.m[k]; ok {
+		v = it.value
+	}
+	m.l.Unlock()
+	return
 }

--- a/util/ttl_map.go
+++ b/util/ttl_map.go
@@ -16,12 +16,12 @@ type TTLMap struct {
 }
 
 func NewTTLMap(maxTTL int64, checkFrequency int64) (m *TTLMap) {
-	m = &TTLMap{ m: make(map[string]*item) }
+	m = &TTLMap{m: make(map[string]*item)}
 	go func() {
 		for now := range time.Tick(time.Second * time.Duration(checkFrequency)) {
 			m.l.Lock()
 			for k, v := range m.m {
-				if now.Unix() - v.createdAt > maxTTL {
+				if now.Unix()-v.createdAt > maxTTL {
 					delete(m.m, k)
 				}
 			}

--- a/util/ttl_map.go
+++ b/util/ttl_map.go
@@ -20,12 +20,12 @@ func NewTTLMap(maxTTL int64, checkFrequency int64) (m *TTLMap) {
 	go func() {
 		for now := range time.Tick(time.Second * time.Duration(checkFrequency)) {
 			m.l.Lock()
+			defer m.l.Unlock()
 			for k, v := range m.m {
 				if now.Unix()-v.createdAt > maxTTL {
 					delete(m.m, k)
 				}
 			}
-			m.l.Unlock()
 		}
 	}()
 	return
@@ -37,20 +37,20 @@ func (m *TTLMap) Len() int {
 
 func (m *TTLMap) Put(k, v string) {
 	m.l.Lock()
+	defer m.l.Unlock()
 	it, ok := m.m[k]
 	if !ok {
 		it = &item{value: v}
 		m.m[k] = it
 	}
 	it.createdAt = time.Now().Unix()
-	m.l.Unlock()
 }
 
 func (m *TTLMap) Get(k string) (v string) {
 	m.l.Lock()
+	defer m.l.Unlock()
 	if it, ok := m.m[k]; ok {
 		v = it.value
 	}
-	m.l.Unlock()
 	return
 }


### PR DESCRIPTION
`FindRdsInstance` is being called 21 times every 10 minutes (once for the full snapshot, once every 30 seconds for log snapshots), which is an issue for customers with many servers.

This PR caches the API requests for log snapshots only, with a TTL of 5 minutes. This should bring us down to 3 requests every 10 minutes.

Edit: this now also caches API errors so we will pause this API request for 10 minutes if there is an outage / a server is being reprovisioned.