### PR TITLE
Cleanup: Use ParseInt with the right bit size instead of strconv.Atoi

### DIFF
--- a/input/postgres/helpers.go
+++ b/input/postgres/helpers.go
@@ -17,7 +17,7 @@ func unpackPostgresInt32Array(input null.String) (result []int32) {
 	}
 
 	for _, cstr := range strings.Split(strings.Trim(input.String, "{}"), ",") {
-		cint, _ := strconv.Atoi(cstr)
+		cint, _ := strconv.ParseInt(cstr, 10, 32)
 		result = append(result, int32(cint))
 	}
 
@@ -30,7 +30,7 @@ func unpackPostgresOidArray(input null.String) (result []state.Oid) {
 	}
 
 	for _, cstr := range strings.Split(strings.Trim(input.String, "{}"), ",") {
-		cint, _ := strconv.Atoi(cstr)
+		cint, _ := strconv.ParseInt(cstr, 10, 32)
 		result = append(result, state.Oid(cint))
 	}
 

--- a/input/postgres/relations.go
+++ b/input/postgres/relations.go
@@ -204,7 +204,7 @@ func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentData
 
 		if partCols.Valid {
 			for _, cstr := range strings.Split(partCols.String, " ") {
-				cint, _ := strconv.Atoi(cstr)
+				cint, _ := strconv.ParseInt(cstr, 10, 32)
 				row.PartitionColumns = append(row.PartitionColumns, int32(cint))
 			}
 		}
@@ -260,7 +260,7 @@ func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentData
 		}
 
 		for _, cstr := range strings.Split(columns, " ") {
-			cint, _ := strconv.Atoi(cstr)
+			cint, _ := strconv.ParseInt(cstr, 10, 32)
 			row.Columns = append(row.Columns, int32(cint))
 		}
 
@@ -310,13 +310,13 @@ func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentData
 		}
 		if columns.Valid {
 			for _, cstr := range strings.Split(strings.Trim(columns.String, "{}"), ",") {
-				cint, _ := strconv.Atoi(cstr)
+				cint, _ := strconv.ParseInt(cstr, 10, 32)
 				row.Columns = append(row.Columns, int32(cint))
 			}
 		}
 		if foreignColumns.Valid {
 			for _, cstr := range strings.Split(strings.Trim(foreignColumns.String, "{}"), ",") {
-				cint, _ := strconv.Atoi(cstr)
+				cint, _ := strconv.ParseInt(cstr, 10, 32)
 				row.ForeignColumns = append(row.ForeignColumns, int32(cint))
 			}
 		}

--- a/input/postgres/vacuum_stats.go
+++ b/input/postgres/vacuum_stats.go
@@ -52,16 +52,16 @@ func GetVacuumStats(logger *util.Logger, db *sql.DB, ignoreRegexp string) (repor
 		case "autovacuum":
 			report.AutovacuumEnabled = value == "on"
 		case "autovacuum_max_workers":
-			val, _ := strconv.Atoi(value)
+			val, _ := strconv.ParseInt(value, 10, 32)
 			report.AutovacuumMaxWorkers = int32(val)
 		case "autovacuum_naptime":
-			val, _ := strconv.Atoi(value)
+			val, _ := strconv.ParseInt(value, 10, 32)
 			report.AutovacuumNaptimeSeconds = int32(val)
 		case "autovacuum_vacuum_threshold":
-			val, _ := strconv.Atoi(value)
+			val, _ := strconv.ParseInt(value, 10, 32)
 			report.AutovacuumVacuumThreshold = int32(val)
 		case "autovacuum_analyze_threshold":
-			val, _ := strconv.Atoi(value)
+			val, _ := strconv.ParseInt(value, 10, 32)
 			report.AutovacuumAnalyzeThreshold = int32(val)
 		case "autovacuum_vacuum_scale_factor":
 			val, _ := strconv.ParseFloat(value, 64)
@@ -70,16 +70,16 @@ func GetVacuumStats(logger *util.Logger, db *sql.DB, ignoreRegexp string) (repor
 			val, _ := strconv.ParseFloat(value, 64)
 			report.AutovacuumAnalyzeScaleFactor = val
 		case "autovacuum_freeze_max_age":
-			val, _ := strconv.Atoi(value)
+			val, _ := strconv.ParseInt(value, 10, 32)
 			report.AutovacuumFreezeMaxAge = int32(val)
 		case "autovacuum_multixact_freeze_max_age":
-			val, _ := strconv.Atoi(value)
+			val, _ := strconv.ParseInt(value, 10, 32)
 			report.AutovacuumMultixactFreezeMaxAge = int32(val)
 		case "autovacuum_vacuum_cost_delay":
-			val, _ := strconv.Atoi(value)
+			val, _ := strconv.ParseInt(value, 10, 32)
 			report.AutovacuumVacuumCostDelay = int32(val)
 		case "autovacuum_vacuum_cost_limit":
-			val, _ := strconv.Atoi(value)
+			val, _ := strconv.ParseInt(value, 10, 32)
 			report.AutovacuumVacuumCostLimit = int32(val)
 		}
 	}
