### PR TITLE
Filter out vacuum records we cannot match to a table name

### DIFF
--- a/input/postgres/vacuum_progress.go
+++ b/input/postgres/vacuum_progress.go
@@ -80,7 +80,7 @@ SELECT (query_start_epoch || padded_pid)::bigint AS vacuum_identity,
 			 JOIN activity a USING (pid)
 			 LEFT JOIN pg_catalog.pg_class c ON (c.oid = v.relid)
 			 LEFT JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
- WHERE v.relid IS NOT NULL OR (a.query <> '<insufficient privilege>' AND a.nspname IS NOT NULL AND a.relname IS NOT NULL)
+ WHERE c.oid IS NOT NULL OR (a.query <> '<insufficient privilege>' AND a.nspname IS NOT NULL AND a.relname IS NOT NULL)
 `
 
 func GetVacuumProgress(logger *util.Logger, db *sql.DB, postgresVersion state.PostgresVersion, ignoreRegexp string) ([]state.PostgresVacuumProgress, error) {


### PR DESCRIPTION
Currently we ensure that we have a v.relid, but that does not
guarantee that we match an entry in pg_class or in our
pg_stat_activity query.

If we have no table name to report (e.g., because of a manual VACUUM
running in a different database), omit the record from the vacuum
progress output.

Alternately, we could try to match manual vacuums in pg_stat_activity
in addition to autovacuums--is there a reason we're not doing that?
