### PR TITLE
Do not count free memory in total memory on Heroku

### DIFF
--- a/input/system/heroku/log_receiver.go
+++ b/input/system/heroku/log_receiver.go
@@ -104,7 +104,7 @@ func processSystemMetrics(timestamp time.Time, content []byte, nameToServer map[
 
 	system.Memory = state.Memory{
 		ApplicationBytes: uint64(memoryPostgresKb * 1024),
-		TotalBytes:       uint64(memoryFreeKb*1024) + uint64(memoryTotalUsedKb*1024),
+		TotalBytes:       uint64(memoryTotalUsedKb * 1024),
 		FreeBytes:        uint64(memoryFreeKb * 1024),
 		CachedBytes:      uint64(memoryCachedKb * 1024),
 	}


### PR DESCRIPTION
Heroku total memory used to exclude free memory, but at some point it
looks like this was changed, so we are now overcounting total memory
by the amount of free memory available.

Exclude free memory from the total memory number.