@@ -117,10 +117,10 @@ func GetVacuumStats(logger *util.Logger, db *sql.DB, ignoreRegexp string) (repor
 				case "autovacuum_enabled":
 					entry.AutovacuumEnabled = parts[1] == "on"
 				case "autovacuum_vacuum_threshold":
-					val, _ := strconv.Atoi(parts[1])
+					val, _ := strconv.ParseInt(parts[1], 10, 32)
 					entry.AutovacuumVacuumThreshold = int32(val)
 				case "autovacuum_analyze_threshold":
-					val, _ := strconv.Atoi(parts[1])
+					val, _ := strconv.ParseInt(parts[1], 10, 32)
 					entry.AutovacuumAnalyzeThreshold = int32(val)
 				case "autovacuum_vacuum_scale_factor":
 					val, _ := strconv.ParseFloat(parts[1], 64)
@@ -129,19 +129,19 @@ func GetVacuumStats(logger *util.Logger, db *sql.DB, ignoreRegexp string) (repor
 					val, _ := strconv.ParseFloat(parts[1], 64)
 					entry.AutovacuumAnalyzeScaleFactor = val
 				case "autovacuum_freeze_max_age":
-					val, _ := strconv.Atoi(parts[1])
+					val, _ := strconv.ParseInt(parts[1], 10, 32)
 					entry.AutovacuumFreezeMaxAge = int32(val)
 				case "autovacuum_multixact_freeze_max_age":
-					val, _ := strconv.Atoi(parts[1])
+					val, _ := strconv.ParseInt(parts[1], 10, 32)
 					entry.AutovacuumMultixactFreezeMaxAge = int32(val)
 				case "autovacuum_vacuum_cost_delay":
-					val, _ := strconv.Atoi(parts[1])
+					val, _ := strconv.ParseInt(parts[1], 10, 32)
 					entry.AutovacuumVacuumCostDelay = int32(val)
 				case "autovacuum_vacuum_cost_limit":
-					val, _ := strconv.Atoi(parts[1])
+					val, _ := strconv.ParseInt(parts[1], 10, 32)
 					entry.AutovacuumVacuumCostLimit = int32(val)
 				case "fillfactor":
-					val, _ := strconv.Atoi(parts[1])
+					val, _ := strconv.ParseInt(parts[1], 10, 32)
 					entry.Fillfactor = int32(val)
 				}
 			}

--- a/logs/analyze.go
+++ b/logs/analyze.go
@@ -1436,16 +1436,16 @@ func classifyAndSetDetails(logLine state.LogLine, statementLine state.LogLine, d
 				detailLine, parts = matchLogLine(detailLine, lockWait.detail)
 				if len(parts) == 3 {
 					logLine.RelatedPids = []int32{}
-					lockHolders := []int64{}
+					lockHolders := []int32{}
 					for _, s := range strings.Split(parts[1], ", ") {
-						i, _ := strconv.ParseInt(s, 10, 64)
-						lockHolders = append(lockHolders, i)
+						i, _ := strconv.ParseInt(s, 10, 32)
+						lockHolders = append(lockHolders, int32(i))
 						logLine.RelatedPids = append(logLine.RelatedPids, int32(i))
 					}
-					lockWaiters := []int64{}
+					lockWaiters := []int32{}
 					for _, s := range strings.Split(parts[2], ", ") {
-						i, _ := strconv.ParseInt(s, 10, 64)
-						lockWaiters = append(lockWaiters, i)
+						i, _ := strconv.ParseInt(s, 10, 32)
+						lockWaiters = append(lockWaiters, int32(i))
 						logLine.RelatedPids = append(logLine.RelatedPids, int32(i))
 					}
 					logLine.Details["lock_holders"] = lockHolders

--- a/logs/parse.go
+++ b/logs/parse.go
@@ -438,11 +438,11 @@ func ParseLogLineWithPrefix(prefix string, line string) (logLine state.LogLine, 
 		logLine.Application = appPart
 	}
 	if logLineNumberPart != "" {
-		logLineNumber, _ := strconv.Atoi(logLineNumberPart)
+		logLineNumber, _ := strconv.ParseInt(logLineNumberPart, 10, 32)
 		logLine.LogLineNumber = int32(logLineNumber)
 	}
 
-	backendPid, _ := strconv.Atoi(pidPart)
+	backendPid, _ := strconv.ParseInt(pidPart, 10, 32)
 	logLine.BackendPid = int32(backendPid)
 	logLine.Content = contentPart
 

--- a/state/postgres_relations.go
+++ b/state/postgres_relations.go
@@ -75,8 +75,10 @@ type PostgresConstraint struct {
 func (r PostgresRelation) Fillfactor() int32 {
 	fstr, exists := r.Options["fillfactor"]
 	if exists {
-		f, _ := strconv.Atoi(fstr)
-		return int32(f)
+		f, err := strconv.ParseInt(fstr, 10, 32)
+		if err == nil {
+			return int32(f)
+		}
 	}
 	return 100
 }
@@ -85,8 +87,10 @@ func (r PostgresRelation) Fillfactor() int32 {
 func (i PostgresIndex) Fillfactor() int32 {
 	fstr, exists := i.Options["fillfactor"]
 	if exists {
-		f, _ := strconv.Atoi(fstr)
-		return int32(f)
+		f, err := strconv.ParseInt(fstr, 10, 32)
+		if err == nil {
+			return int32(f)
+		}
 	}
 	if i.IndexType == "btree" {
 		return 90


### PR DESCRIPTION
As reported by CodeQL. Whilst in some situations this could be a
security-sensitive bug, none of the callsites here present problems -
but its a good practice to avoid unsafe casts.