### PR TITLE
Improve the "too many tables" error message

### DIFF
--- a/input/postgres/schema.go
+++ b/input/postgres/schema.go
@@ -54,7 +54,7 @@ func CollectAllSchemas(server *state.Server, collectionOpts state.CollectionOpts
 		schemaTableLimit = defaultSchemaTableLimit
 	}
 	if relCount := len(ps.Relations); relCount > schemaTableLimit {
-		logger.PrintWarning("Too many tables: got %d, but only %d can be monitored per server; use ignore_schema_regexp config setting to filter", relCount, schemaTableLimit)
+		logger.PrintWarning("Too many tables: got %d, but only %d can be monitored per server; schema information will be lost; learn more at https://pganalyze.com/docs/collector/settings#schema-filter-settings", relCount, schemaTableLimit)
 	}
 
 	return ps, ts


### PR DESCRIPTION
This error message does not make it clear (1) what the consequences are and (2) what you can do about it.

Attempt to address both of these by clarifying the impact and including a link.