### PR TITLE
Log streams: Support processing primary and secondary lines out of order

### DIFF
--- a/logs/stream/stream.go
+++ b/logs/stream/stream.go
@@ -39,7 +39,8 @@ import (
 // - Not correctly ordered (lines from Pub/Sub may arrive in any order)
 // - All lines have a timestamp
 // - Always has the log line number, allowing association of related log lines
-// - Multi-line messages are already combined together (as of Sept 14, 2021)
+// - Multi-line messages are already combined together
+//   (as of Sept 14, 2021 - see https://cloud.google.com/sql/docs/release-notes#September_14_2021)
 
 const InvalidPid int32 = -1
 

--- a/logs/stream/stream.go
+++ b/logs/stream/stream.go
@@ -79,7 +79,7 @@ func determineLogLineReadiness(logLine state.LogLine, threshold time.Duration, n
 	// or any other contextual information!
 	//
 	// This is the case for self-managed servers where we tail a log file,
-	// and so we can reasonably assume that subsequent unidentifyable lines
+	// and so we can reasonably assume that subsequent unidentifiable lines
 	// directly belong to the line we saw right before.
 	//
 	// There are edge cases where we discard lines here, since we want to avoid

--- a/logs/stream/stream_test.go
+++ b/logs/stream/stream_test.go
@@ -256,6 +256,63 @@ var tests = []testpair{
 		[]state.LogLine{},
 		nil,
 	},
+	{
+		[]state.LogLine{
+			{
+				CollectedAt: now.Add(-4 * time.Second),
+				OccurredAt:  now.Add(-4 * time.Second),
+				LogLevel:    pganalyze_collector.LogLineInformation_LOG,
+				BackendPid:  80,
+				Content:     "main\n",
+			},
+			{
+				CollectedAt: now.Add(-2 * time.Second),
+				OccurredAt:  now.Add(-2 * time.Second),
+				LogLevel:    pganalyze_collector.LogLineInformation_DETAIL,
+				BackendPid:  92,
+				Content:     "other-detail\n",
+			},
+			{
+				CollectedAt: now.Add(-2 * time.Second),
+				OccurredAt:  now.Add(-4 * time.Second),
+				LogLevel:    pganalyze_collector.LogLineInformation_DETAIL,
+				BackendPid:  80,
+				Content:     "detail\n",
+			},
+		},
+		state.TransientLogState{},
+		state.LogFile{
+			LogLines: []state.LogLine{
+				{
+					CollectedAt: now.Add(-4 * time.Second),
+					OccurredAt:  now.Add(-4 * time.Second),
+					LogLevel:    pganalyze_collector.LogLineInformation_LOG,
+					ByteEnd:     5,
+					BackendPid:  80,
+				},
+				{
+					CollectedAt:      now.Add(-2 * time.Second),
+					OccurredAt:       now.Add(-4 * time.Second),
+					LogLevel:         pganalyze_collector.LogLineInformation_DETAIL,
+					ByteStart:        5,
+					ByteContentStart: 5,
+					ByteEnd:          12,
+					BackendPid:       80,
+				},
+			},
+		},
+		"main\ndetail\n",
+		[]state.LogLine{
+			{
+				CollectedAt: now.Add(-2 * time.Second),
+				OccurredAt:  now.Add(-2 * time.Second),
+				LogLevel:    pganalyze_collector.LogLineInformation_DETAIL,
+				BackendPid:  92,
+				Content:     "other-detail\n",
+			},
+		},
+		nil,
+	},
 	//{
 	// There should be a test for this method
 	// - Pass in two logLines, one at X, one at X + 2, and assume the time is x + 3


### PR DESCRIPTION
This is in particular useful for GCP, where Pub/Sub does not guarantee
that associated lines will be received in order, e.g. when the DETAIL
line comes before the LOG line for log_min_duration_statement output,
causing parameters to be missed.

In passing, fix a bug in logline readiness handling that likely caused
some problems with Heroku logs, as we were considering logs to be "ready"
too often, due to a buggy comparison of the "logLine" loop variable
which we kept a long-lived pointer too (and then compared the next
iteration against that pointer, which would always succeed).