### PR TITLE
Log database name in column-stats-helper-missing warning

### DIFF
--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -182,9 +182,11 @@ func GetColumnStats(logger *util.Logger, db *sql.DB, globalCollectionOpts state.
 		sourceTable = "pganalyze.get_column_stats()"
 	} else {
 		if systemType != "heroku" && !connectedAsSuperUser(db, systemType) && globalCollectionOpts.TestRun {
-			logger.PrintInfo("Warning: Limited access to table column statistics detected. Please setup" +
-				" the monitoring helper function pganalyze.get_column_stats (https://github.com/pganalyze/collector#setting-up-a-restricted-monitoring-user)" +
-				" or connect as superuser, to get column statistics for all tables.")
+			var currentDb string
+			db.QueryRow(QueryMarkerSQL + "SELECT current_database()").Scan(&currentDb)
+			logger.PrintInfo("Warning: Limited access to table column statistics detected in database %s. Please set up"+
+				" the monitoring helper function pganalyze.get_column_stats (https://github.com/pganalyze/collector#setting-up-a-restricted-monitoring-user)"+
+				" or connect as superuser, to get column statistics for all tables.", currentDb)
 		}
 		sourceTable = "pg_catalog.pg_stats"
 	}

--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -171,7 +171,7 @@ func GetIndexStats(db *sql.DB, postgresVersion state.PostgresVersion, ignoreRege
 	return
 }
 
-func GetColumnStats(logger *util.Logger, db *sql.DB, globalCollectionOpts state.CollectionOpts, systemType string) (columnStats state.PostgresColumnStatsMap, err error) {
+func GetColumnStats(logger *util.Logger, db *sql.DB, globalCollectionOpts state.CollectionOpts, systemType string, dbName string) (columnStats state.PostgresColumnStatsMap, err error) {
 	var sourceTable string
 
 	helperExists := false
@@ -182,11 +182,9 @@ func GetColumnStats(logger *util.Logger, db *sql.DB, globalCollectionOpts state.
 		sourceTable = "pganalyze.get_column_stats()"
 	} else {
 		if systemType != "heroku" && !connectedAsSuperUser(db, systemType) && globalCollectionOpts.TestRun {
-			var currentDb string
-			db.QueryRow(QueryMarkerSQL + "SELECT current_database()").Scan(&currentDb)
 			logger.PrintInfo("Warning: Limited access to table column statistics detected in database %s. Please set up"+
 				" the monitoring helper function pganalyze.get_column_stats (https://github.com/pganalyze/collector#setting-up-a-restricted-monitoring-user)"+
-				" or connect as superuser, to get column statistics for all tables.", currentDb)
+				" or connect as superuser, to get column statistics for all tables.", dbName)
 		}
 		sourceTable = "pg_catalog.pg_stats"
 	}


### PR DESCRIPTION
This helper must be installed in each database separately, but the
current warning does not say where the problem is.

Include the database name in the warning.
