### PR TITLE
Google Cloud SQL: Re-enable log stitching for messages

### DIFF
--- a/input/system/google_cloudsql/logs.go
+++ b/input/system/google_cloudsql/logs.go
@@ -156,14 +156,12 @@ func setupLogTransformer(ctx context.Context, wg *sync.WaitGroup, servers []*sta
 					return
 				}
 
+				// We ignore failures here since we want the per-backend stitching logic
+				// that runs later on (and any other parsing errors will just be ignored).
 				// Note that we need to restore the original trailing newlines since
 				// ProcessLogStream below expects them and they are not present in the GCP
 				// log stream.
-				logLine, ok := logs.ParseLogLineWithPrefix("", in.Content+"\n")
-				if !ok {
-					logger.PrintError("Can't parse log line: \"%s\"", in.Content)
-					continue
-				}
+				logLine, _ := logs.ParseLogLineWithPrefix("", in.Content+"\n")
 				logLine.OccurredAt = in.OccurredAt
 
 				// Ignore loglines which are outside our time window

--- a/logs/stream/stream.go
+++ b/logs/stream/stream.go
@@ -37,10 +37,12 @@ import (
 //
 // Google Cloud SQL log data looks like this:
 // - Not correctly ordered (lines from Pub/Sub may arrive in any order)
-// - All lines have a timestamp
-// - Always has the log line number, allowing association of related log lines
-// - Multi-line messages are already combined together
-//   (as of Sept 14, 2021 - see https://cloud.google.com/sql/docs/release-notes#September_14_2021)
+// - All lines have a timestamp (taken from the Timestamp field in the original Cloud Logging message)
+// - First line of a message always has log line number (due to fixed log_line_prefix)
+// - Log events split across multiple log messages only have the PID and line number in the first message,
+//   may arrive out of order, but have a timestamp that is correctly ordering each part of the log event
+// - Split log events are rare (as of Sept 14, 2021 - see https://cloud.google.com/sql/docs/release-notes#September_14_2021),
+//   but can still happen if the log data is too big (cutoff appears to be around 1000-2000 lines, or ~100kb of data)
 
 const InvalidPid int32 = -1
 const UnknownPid int32 = 0

--- a/logs/stream/stream_test.go
+++ b/logs/stream/stream_test.go
@@ -193,7 +193,7 @@ var streamTests = []streamTestpair{
 		[]state.LogLine{},
 		nil,
 	},
-	// Multiple lines not concatenated yet (use case for self-managed systems)
+	// Multiple lines not concatenated yet (use case for self-managed systems and long texts on GCP)
 	{
 		[]state.LogLine{
 			{
@@ -253,6 +253,36 @@ var streamTests = []streamTestpair{
 			},
 		},
 		"zero\nfirst\nsecond\nthird\n",
+		[]state.LogLine{},
+		nil,
+	},
+	// Multiple lines not concatenated yet (out of order messages, can occur for long texts on GCP)
+	{
+		[]state.LogLine{{
+			CollectedAt: now.Add(-5 * time.Second),
+			OccurredAt: now.Add(-4 * time.Second),
+			Content:     " );\n",
+		},
+			{
+				CollectedAt: now.Add(-4 * time.Second),
+				OccurredAt: now.Add(-5 * time.Second),
+				LogLevel:    pganalyze_collector.LogLineInformation_LOG,
+				LogLineNumber: 2,
+				BackendPid:    42,
+				Content:     "LOG:  duration: 10010.397 ms  statement: SELECT pg_sleep(10\n",
+			}},
+		state.TransientLogState{},
+		state.LogFile{
+			LogLines: []state.LogLine{{
+				CollectedAt:   now.Add(-4 * time.Second),
+				OccurredAt:    now.Add(-5 * time.Second),
+				LogLevel:      pganalyze_collector.LogLineInformation_LOG,
+				ByteEnd:       64,
+				LogLineNumber: 2,
+				BackendPid:    42,
+			}},
+		},
+		"LOG:  duration: 10010.397 ms  statement: SELECT pg_sleep(10\n );\n",
 		[]state.LogLine{},
 		nil,
 	},

--- a/logs/stream/stream_test.go
+++ b/logs/stream/stream_test.go
@@ -260,16 +260,16 @@ var streamTests = []streamTestpair{
 	{
 		[]state.LogLine{{
 			CollectedAt: now.Add(-5 * time.Second),
-			OccurredAt: now.Add(-4 * time.Second),
+			OccurredAt:  now.Add(-4 * time.Second),
 			Content:     " );\n",
 		},
 			{
-				CollectedAt: now.Add(-4 * time.Second),
-				OccurredAt: now.Add(-5 * time.Second),
-				LogLevel:    pganalyze_collector.LogLineInformation_LOG,
+				CollectedAt:   now.Add(-4 * time.Second),
+				OccurredAt:    now.Add(-5 * time.Second),
+				LogLevel:      pganalyze_collector.LogLineInformation_LOG,
 				LogLineNumber: 2,
 				BackendPid:    42,
-				Content:     "LOG:  duration: 10010.397 ms  statement: SELECT pg_sleep(10\n",
+				Content:       "LOG:  duration: 10010.397 ms  statement: SELECT pg_sleep(10\n",
 			}},
 		state.TransientLogState{},
 		state.LogFile{


### PR DESCRIPTION
Whilst the GCP release notes mention that this is no longer a problem as of
Sept 2021, log events can still be split up into multiple messages if they
exceed a threshold around 1000-2000 lines, or ~100kb.

In order to fix message like this, re-enable the logic that was previously
turned off in commit 735d95cc4e6d4ab012a2a5a92bc282bd180c2fb1.

This can be reproduced by a query like this on a pgbench database:

SELECT aid FROM pgbench_accounts, pg_sleep(1)
UNION SELECT aid FROM pgbench_accounts --- repeat this line 100 times
ORDER BY 1 LIMIT 1