### PR TITLE
Reduce build time and use slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY contrib/sslrootcert/rds-ca-2019-root.pem contrib/sslrootcert/rds-ca-2015-ro
 COPY contrib/docker-entrypoint.sh $HOME_DIR
 RUN chmod +x $HOME_DIR/docker-entrypoint.sh
 
-FROM alpine as slim
+FROM alpine:3.15 as slim
 
 RUN adduser -D pganalyze pganalyze \ 
   && mkdir /state  \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk add --no-cache --virtual .build-deps make curl libc-dev gcc go git tar \
   && apk add --no-cache ca-certificates setpriv \
   && make build_dist_alpine OUTFILE=$HOME_DIR/collector \
   && rm -rf $GOPATH \
-	&& apk del --purge .build-deps
+  && apk del --purge .build-deps
 
 RUN chown pganalyze:pganalyze $HOME_DIR/collector
 
@@ -28,6 +28,10 @@ COPY contrib/sslrootcert/rds-ca-2019-root.pem /usr/share/pganalyze-collector/ssl
 COPY contrib/docker-entrypoint.sh $HOME_DIR
 RUN chmod +x $HOME_DIR/docker-entrypoint.sh
 
+FROM alpine as slim
+RUN adduser -D pganalyze pganalyze
+COPY --from=0 --chown=pganalyze:pganalyze $HOME_DIR $HOME_DIR
+COPY --from=0 /usr/share/pganalyze-collector/sslrootcert/ /usr/share/pganalyze-collector/sslrootcert/
 USER pganalyze
 
 ENTRYPOINT ["/home/pganalyze/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache ca-certificates
 
 RUN adduser -D pganalyze pganalyze \ 
   && mkdir /state  \
-  && chown pganalyze. /state 
+  && chown pganalyze:pganalyze /state 
 
 COPY --from=base --chown=pganalyze:pganalyze /home/pganalyze/docker-entrypoint.sh /home/pganalyze/collector /home/pganalyze
 COPY --from=base /usr/share/pganalyze-collector/sslrootcert/ /usr/share/pganalyze-collector/sslrootcert/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,35 @@
-FROM golang:1.17-alpine
+FROM golang:1.17-alpine as base
 MAINTAINER team@pganalyze.com
 
-RUN adduser -D pganalyze pganalyze
 ENV GOPATH /go
 ENV HOME_DIR /home/pganalyze
 ENV CODE_DIR $GOPATH/src/github.com/pganalyze/collector
 
+RUN apk add --no-cache --virtual .build-deps make curl libc-dev gcc git tar \
+  && apk add --no-cache ca-certificates setpriv \
+  && mkdir -p $HOME_DIR
+
 COPY . $CODE_DIR
 WORKDIR $CODE_DIR
 
-# We run this all in one layer to reduce the resulting image size
-RUN apk add --no-cache --virtual .build-deps make curl libc-dev gcc go git tar \
-  && apk add --no-cache ca-certificates setpriv \
-  && make build_dist_alpine OUTFILE=$HOME_DIR/collector \
-  && rm -rf $GOPATH \
-  && apk del --purge .build-deps
-
-RUN chown pganalyze:pganalyze $HOME_DIR/collector
-
-RUN mkdir /state
-RUN chown pganalyze:pganalyze /state
-VOLUME ["/state"]
+RUN  make build_dist_alpine OUTFILE=$HOME_DIR/collector 
 
 RUN mkdir -p /usr/share/pganalyze-collector/sslrootcert/
-COPY contrib/sslrootcert/rds-ca-2015-root.pem /usr/share/pganalyze-collector/sslrootcert/
-COPY contrib/sslrootcert/rds-ca-2019-root.pem /usr/share/pganalyze-collector/sslrootcert/
+COPY contrib/sslrootcert/rds-ca-2019-root.pem contrib/sslrootcert/rds-ca-2015-root.pem /usr/share/pganalyze-collector/sslrootcert/
 COPY contrib/docker-entrypoint.sh $HOME_DIR
 RUN chmod +x $HOME_DIR/docker-entrypoint.sh
 
 FROM alpine as slim
-RUN adduser -D pganalyze pganalyze
-COPY --from=0 --chown=pganalyze:pganalyze $HOME_DIR $HOME_DIR
-COPY --from=0 /usr/share/pganalyze-collector/sslrootcert/ /usr/share/pganalyze-collector/sslrootcert/
+
+RUN adduser -D pganalyze pganalyze \ 
+  && mkdir /state  \
+  && chown pganalyze. /state
+
+COPY --from=base --chown=pganalyze:pganalyze /home/pganalyze/docker-entrypoint.sh /home/pganalyze/collector /home/pganalyze/collector
+COPY --from=base /usr/share/pganalyze-collector/sslrootcert/ /usr/share/pganalyze-collector/sslrootcert/
+
+VOLUME ["/state"]
+
 USER pganalyze
 
 ENTRYPOINT ["/home/pganalyze/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN adduser -D pganalyze pganalyze \
   && mkdir /state  \
   && chown pganalyze. /state
 
-COPY --from=base --chown=pganalyze:pganalyze /home/pganalyze/docker-entrypoint.sh /home/pganalyze/collector /home/pganalyze/collector
+COPY --from=base --chown=pganalyze:pganalyze /home/pganalyze/docker-entrypoint.sh /home/pganalyze/collector /home/pganalyze
 COPY --from=base /usr/share/pganalyze-collector/sslrootcert/ /usr/share/pganalyze-collector/sslrootcert/
 
 VOLUME ["/state"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ ENV HOME_DIR /home/pganalyze
 ENV CODE_DIR $GOPATH/src/github.com/pganalyze/collector
 
 RUN apk add --no-cache --virtual .build-deps make curl libc-dev gcc git tar \
-  && apk add --no-cache ca-certificates setpriv \
   && mkdir -p $HOME_DIR
 
 COPY . $CODE_DIR
@@ -21,9 +20,11 @@ RUN chmod +x $HOME_DIR/docker-entrypoint.sh
 
 FROM alpine:3.15 as slim
 
+RUN apk add --no-cache ca-certificates
+
 RUN adduser -D pganalyze pganalyze \ 
   && mkdir /state  \
-  && chown pganalyze. /state
+  && chown pganalyze. /state 
 
 COPY --from=base --chown=pganalyze:pganalyze /home/pganalyze/docker-entrypoint.sh /home/pganalyze/collector /home/pganalyze
 COPY --from=base /usr/share/pganalyze-collector/sslrootcert/ /usr/share/pganalyze-collector/sslrootcert/


### PR DESCRIPTION
This change reduces the build time and reduces the runtime image size from 620mb to 38mb(updated these values as i had accidentally built the -original image initially off of an edit i had made. this is now the diff in build size/time from what's currently in master)

with changes
```
-> % docker build . -t pgcollector
[+] Building 63.9s (19/19) FINISHED                                                                                                                       
 => [internal] load build definition from Dockerfile                                                                                                 0.0s
 => => transferring dockerfile: 1.18kB                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                    0.0s
 => => transferring context: 34B                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                     1.9s
 => [internal] load metadata for docker.io/library/golang:1.17-alpine                                                                                1.9s
 => [base 1/9] FROM docker.io/library/golang:1.17-alpine@sha256:4918412049183afe42f1ecaf8f5c2a88917c2eab153ce5ecf4bf2d55c1507b74                     0.0s
 => [slim 1/4] FROM docker.io/library/alpine@sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300                                 0.0s
 => [internal] load build context                                                                                                                    0.2s
 => => transferring context: 249.72kB                                                                                                                0.2s
 => CACHED [slim 2/4] RUN adduser -D pganalyze pganalyze   && mkdir /state    && chown pganalyze. /state                                             0.0s
 => CACHED [base 2/9] RUN apk add --no-cache --virtual .build-deps make curl libc-dev gcc git tar   && apk add --no-cache ca-certificates setpriv    0.0s
 => [base 3/9] COPY . /go/src/github.com/pganalyze/collector                                                                                         0.4s
 => [base 4/9] WORKDIR /go/src/github.com/pganalyze/collector                                                                                        0.0s
 => [base 5/9] RUN  make build_dist_alpine OUTFILE=/home/pganalyze/collector                                                                        60.6s
 => [base 6/9] RUN mkdir -p /usr/share/pganalyze-collector/sslrootcert/                                                                              0.2s
 => [base 7/9] COPY contrib/sslrootcert/rds-ca-2019-root.pem contrib/sslrootcert/rds-ca-2015-root.pem /usr/share/pganalyze-collector/sslrootcert/    0.0s 
 => [base 8/9] COPY contrib/docker-entrypoint.sh /home/pganalyze                                                                                     0.0s 
 => [base 9/9] RUN chmod +x /home/pganalyze/docker-entrypoint.sh                                                                                     0.2s 
 => [slim 3/4] COPY --from=base --chown=pganalyze:pganalyze /home/pganalyze/docker-entrypoint.sh /home/pganalyze/collector /home/pganalyze           0.1s 
 => [slim 4/4] COPY --from=base /usr/share/pganalyze-collector/sslrootcert/ /usr/share/pganalyze-collector/sslrootcert/                              0.0s 
 => exporting to image                                                                                                                               0.1s
 => => exporting layers                                                                                                                              0.1s
 => => writing image sha256:56ae2a5b24d39cd6a8cafed3d87986cb7de900b155d015087ad51708a697d6ac                                                         0.0s
 => => naming to docker.io/library/pgcollector 
```


without changes
```
-> % docker build . --no-cache -t pgcollector-original
[+] Building 195.6s (18/18) FINISHED                                                                                                                      
 => [internal] load build definition from Dockerfile                                                                                                 0.0s
 => => transferring dockerfile: 1.12kB                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                    0.0s
 => => transferring context: 34B                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/golang:1.17-alpine                                                                                1.0s
 => CACHED [ 1/13] FROM docker.io/library/golang:1.17-alpine@sha256:4918412049183afe42f1ecaf8f5c2a88917c2eab153ce5ecf4bf2d55c1507b74                 0.0s
 => [internal] load build context                                                                                                                    0.2s
 => => transferring context: 250.12kB                                                                                                                0.2s
 => [ 2/13] RUN adduser -D pganalyze pganalyze                                                                                                       0.3s
 => [ 3/13] COPY . /go/src/github.com/pganalyze/collector                                                                                            0.4s
 => [ 4/13] WORKDIR /go/src/github.com/pganalyze/collector                                                                                           0.0s
 => [ 5/13] RUN apk add --no-cache --virtual .build-deps make curl libc-dev gcc go git tar   && apk add --no-cache ca-certificates setpriv   && m  191.5s
 => [ 6/13] RUN chown pganalyze:pganalyze /home/pganalyze/collector                                                                                  0.3s
 => [ 7/13] RUN mkdir /state                                                                                                                         0.2s 
 => [ 8/13] RUN chown pganalyze:pganalyze /state                                                                                                     0.2s 
 => [ 9/13] RUN mkdir -p /usr/share/pganalyze-collector/sslrootcert/                                                                                 0.2s 
 => [10/13] COPY contrib/sslrootcert/rds-ca-2015-root.pem /usr/share/pganalyze-collector/sslrootcert/                                                0.0s 
 => [11/13] COPY contrib/sslrootcert/rds-ca-2019-root.pem /usr/share/pganalyze-collector/sslrootcert/                                                0.0s 
 => [12/13] COPY contrib/docker-entrypoint.sh /home/pganalyze                                                                                        0.0s
 => [13/13] RUN chmod +x /home/pganalyze/docker-entrypoint.sh                                                                                        0.2s
 => exporting to image                                                                                                                               1.0s
 => => exporting layers                                                                                                                              1.0s
writing image sha256:1659f428e078a43b65240b55889240f7d28d15fcaabcc1b3dbbdce78bb1bce0d                                                    0.0s
 => => naming to docker.io/library/pgcollector-original           
```



image sizes
```
-> % docker images |grep pgcollector
pgcollector-original                                                   latest    1659f428e078   About a minute ago   620MB
pgcollector                                                            latest    56ae2a5b24d3   5 minutes ago          38MB
```