### PR TITLE
Build multi-arch Docker image for x86/amd64 and ARM64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,6 @@ integration_test:
 packages:
 	make -C packages
 
-docker_latest:
-	docker build -t quay.io/pganalyze/collector:latest .
-	docker push quay.io/pganalyze/collector:latest
-
 DOCKER_RELEASE_TAG := $(shell git describe --tags --exact-match --abbrev=0)
 docker_release:
 	@test -n "$(DOCKER_RELEASE_TAG)" || (echo "ERROR: DOCKER_RELEASE_TAG is not set, make sure you are on a git release tag or override by setting DOCKER_RELEASE_TAG" ; exit 1)


### PR DESCRIPTION
This utilizes Docker's manifest handling to contain both architectures
within the same Docker tag.

In passing improve the Makefile task and rename it to "docker_release"
for clarity.