### PR TITLE
Docker image: Add tzdata package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN chmod +x $HOME_DIR/docker-entrypoint.sh
 
 FROM alpine:3.15 as slim
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates tzdata
 
 RUN adduser -D pganalyze pganalyze \ 
   && mkdir /state  \


### PR DESCRIPTION
This is required to allow timezone parsing during log line handling.