### PR TITLE
Package repo: Verify debian/ubuntu signatures after package updates

### DIFF
--- a/packages/repo/sync_deb.sh
+++ b/packages/repo/sync_deb.sh
@@ -39,3 +39,13 @@ mkdir -p /repo/debian/bullseye/conf
 cp /root/deb.distributions /repo/debian/bullseye/conf/distributions
 reprepro --basedir /repo/debian/bullseye includedeb stable /deb/systemd/$DEB_PACKAGE_X86_64
 reprepro --basedir /repo/debian/bullseye includedeb stable /deb/systemd/$DEB_PACKAGE_ARM64
+
+# Verify signatures
+apt-key add /repo/pganalyze_signing_key.asc
+gpgv --keyring /etc/apt/trusted.gpg /repo/ubuntu/xenial/dists/stable/InRelease
+gpgv --keyring /etc/apt/trusted.gpg /repo/ubuntu/bionic/dists/stable/InRelease
+gpgv --keyring /etc/apt/trusted.gpg /repo/ubuntu/focal/dists/stable/InRelease
+gpgv --keyring /etc/apt/trusted.gpg /repo/debian/jessie/dists/stable/InRelease
+gpgv --keyring /etc/apt/trusted.gpg /repo/debian/stretch/dists/stable/InRelease
+gpgv --keyring /etc/apt/trusted.gpg /repo/debian/buster/dists/stable/InRelease
+gpgv --keyring /etc/apt/trusted.gpg /repo/debian/bullseye/dists/stable/InRelease


### PR DESCRIPTION
There can be cosmic ray type errors from time to time causing bad
signatures - this ensures the signatures we made are actually valid, and
stops the build process if they are not.