### PR TITLE
Log test: Don't count Heroku Free Tier as hard failure (different prefix)

### DIFF
--- a/logs/parse.go
+++ b/logs/parse.go
@@ -93,6 +93,7 @@ var RsyslogRegexp = regexp.MustCompile(`^` + RsyslogTimeRegexp + ` ` + RsyslogHo
 
 // The Heroku log_line_prefix is handled directly in the Heroku log receiver, included here for reference only
 var HerokuLogLinePrefix = " sql_error_code = %e "
+var HerokuLogLinePrefixFreeTier = " database = %d connection_source = %r sql_error_code = %e " // Used only to allow log_line_prefix checks to pass
 var HerokuPostgresDebugRegexp = regexp.MustCompile(`^(\w+ \d+ \d+:\d+:\d+ \w+ app\[postgres\] \w+ )?\[(\w+)\] \[\d+-\d+\] ( sql_error_code = ` + SqlstateRegexp + ` (\w+):  )?(.+)`)
 
 func IsSupportedPrefix(prefix string) bool {

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -321,7 +321,12 @@ func TestLogsForAllServers(servers []*state.Server, globalCollectionOpts state.C
 			prefixedLogger.PrintError("ERROR - Could not check log_line_prefix for server: %s", err)
 			hasFailedServers = true
 			continue
-		} else if !logs.IsSupportedPrefix(logLinePrefix) && !(server.Config.SystemType == "heroku" && logLinePrefix == logs.HerokuLogLinePrefix) {
+		} else if server.Config.SystemType == "heroku" && logLinePrefix == logs.HerokuLogLinePrefix {
+			// Special cased in the Heroku log handling (but not a supported log_line_prefix otherwise)
+		} else if server.Config.SystemType == "heroku" && logLinePrefix == logs.HerokuLogLinePrefixFreeTier {
+			prefixedLogger.PrintWarning("WARNING - Detected log_line_prefix indicates Heroku Postgres Free Tier, which has no log output support")
+			continue
+		} else if !logs.IsSupportedPrefix(logLinePrefix) {
 			prefixedLogger.PrintError("ERROR - Unsupported log_line_prefix setting: '%s'", logLinePrefix)
 			hasFailedServers = true
 			continue


### PR DESCRIPTION
We can't support log monitoring for Heroku Postgres' free tier, since
the log stream is not exported (intentionally, by Heroku), but previously
we would fail when running the test function, which may not be desirable
when multiple databases are mounted to the same collector application.

Instead emit a warning when the special log_line_prefix used by the
free tier is detected.