### PR TITLE
Handle unexpected schema / version in pg_stat_statements

### DIFF
--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -104,7 +104,7 @@ func GetStatements(server *state.Server, logger *util.Logger, db *sql.DB, global
 
 		var extSchema string
 		var foundExtVersion float32
-		err = db.QueryRow("SELECT nspname, extversion FROM pg_extension pge INNER JOIN pg_namespace pgn ON pge.extnamespace = pgn.oid WHERE pge.extname = 'pg_stat_statements'").Scan(&extSchema, &foundExtVersion)
+		err = db.QueryRow(QueryMarkerSQL+"SELECT nspname, extversion FROM pg_extension pge INNER JOIN pg_namespace pgn ON pge.extnamespace = pgn.oid WHERE pge.extname = 'pg_stat_statements'").Scan(&extSchema, &foundExtVersion)
 		if err != nil && err != sql.ErrNoRows {
 			return nil, nil, nil, err
 		}

--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -83,28 +83,6 @@ func GetStatements(server *state.Server, logger *util.Logger, db *sql.DB, global
 	var totalTimeField string
 	var optionalFields string
 	var sourceTable string
-	var extVersion float32               // defined in pg_stat_statements.c
-	var maxKnownExtVersion float32 = 1.8 // keeps the collector from erroring out when new Postgres versions are released
-
-	if postgresVersion.Numeric >= state.PostgresVersion13 {
-		totalTimeField = statementSQLpg13TotalTimeField
-	} else {
-		totalTimeField = statementSQLDefaultTotalTimeField
-	}
-
-	if postgresVersion.Numeric >= state.PostgresVersion13 {
-		optionalFields = statementSQLpg13OptionalFields
-		extVersion = 1.8
-	} else if postgresVersion.Numeric >= state.PostgresVersion95 {
-		optionalFields = statementSQLpg95OptionalFields
-		extVersion = 1.3
-	} else if postgresVersion.Numeric >= state.PostgresVersion94 {
-		optionalFields = statementSQLpg94OptionalFields
-		extVersion = 1.2
-	} else {
-		optionalFields = statementSQLDefaultOptionalFields
-		extVersion = 1.1
-	}
 
 	usingStatsHelper := false
 
@@ -123,10 +101,59 @@ func GetStatements(server *state.Server, logger *util.Logger, db *sql.DB, global
 				" the monitoring helper functions (https://github.com/pganalyze/collector#setting-up-a-restricted-monitoring-user)" +
 				" or connect as superuser, to get query statistics for all roles.")
 		}
-		if !showtext {
-			sourceTable = "public.pg_stat_statements(false)"
+
+		var extSchema string
+		var foundExtVersion float32
+		err = db.QueryRow("SELECT nspname, extversion FROM pg_extension pge INNER JOIN pg_namespace pgn ON pge.extnamespace = pgn.oid WHERE pge.extname = 'pg_stat_statements'").Scan(&extSchema, &foundExtVersion)
+		if err != nil && err != sql.ErrNoRows {
+			return nil, nil, nil, err
+		}
+
+		var extVersion float32 // defined in pg_stat_statements.c
+		if postgresVersion.Numeric >= state.PostgresVersion13 {
+			extVersion = 1.8
+		} else if postgresVersion.Numeric >= state.PostgresVersion95 {
+			extVersion = 1.3
+		} else if postgresVersion.Numeric >= state.PostgresVersion94 {
+			extVersion = 1.2
 		} else {
-			sourceTable = "public.pg_stat_statements"
+			extVersion = 1.1
+		}
+
+		if err == sql.ErrNoRows {
+			logger.PrintInfo("pg_stat_statements does not exist, trying to create extension...")
+			_, err = db.Exec(QueryMarkerSQL + "CREATE EXTENSION IF NOT EXISTS pg_stat_statements SCHEMA public")
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			extSchema = "public"
+			foundExtVersion = extVersion
+		}
+
+		if foundExtVersion >= 1.8 {
+			optionalFields = statementSQLpg13OptionalFields
+		} else if foundExtVersion >= 1.3 {
+			optionalFields = statementSQLpg95OptionalFields
+		} else if foundExtVersion >= 1.2 {
+			optionalFields = statementSQLpg94OptionalFields
+		} else {
+			optionalFields = statementSQLDefaultOptionalFields
+		}
+
+		if foundExtVersion >= 1.8 {
+			totalTimeField = statementSQLpg13TotalTimeField
+		} else {
+			totalTimeField = statementSQLDefaultTotalTimeField
+		}
+
+		if foundExtVersion < extVersion {
+			logger.PrintInfo("pg_stat_statements extension outdated (%.1f installed, %.1f available). To update run `ALTER EXTENSION pg_stat_statements UPDATE`", foundExtVersion, extVersion)
+		}
+
+		if !showtext {
+			sourceTable = extSchema + ".pg_stat_statements(false)"
+		} else {
+			sourceTable = extSchema + ".pg_stat_statements"
 		}
 	}
 
@@ -135,29 +162,9 @@ func GetStatements(server *state.Server, logger *util.Logger, db *sql.DB, global
 	stmt, err := db.Prepare(querySql)
 	if err != nil {
 		var e *pq.Error
-		if !usingStatsHelper && errors.As(err, &e) && (e.Code == "42P01" || e.Code == "42883") { // undefined_table / undefined_function
-			var pgssSchema string
-			var foundExtVersion float32
-			err = db.QueryRow("SELECT nspname, extversion FROM pg_extension pge INNER JOIN pg_namespace pgn ON pge.extnamespace = pgn.oid WHERE pge.extname = 'pg_stat_statements'").Scan(&pgssSchema, &foundExtVersion)
-			if err == nil && pgssSchema != "public" {
-				return nil, nil, nil, fmt.Errorf("pg_stat_statements must be created in schema \"public\"; found in schema \"%s\"", pgssSchema)
-			}
-			if err == nil && extVersion != foundExtVersion && foundExtVersion <= maxKnownExtVersion {
-				return nil, nil, nil, fmt.Errorf("pg_stat_statements version mismatch (found %f but expected %f). Please run `ALTER EXTENSION pg_stat_statements UPDATE`", foundExtVersion, extVersion)
-			}
+		if !usingStatsHelper && errors.As(err, &e) {
 			// If we get ErrNoRows, the extension does not exist, which is one of the expected paths
 			if err != nil && err != sql.ErrNoRows {
-				return nil, nil, nil, err
-			}
-
-			logger.PrintInfo("pg_stat_statements does not exist, trying to create extension...")
-			_, err = db.Exec(QueryMarkerSQL + "CREATE EXTENSION IF NOT EXISTS pg_stat_statements SCHEMA public")
-			if err != nil {
-				return nil, nil, nil, err
-			}
-
-			stmt, err = db.Prepare(querySql)
-			if err != nil {
 				return nil, nil, nil, err
 			}
 		} else {

--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -128,7 +128,7 @@ func GetStatements(server *state.Server, logger *util.Logger, db *sql.DB, global
 		totalTimeField = statementSQLDefaultTotalTimeField
 	}
 
-	if foundExtVersion < extVersion {
+	if globalCollectionOpts.TestRun && foundExtVersion < extVersion {
 		logger.PrintInfo("pg_stat_statements extension outdated (%.1f installed, %.1f available). To update run `ALTER EXTENSION pg_stat_statements UPDATE`", foundExtVersion, extVersion)
 	}
 

--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -83,7 +83,7 @@ func GetStatements(server *state.Server, logger *util.Logger, db *sql.DB, global
 	var totalTimeField string
 	var optionalFields string
 	var sourceTable string
-	var extVersion float32 // defined in pg_stat_statements.c
+	var extVersion float32               // defined in pg_stat_statements.c
 	var maxKnownExtVersion float32 = 1.8 // keeps the collector from erroring out when new Postgres versions are released
 
 	if postgresVersion.Numeric >= state.PostgresVersion13 {


### PR DESCRIPTION
It's fairly common for customers to upgrade Postgres without realizing they need to upgrade pg_stat_statements as well. In that case, we show them an unhelpful error message:

```
Error collecting pg_stat_statements: pq: column "total_exec_time" does not exist
```

This PR updates the collector to instead use the correct `pg_stat_statements` columns based on the installed version of the extension, instead of the version we assume is installed based on the Postgres version.

If we know the extension is out of date we'll log a helpful message: (only during test runs)

```
pg_stat_statements extension outdated (1.6 installed, 1.8 available). To update run `ALTER EXTENSION pg_stat_statements UPDATE`
```

This PR also prevents errors when the extension is installed in a non-public schema, instead calling it in whatever schema it's defined.