### PR TITLE
Ensure temp files are cleaned up properly for RDS log processing

### DIFF
--- a/runner/logs.go
+++ b/runner/logs.go
@@ -140,7 +140,9 @@ func downloadLogsForServer(server *state.Server, globalCollectionOpts state.Coll
 	}
 
 	transientLogState := state.TransientLogState{CollectedAt: time.Now()}
-	defer transientLogState.Cleanup()
+	defer func() {
+		transientLogState.Cleanup()
+	}()
 
 	var newLogState state.PersistedLogState
 	newLogState, transientLogState.LogFiles, transientLogState.QuerySamples, err = system.DownloadLogFiles(server.LogPrevState, server.Config, logger)

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -140,9 +140,7 @@ func downloadLogsForServer(server *state.Server, globalCollectionOpts state.Coll
 	}
 
 	transientLogState := state.TransientLogState{CollectedAt: time.Now()}
-	defer func() {
-		transientLogState.Cleanup()
-	}()
+	defer transientLogState.Cleanup()
 
 	var newLogState state.PersistedLogState
 	newLogState, transientLogState.LogFiles, transientLogState.QuerySamples, err = system.DownloadLogFiles(server.LogPrevState, server.Config, logger)
@@ -228,9 +226,7 @@ func processLogStream(server *state.Server, logLines []state.LogLine, now time.T
 		logger.PrintError("%s", err)
 		return tooFreshLogLines
 	}
-	defer func() {
-		transientLogState.Cleanup()
-	}()
+	defer transientLogState.Cleanup()
 
 	transientLogState.LogFiles = []state.LogFile{logFile}
 

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -228,7 +228,9 @@ func processLogStream(server *state.Server, logLines []state.LogLine, now time.T
 		logger.PrintError("%s", err)
 		return tooFreshLogLines
 	}
-	defer transientLogState.Cleanup()
+	defer func() {
+		transientLogState.Cleanup()
+	}()
 
 	transientLogState.LogFiles = []state.LogFile{logFile}
 

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -296,7 +296,6 @@ func postprocessAndSendLogs(server *state.Server, globalCollectionOpts state.Col
 
 	err = output.UploadAndSendLogs(server, grant, globalCollectionOpts, logger, transientLogState)
 	if err != nil {
-		transientLogState.Cleanup()
 		return errors.Wrap(err, "failed to upload/send logs")
 	}
 

--- a/state/logs.go
+++ b/state/logs.go
@@ -176,14 +176,14 @@ type LogLine struct {
 	SecretMarkers      []LogSecretMarker
 }
 
-func (logFile LogFile) Cleanup() {
+func (logFile *LogFile) Cleanup() {
 	if logFile.TmpFile != nil {
 		logFile.TmpFile.Close()
 		os.Remove(logFile.TmpFile.Name())
 	}
 }
 
-func (ls TransientLogState) Cleanup() {
+func (ls *TransientLogState) Cleanup() {
 	for _, logFile := range ls.LogFiles {
 		logFile.Cleanup()
 	}


### PR DESCRIPTION
You can see this minimized in https://go.dev/play/p/pZo9NWTiN2n versus https://go.dev/play/p/Z2ODTVDTgSR . The problem is that we copy the struct at the site of the defer. When we later replace the LogFiles slice, the copy captured by the defer is not updated, so when we run Cleanup, it cleans up only the empty slice in the captured copy. Adding a wrapper function means the struct is only copied when the deferred function is executed.