### PR TITLE
Add support for new Heroku log_line_prefix

### DIFF
--- a/input/system/heroku/logs.go
+++ b/input/system/heroku/logs.go
@@ -154,24 +154,24 @@ func logStreamItemToLogLine(item HerokuLogStreamItem, servers []*state.Server, s
 	}
 	backendPid, _ := strconv.ParseInt(parts[1], 10, 32)
 
-	contentParts := regexp.MustCompile(`^\[(\w+)\] \[(\d+)-(\d+)\] (.+)`).FindStringSubmatch(string(item.Content))
-	if len(contentParts) != 5 {
+	lineParts := regexp.MustCompile(`^\[(\w+)\] \[(\d+)-(\d+)\] (.+)`).FindStringSubmatch(string(item.Content))
+	if len(lineParts) != 5 {
 		fmt.Printf("ERR: %s\n", string(item.Content))
 		return sourceToServer, nil, ""
 	}
 
-	sourceName := contentParts[1]
+	sourceName := lineParts[1]
 	if !strings.HasPrefix(sourceName, "HEROKU_POSTGRESQL_") {
 		sourceName = "HEROKU_POSTGRESQL_" + sourceName
 	}
 	sourceName = namespace + " / " + sourceName
-	logLineNumber, _ := strconv.ParseInt(contentParts[2], 10, 32)
-	logLineNumberChunk, _ := strconv.ParseInt(contentParts[3], 10, 32)
-	content := contentParts[4]
+	logLineNumber, _ := strconv.ParseInt(lineParts[2], 10, 32)
+	logLineNumberChunk, _ := strconv.ParseInt(lineParts[3], 10, 32)
+	prefixedContent := lineParts[4]
 
-	sourceToServer = catchIdentifyServerLine(sourceName, content, sourceToServer, servers)
+	logLine, _ := logs.ParseLogLineWithPrefix("", prefixedContent+"\n")
 
-	logLine, _ := logs.ParseLogLineWithPrefix("", content+"\n")
+	sourceToServer = catchIdentifyServerLine(sourceName, logLine.Content, sourceToServer, servers)
 
 	logLine.OccurredAt = timestamp
 	logLine.BackendPid = int32(backendPid)

--- a/input/system/heroku/logs.go
+++ b/input/system/heroku/logs.go
@@ -173,7 +173,7 @@ func logStreamItemToLogLine(item HerokuLogStreamItem, servers []*state.Server, s
 	}
 	backendPid, _ := strconv.ParseInt(parts[1], 10, 32)
 
-	contentParts := regexp.MustCompile(`^\[(\w+)\] \[(\d+)-(\d+)\] ( sql_error_code = \w+ (\w+):  )?(.+)`).FindStringSubmatch(string(item.Content))
+	contentParts := regexp.MustCompile(`^\[(\w+)\] \[(\d+)-(\d+)\] (?:( sql_error_code = \w+ (\w+):  )|( sql_error_code = \w+ time_ms = ".+?" pid=".+?" proc_start_time=".+?" session_id=".+?" vtid=".+?" tid=".+?" log_line=".+?" .+?database=".+?" connection_source=".+?" user=".+?" application_name=".+?" ))?(.+)`).FindStringSubmatch(string(item.Content))
 	if len(contentParts) != 7 {
 		fmt.Printf("ERR: %s\n", string(item.Content))
 		return sourceToServer, nil, ""

--- a/input/system/heroku/logs.go
+++ b/input/system/heroku/logs.go
@@ -173,7 +173,7 @@ func logStreamItemToLogLine(item HerokuLogStreamItem, servers []*state.Server, s
 	}
 	backendPid, _ := strconv.ParseInt(parts[1], 10, 32)
 
-	contentParts := regexp.MustCompile(`^\[(\w+)\] \[(\d+)-(\d+)\] (?:( sql_error_code = \w+ (\w+):  )|( sql_error_code = \w+ time_ms = ".+?" pid=".+?" proc_start_time=".+?" session_id=".+?" vtid=".+?" tid=".+?" log_line=".+?" .+?database=".+?" connection_source=".+?" user=".+?" application_name=".+?" ))?(.+)`).FindStringSubmatch(string(item.Content))
+	contentParts := regexp.MustCompile(`^\[(\w+)\] \[(\d+)-(\d+)\] ((?: sql_error_code = \w+ (\w+):  )|(?: sql_error_code = \w+ time_ms = ".+?" pid=".+?" proc_start_time=".+?" session_id=".+?" vtid=".+?" tid=".+?" log_line=".+?" .+?database=".+?" connection_source=".+?" user=".+?" application_name=".+?" ))?(.+)`).FindStringSubmatch(string(item.Content))
 	if len(contentParts) != 7 {
 		fmt.Printf("ERR: %s\n", string(item.Content))
 		return sourceToServer, nil, ""

--- a/logs/parse.go
+++ b/logs/parse.go
@@ -31,6 +31,12 @@ const LogPrefixCustom12 string = "user=%u,db=%d,app=%a,client=%h "
 const LogPrefixCustom13 string = "%p-%s-%c-%l-%h-%u-%d-%m "
 const LogPrefixCustom14 string = "%m [%p][%b][%v][%x] %q[user=%u,db=%d,app=%a] "
 const LogPrefixSimple string = "%m [%p] "
+const LogPrefixHeroku1 string = " sql_error_code = %e "
+const LogPrefixHeroku2 string = ` sql_error_code = %e time_ms = "%m" pid="%p" proc_start_time="%s" session_id="%c" vtid="%v" tid="%x" log_line="%l" %qdatabase="%d" connection_source="%r" user="%u" application_name="%a" `
+
+// Used only to recognize the Heroku hobby tier log_line_prefix to give a warning (logs are not supported
+// on hobby tier) and avoid errors during prefix check; logs with this prefix are never actually received
+const LogPrefixHerokuHobbyTier string = " database = %d connection_source = %r sql_error_code = %e "
 const LogPrefixEmpty string = ""
 
 var RecommendedPrefixIdx = 4
@@ -40,7 +46,7 @@ var SupportedPrefixes = []string{
 	LogPrefixCustom3, LogPrefixCustom4, LogPrefixCustom5, LogPrefixCustom6,
 	LogPrefixCustom7, LogPrefixCustom8, LogPrefixCustom9, LogPrefixCustom10,
 	LogPrefixCustom11, LogPrefixCustom12, LogPrefixCustom13, LogPrefixCustom14,
-	LogPrefixSimple, LogPrefixEmpty,
+	LogPrefixSimple, LogPrefixHeroku1, LogPrefixHeroku2, LogPrefixEmpty,
 }
 
 // Every one of these regexps should produce exactly one matching group
@@ -51,6 +57,7 @@ var UserRegexp = `(\S*)`                                                     // 
 var DbRegexp = `(\S*)`                                                       // %d
 var AppBeforeSpaceRegexp = `(\S*)`                                           // %a
 var AppBeforeCommaRegexp = `([^,]*)`                                         // %a
+var AppBeforeQuoteRegexp = `([^"]*)`                                         // %a
 var AppInsideBracketsRegexp = `(\[unknown\]|[^,\]]*)`                        // %a
 var HostRegexp = `(\S*)`                                                     // %h
 var VirtualTxRegexp = `(\d+/\d+)?`                                           // %v
@@ -82,6 +89,8 @@ var LogPrefixCustom13Regexp = regexp.MustCompile(`(?s)^` + PidRegexp + `-` + Tim
 var LogPrefixCustom14Regexp = regexp.MustCompile(`(?s)^` + TimeRegexp + ` \[` + PidRegexp + `\]\[` + BackendTypeRegexp + `\]\[` + VirtualTxRegexp + `\]\[` + TransactionIdRegexp + `\] (?:\[user=` + UserRegexp + `,db=` + DbRegexp + `,app=` + AppInsideBracketsRegexp + `\] )?` + LevelAndContentRegexp)
 var LogPrefixSimpleRegexp = regexp.MustCompile(`(?s)^` + TimeRegexp + ` \[` + PidRegexp + `\] ` + LevelAndContentRegexp)
 var LogPrefixNoTimestampUserDatabaseAppRegexp = regexp.MustCompile(`(?s)^\[user=` + UserRegexp + `,db=` + DbRegexp + `,app=` + AppInsideBracketsRegexp + `\] ` + LevelAndContentRegexp)
+var LogPrefixHeroku1Regexp = regexp.MustCompile(`^ sql_error_code = ` + SqlstateRegexp + " " + LevelAndContentRegexp)
+var LogPrefixHeroku2Regexp = regexp.MustCompile(`^ sql_error_code = ` + SqlstateRegexp + ` time_ms = "` + TimeRegexp + `" pid="` + PidRegexp + `" proc_start_time="` + TimeRegexp + `" session_id="` + SessionIdRegexp + `" vtid="` + VirtualTxRegexp + `" tid="` + TransactionIdRegexp + `" log_line="` + LogLineCounterRegexp + `" (?:database="` + DbRegexp + `" connection_source="` + HostAndPortRegexp + `" user="` + UserRegexp + `" application_name="` + AppBeforeQuoteRegexp + `" )?` + LevelAndContentRegexp)
 
 var SyslogSequenceAndSplitRegexp = `(\[[\d-]+\])?`
 
@@ -91,11 +100,7 @@ var RsyslogHostnameRegxp = `(\S+)`
 var RsyslogProcessNameRegexp = `(\w+)`
 var RsyslogRegexp = regexp.MustCompile(`^` + RsyslogTimeRegexp + ` ` + RsyslogHostnameRegxp + ` ` + RsyslogProcessNameRegexp + `\[` + PidRegexp + `\]: ` + SyslogSequenceAndSplitRegexp + ` ` + RsyslogLevelAndContentRegexp)
 
-// The Heroku log_line_prefix is handled directly in the Heroku log receiver, included here for reference only
-var HerokuLogLinePrefix = " sql_error_code = %e "
-var HerokuLogLinePrefixNew = ` sql_error_code = %e time_ms = "%m" pid="%p" proc_start_time="%s" session_id="%c" vtid="%v" tid="%x" log_line="%l" %qdatabase="%d" connection_source="%r" user="%u" application_name="%a" `
-var HerokuLogLinePrefixFreeTier = " database = %d connection_source = %r sql_error_code = %e " // Used only to allow log_line_prefix checks to pass
-var HerokuPostgresDebugRegexp = regexp.MustCompile(`^(\w+ \d+ \d+:\d+:\d+ \w+ app\[postgres\] \w+ )?\[(\w+)\] \[\d+-\d+\] ( sql_error_code = ` + SqlstateRegexp + ` (\w+):  )?(.+)`)
+var HerokuPostgresDebugRegexp = regexp.MustCompile(`^(\w+ \d+ \d+:\d+:\d+ \w+ app\[postgres\] \w+ )?\[(\w+)\] \[\d+-\d+\] (.+)`)
 
 func IsSupportedPrefix(prefix string) bool {
 	for _, supportedPrefix := range SupportedPrefixes {
@@ -150,6 +155,11 @@ func ParseLogLineWithPrefix(prefix string, line string) (logLine state.LogLine, 
 			prefix = LogPrefixCustom14
 		} else if LogPrefixSimpleRegexp.MatchString(line) {
 			prefix = LogPrefixSimple
+		} else if LogPrefixHeroku2Regexp.MatchString(line) {
+			prefix = LogPrefixHeroku2
+		} else if LogPrefixHeroku1Regexp.MatchString(line) {
+			// LogPrefixHeroku1 is a subset of 2, so it must be matched second
+			prefix = LogPrefixHeroku1
 		} else if RsyslogRegexp.MatchString(line) {
 			rsyslog = true
 		}
@@ -391,6 +401,33 @@ func ParseLogLineWithPrefix(prefix string, line string) (logLine state.LogLine, 
 			pidPart = parts[2]
 			levelPart = parts[3]
 			contentPart = parts[4]
+		case LogPrefixHeroku1:
+			parts := LogPrefixHeroku1Regexp.FindStringSubmatch(line)
+			if len(parts) == 0 {
+				return
+			}
+			// skip %e
+			levelPart = parts[2]
+			contentPart = parts[3]
+		case LogPrefixHeroku2:
+			parts := LogPrefixHeroku2Regexp.FindStringSubmatch(line)
+			if len(parts) == 0 {
+				return
+			}
+			// skip %e
+			timePart = parts[2]
+			pidPart = parts[3]
+			// skip %s
+			// skip %c
+			// skip %v
+			// skip %x
+			logLineNumberPart = parts[8]
+			dbPart = parts[9]
+			// skip %r
+			userPart = parts[11]
+			appPart = parts[12]
+			levelPart = parts[13]
+			contentPart = parts[14]
 		default:
 			// Some callers use the content of unparsed lines to stitch multi-line logs together
 			logLine.Content = line
@@ -529,27 +566,22 @@ func DebugParseAndAnalyzeBuffer(buffer string) ([]state.LogLine, []state.Postgre
 
 		contentParts := HerokuPostgresDebugRegexp.FindStringSubmatch(line)
 		var logLine state.LogLine
-		if len(contentParts) == 7 {
-			logLine.Content = contentParts[6]
-			if contentParts[4] != "" && contentParts[5] != "" { // We have a SQLSTATE and a log level, so its a new Postgres log line
-				logLine.LogLevel = pganalyze_collector.LogLineInformation_LogLevel(pganalyze_collector.LogLineInformation_LogLevel_value[contentParts[5]])
-			} else {
+		var lineContent string
+		if len(contentParts) == 4 {
+			lineContent = contentParts[3]
+		} else {
+			lineContent = line
+		}
+		var ok bool
+		logLine, ok = ParseLogLineWithPrefix("", lineContent)
+		if !ok {
+			// Assume that a parsing error in a follow-on line means that we actually
+			// got additional data for the previous line
+			if len(logLines) > 0 && logLine.Content != "" {
 				logLines[len(logLines)-1].Content += logLine.Content
 				logLines[len(logLines)-1].ByteEnd += int64(len(logLine.Content))
-				continue
 			}
-		} else {
-			var ok bool
-			logLine, ok = ParseLogLineWithPrefix("", line)
-			if !ok {
-				// Assume that a parsing error in a follow-on line means that we actually
-				// got additional data for the previous line
-				if len(logLines) > 0 && logLine.Content != "" {
-					logLines[len(logLines)-1].Content += logLine.Content
-					logLines[len(logLines)-1].ByteEnd += int64(len(logLine.Content))
-				}
-				continue
-			}
+			continue
 		}
 
 		logLine.ByteStart = byteStart

--- a/logs/parse.go
+++ b/logs/parse.go
@@ -93,6 +93,7 @@ var RsyslogRegexp = regexp.MustCompile(`^` + RsyslogTimeRegexp + ` ` + RsyslogHo
 
 // The Heroku log_line_prefix is handled directly in the Heroku log receiver, included here for reference only
 var HerokuLogLinePrefix = " sql_error_code = %e "
+var HerokuLogLinePrefixNew = ` sql_error_code = %e time_ms = "%m" pid="%p" proc_start_time="%s" session_id="%c" vtid="%v" tid="%x" log_line="%l" %qdatabase="%d" connection_source="%r" user="%u" application_name="%a" `
 var HerokuLogLinePrefixFreeTier = " database = %d connection_source = %r sql_error_code = %e " // Used only to allow log_line_prefix checks to pass
 var HerokuPostgresDebugRegexp = regexp.MustCompile(`^(\w+ \d+ \d+:\d+:\d+ \w+ app\[postgres\] \w+ )?\[(\w+)\] \[\d+-\d+\] ( sql_error_code = ` + SqlstateRegexp + ` (\w+):  )?(.+)`)
 

--- a/logs/parse_test.go
+++ b/logs/parse_test.go
@@ -450,6 +450,29 @@ var parseTests = []parseTestpair{
 		},
 		true,
 	},
+	{
+		"",
+		` sql_error_code = 28000 FATAL:  no pg_hba.conf entry for host "127.0.0.1", user "postgres", database "postgres", SSL off`,
+		state.LogLine{
+			LogLevel: pganalyze_collector.LogLineInformation_FATAL,
+			Content:  "no pg_hba.conf entry for host \"127.0.0.1\", user \"postgres\", database \"postgres\", SSL off",
+		},
+		true,
+	},
+	{
+		"",
+		` sql_error_code = 28000 time_ms = "2022-06-02 22:48:20.807 UTC" pid="11666" proc_start_time="2022-06-02 22:48:20 UTC" session_id="62993e34.2d92" vtid="6/17007" tid="0" log_line="1" database="postgres" connection_source="127.0.0.1(36532)" user="postgres" application_name="[unknown]" FATAL:  no pg_hba.conf entry for host "127.0.0.1", user "postgres", database "postgres", SSL off`,
+		state.LogLine{
+			OccurredAt:    time.Date(2022, time.June, 2, 22, 48, 20, 807*1000*1000, time.UTC),
+			Username:      "postgres",
+			Database:      "postgres",
+			LogLevel:      pganalyze_collector.LogLineInformation_FATAL,
+			BackendPid:    11666,
+			LogLineNumber: 1,
+			Content:       "no pg_hba.conf entry for host \"127.0.0.1\", user \"postgres\", database \"postgres\", SSL off",
+		},
+		true,
+	},
 }
 
 func TestParseLogLineWithPrefix(t *testing.T) {

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -322,10 +322,8 @@ func TestLogsForAllServers(servers []*state.Server, globalCollectionOpts state.C
 			prefixedLogger.PrintError("ERROR - Could not check log_line_prefix for server: %s", err)
 			hasFailedServers = true
 			continue
-		} else if server.Config.SystemType == "heroku" && (logLinePrefix == logs.HerokuLogLinePrefix || logLinePrefix == logs.HerokuLogLinePrefixNew) {
-			// Special cased in the Heroku log handling (but not a supported log_line_prefix otherwise)
-		} else if server.Config.SystemType == "heroku" && logLinePrefix == logs.HerokuLogLinePrefixFreeTier {
-			prefixedLogger.PrintWarning("WARNING - Detected log_line_prefix indicates Heroku Postgres Free Tier, which has no log output support")
+		} else if server.Config.SystemType == "heroku" && logLinePrefix == logs.LogPrefixHerokuHobbyTier {
+			prefixedLogger.PrintWarning("WARNING - Detected log_line_prefix indicates Heroku Postgres Hobby tier, which has no log output support")
 			continue
 		} else if !logs.IsSupportedPrefix(logLinePrefix) {
 			prefixedLogger.PrintError("ERROR - Unsupported log_line_prefix setting: '%s'", logLinePrefix)

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -322,7 +322,7 @@ func TestLogsForAllServers(servers []*state.Server, globalCollectionOpts state.C
 			prefixedLogger.PrintError("ERROR - Could not check log_line_prefix for server: %s", err)
 			hasFailedServers = true
 			continue
-		} else if server.Config.SystemType == "heroku" && logLinePrefix == logs.HerokuLogLinePrefix {
+		} else if server.Config.SystemType == "heroku" && (logLinePrefix == logs.HerokuLogLinePrefix || logLinePrefix == logs.HerokuLogLinePrefixNew) {
 			// Special cased in the Heroku log handling (but not a supported log_line_prefix otherwise)
 		} else if server.Config.SystemType == "heroku" && logLinePrefix == logs.HerokuLogLinePrefixFreeTier {
 			prefixedLogger.PrintWarning("WARNING - Detected log_line_prefix indicates Heroku Postgres Free Tier, which has no log output support")


### PR DESCRIPTION
Update the collector to support new Heroku log_line_prefix

Heroku recently updated the log_line_prefix on their new databases
[1]. Through regular maintenance, this new prefix will eventually come
to old databases as well. The new prefix is rejected by the collector
test and not parsed correctly by the log processing code.

Update the Heroku-specific code path to accept this new prefix as
well.

[1]: https://devcenter.heroku.com/changelog-items/2419
