### PR TITLE
Log processing: Handle non-UTC/non-local log_timezone values correctly

### DIFF
--- a/logs/parse_test.go
+++ b/logs/parse_test.go
@@ -105,6 +105,20 @@ var parseTests = []parseTestpair{
 		},
 		true,
 	},
+	// Custom 1 format
+	{
+		"",
+		"2018-09-27 06:57:01.030 EST [20194][] : [1-1] [app=pganalyze_collector] LOG:  connection received: host=[local]",
+		state.LogLine{
+			OccurredAt:    time.Date(2018, time.September, 27, 6, 57, 1, 30*1000*1000, time.FixedZone("EST", -5*3600)),
+			LogLevel:      pganalyze_collector.LogLineInformation_LOG,
+			BackendPid:    20194,
+			LogLineNumber: 1,
+			Application:   "pganalyze_collector",
+			Content:       "connection received: host=[local]",
+		},
+		true,
+	},
 	// Custom 3 format
 	{
 		"",


### PR DESCRIPTION
Previously we supported handling timezone values in three cases:

(1) No timezone specified
(2) UTC/GMT timezone explicitly specified
(3) Timezone specified that matches the collector system timezone

However we did not handle a log_timezone setting that is different from
the timezone thats configured on the system the collector is running on.

This was caused by incorrect assumptions of what time.Parse() does in
this case. As we have no other way to get the UTC timestamp of a logline,
we rely on the system's timezone database to help us parse the log line
in the correct timezone for this edge case.