### PR TITLE
Fix Heroku environment parsing

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -488,7 +488,7 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 	} else {
 		if os.Getenv("DYNO") != "" && os.Getenv("PORT") != "" {
 			for _, kv := range os.Environ() {
-				parts := strings.Split(kv, "=")
+				parts := strings.SplitN(kv, "=", 2)
 				if strings.HasSuffix(parts[0], "_URL") {
 					config := getDefaultConfig()
 					config, err = preprocessConfig(config)


### PR DESCRIPTION
Due to Go's primitive os.Environ(), we do not correctly parse
environment variables whose values contain equal signs on Heroku. This
means the collector does not work with the new Heroku Postgres
Enhanced Certificates [1] or any other database URLs containing query
parameters.

Fix the parsing to correctly handle equal signs.

[1]: https://devcenter.heroku.com/articles/heroku-postgres-enhanced-certificates
