### PR TITLE
logging: add option for structured JSON logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -238,6 +238,7 @@ func main() {
 	var writeHeapProfile bool
 	var testRunAndTrace bool
 	var logToSyslog bool
+	var logToJSON bool
 	var logNoTimestamps bool
 	var reloadRun bool
 
@@ -252,6 +253,7 @@ func main() {
 	flag.BoolVar(&reloadRun, "reload", false, "Reloads the collector daemon thats running on the host")
 	flag.BoolVarP(&logger.Verbose, "verbose", "v", false, "Outputs additional debugging information, use this if you're encoutering errors or other problems")
 	flag.BoolVar(&logToSyslog, "syslog", false, "Write all log output to syslog instead of stderr (disabled by default)")
+	flag.BoolVar(&logToJSON, "json-logs", false, "Write all log output to stderr as newline delimited json (disabled by default, ignored if --syslog is set)")
 	flag.BoolVar(&logNoTimestamps, "no-log-timestamps", false, "Disable timestamps in the log output (automatically done when syslog is enabled)")
 	flag.BoolVar(&dryRun, "dry-run", false, "Print JSON data that would get sent to web service (without actually sending) and exit afterwards")
 	flag.BoolVar(&dryRunLogs, "dry-run-logs", false, "Print JSON data for log snapshot (without actually sending) and exit afterwards")
@@ -293,6 +295,7 @@ func main() {
 			panic(fmt.Errorf("Could not setup syslog as requested: %s", err))
 		}
 	} else {
+		logger.UseJSON = logToJSON
 		logger.Destination = log.New(os.Stderr, "", logFlags)
 	}
 

--- a/util/logger.go
+++ b/util/logger.go
@@ -1,8 +1,11 @@
 package util
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
+	"os"
+	"time"
 )
 
 type Logger struct {
@@ -12,6 +15,7 @@ type Logger struct {
 	Destination    *log.Logger
 	RememberErrors bool
 	ErrorMessages  []string
+	UseJSON        bool // if true, emit newline delimited JSON
 }
 
 func (logger *Logger) WithPrefix(prefix string) *Logger {
@@ -27,9 +31,36 @@ func (logger *Logger) print(logLevel string, format string, args ...interface{})
 		format = fmt.Sprintf("[%s] %s", *logger.Prefix, format)
 	}
 
-	format = fmt.Sprintf("%s %s", logLevel, format)
+	if logger.UseJSON {
+		logger.printJSON(logLevel, format, args...)
+		return
+	}
 
+	format = fmt.Sprintf("%s %s", logLevel, format)
 	logger.Destination.Printf(format, args...)
+}
+
+func (logger *Logger) printJSON(logLevel string, format string, args ...interface{}) {
+	severity := "DEFAULT"
+	switch logLevel {
+	case "I":
+		severity = "INFO"
+	case "V":
+		severity = "DEBUG"
+	case "E":
+		severity = "ERROR"
+	case "W":
+		severity = "WARNING"
+	}
+	entry := jsonLogEntry{
+		Severity: severity,
+		Message:  fmt.Sprintf(format, args...),
+		Time:     time.Now().Format(time.RFC3339Nano),
+	}
+	bs, _ := json.Marshal(entry)
+	bs = append(bs, '\n')
+	_, _ = os.Stderr.Write(bs)
+	return
 }
 
 func (logger *Logger) PrintVerbose(format string, args ...interface{}) {
@@ -58,4 +89,10 @@ func (logger *Logger) PrintError(format string, args ...interface{}) {
 	}
 
 	logger.print("E", format, args...)
+}
+
+type jsonLogEntry struct {
+	Severity string `json:"severity,omitempty"`
+	Message  string `json:"message,omitempty"`
+	Time     string `json:"time,omitempty"`
 }


### PR DESCRIPTION
Add support for emitting logs as newline-delimited JSON with a bit of
structure matching the GCP stackdriver conventions [1]. I didn't use a library
like zerolog or zap because it seemed way overkill since there's already
a logging facade with util.logger, and we just need a way to dump output
to stderr.

[1]: https://cloud.google.com/logging/docs/structured-logging

Output looks like:

```json
{"severity":"INFO","message":"Running collector test with pganalyze-collector 0.43.0","time":"2022-04-19T12:31:05.100489-07:00"}
```

Future work could include:

- Using a more allocation efficient JSON encoder in place of Go's standard JSON
  library. The format is simple enough that it's tempting to roll our own.

- Capturing more structured data like source-code location.

Fixes #261. 