### PR TITLE
Fix rare bug with duplicate pg_settings values on Aurora Postgres

### DIFF
--- a/input/postgres/settings.go
+++ b/input/postgres/settings.go
@@ -27,7 +27,7 @@ SELECT DISTINCT ON (name)
 	   sourcefile,
 	   sourceline
   FROM pg_catalog.pg_settings
- ORDER BY name, sourceline DESC NULLS LAST`
+ ORDER BY name, CASE source WHEN 'default' THEN 1 ELSE 0 END`
 
 func GetSettings(db *sql.DB) ([]state.PostgresSetting, error) {
 	stmt, err := db.Prepare(QueryMarkerSQL + settingsSQL)


### PR DESCRIPTION
On some systems, notably Aurora Postgres 12.6, it appears possible to have
duplicate values in the pg_settings output, specifically as seen with the
"ssl_min_protocol_version" and "ssl_max_protocol_version" settings.

This is most likely a bug in the modified Postgres engine.

Since this causes other problems in the processing of the settings,
ensure that at most we get one result row per setting name.