### PR TITLE
Check citus.shard_replication_factor before querying citus_table_size

### DIFF
--- a/input/postgres/relation_stats_ext.go
+++ b/input/postgres/relation_stats_ext.go
@@ -9,7 +9,11 @@ import (
 
 const citusRelationSizeSQL = `
 SELECT logicalrelid::oid,
-       pg_catalog.citus_table_size(logicalrelid)
+			 CASE
+			   WHEN coalesce(current_setting('citus.shard_replication_factor')::integer, 1) = 1
+				 THEN pg_catalog.citus_table_size(logicalrelid)
+				 ELSE 0
+			 END AS citus_table_size
 	FROM pg_catalog.pg_dist_partition dp
 			 INNER JOIN pg_catalog.pg_class c ON (dp.logicalrelid::oid = c.oid)
 			 INNER JOIN pg_catalog.pg_namespace n ON (c.relnamespace = n.oid)


### PR DESCRIPTION
The citus_table_size function errors out if
citus.shard_replication_factor is greater than 1. Since checking this
is part of the extended stats collection, a shard_replication_factor
greater than 1 means schema collection will fail.

Check the citus.shard_replication_factor parameter before invoking the
function. Fall back to 0 since the field is nut nullable in our
snapshot.