### PR TITLE
Log Insights: C22 Auth failed - detect additional DETAIL information

### DIFF
--- a/logs/analyze.go
+++ b/logs/analyze.go
@@ -165,8 +165,8 @@ var authenticationFailed = analyzeGroup{
 		secrets:  []state.LogSecretKind{0, 0, 0},
 	},
 	detail: match{
-		regexp:  regexp.MustCompile(`^Connection matched pg_hba.conf line \d+: "([^"]+)"`),
-		secrets: []state.LogSecretKind{state.UnidentifiedLogSecret},
+		regexp:  regexp.MustCompile(`^(?:(?:Role|User|Password does not match for user|Password of user) "([^"]+)" ?(?:does not have a valid SCRAM secret|does not exist|has no password assigned|has an expired password|has a password that cannot be used with MD5 authentication|is in unrecognized format)?\.\s+)?Connection matched pg_hba.conf line \d+: "([^"]+)"`),
+		secrets: []state.LogSecretKind{0, state.OpsLogSecret},
 	},
 }
 var roleNotAllowedLogin = analyzeGroup{

--- a/logs/analyze_test.go
+++ b/logs/analyze_test.go
@@ -252,6 +252,13 @@ var tests = []testpair{
 			Content:  "Connection matched pg_hba.conf line 4: \"hostssl postgres        postgres        0.0.0.0/0               md5\"",
 			LogLevel: pganalyze_collector.LogLineInformation_DETAIL,
 		}, {
+			Content:  "password authentication failed for user \"special\"",
+			LogLevel: pganalyze_collector.LogLineInformation_FATAL,
+			UUID:     uuid.UUID{2},
+		}, {
+			Content:  "Role \"special\" does not exist. Connection matched pg_hba.conf line 67: \"hostnossl all all all md5\"",
+			LogLevel: pganalyze_collector.LogLineInformation_DETAIL,
+		}, {
 			Content:  "database \"template0\" is not currently accepting connections",
 			LogLevel: pganalyze_collector.LogLineInformation_FATAL,
 		}, {
@@ -314,7 +321,21 @@ var tests = []testpair{
 			SecretMarkers: []state.LogSecretMarker{{
 				ByteStart: 40,
 				ByteEnd:   107,
-				Kind:      state.UnidentifiedLogSecret,
+				Kind:      state.OpsLogSecret,
+			}},
+		}, {
+			Classification:     pganalyze_collector.LogLineInformation_CONNECTION_REJECTED,
+			LogLevel:           pganalyze_collector.LogLineInformation_FATAL,
+			UUID:               uuid.UUID{2},
+			ReviewedForSecrets: true,
+		}, {
+			LogLevel:           pganalyze_collector.LogLineInformation_DETAIL,
+			ParentUUID:         uuid.UUID{2},
+			ReviewedForSecrets: true,
+			SecretMarkers: []state.LogSecretMarker{{
+				ByteStart: 72,
+				ByteEnd:   97,
+				Kind:      state.OpsLogSecret,
 			}},
 		}, {
 			Classification:     pganalyze_collector.LogLineInformation_CONNECTION_REJECTED,

--- a/state/logs.go
+++ b/state/logs.go
@@ -83,7 +83,7 @@ const (
 	// TableDataLogSecret - Table data contained in constraint violations and COPY errors
 	TableDataLogSecret
 
-	// OpsLogSecret - System, network errors, file locations and configured commands (e.g. archive command)
+	// OpsLogSecret - System, network errors, file locations, pg_hba.conf contents, and configured commands (e.g. archive command)
 	OpsLogSecret
 
 	// UnidentifiedLogSecret - Text that could not be identified and might contain secrets


### PR DESCRIPTION
This avoids flagging the whole DETAIL log line as an unidentified line in
cases where the logdetail value is set by Postgres, e.g. because the
role that tried logging in does not exist (which is included in the
error message).

In passing, mark pg_hba.conf contents output by this log event as
OpsLogSecret.