### PR TITLE
Drop Log Insights instructions after Heroku log test

### DIFF
--- a/runner/logs.go
+++ b/runner/logs.go
@@ -150,8 +150,6 @@ func TestLogsForAllServers(servers []*state.Server, globalCollectionOpts state.C
 			} else {
 				prefixedLogger.PrintInfo("  Log test successful")
 			}
-		} else if server.Config.SystemType == "heroku" {
-			prefixedLogger.PrintInfo("NOTICE - To confirm Log Insights config, setup Heroku log drain per docs (https://pganalyze.com/docs/log-insights/setup/heroku-postgres) and verify data shows up in pganalyze app.")
 		}
 	}
 


### PR DESCRIPTION
Since this also occurs as output after a successful regular test, it
contradicts our in-app instructions to wait until real snapshot data
comes in to proceed with Log Insights setup.

Since Heroku setup is generally straightforward, proceeding
optimistically here does not save much time and may make it harder to
diagnose issues if there is a problem, so drop these instructions.
