### PR TITLE
Custom types: Correctly track custom type reference for array types

### DIFF
--- a/input/postgres/types.go
+++ b/input/postgres/types.go
@@ -9,6 +9,7 @@ import (
 
 const typesSQL string = `
 SELECT t.oid,
+       t.typarray AS arrayoid,
        n.nspname AS schema,
        t.typname AS name,
        t.typtype AS type,
@@ -56,7 +57,7 @@ func GetTypes(db *sql.DB, postgresVersion state.PostgresVersion, currentDatabase
 		t.DatabaseOid = currentDatabaseOid
 
 		err := rows.Scan(
-			&t.Oid, &t.SchemaName, &t.Name, &t.Type, &t.DomainType, &t.DomainNotNull, &t.DomainDefault, &arrayString)
+			&t.Oid, &t.ArrayOid, &t.SchemaName, &t.Name, &t.Type, &t.DomainType, &t.DomainNotNull, &t.DomainDefault, &arrayString)
 
 		if err != nil {
 			return nil, err

--- a/output/transform/postgres_types.go
+++ b/output/transform/postgres_types.go
@@ -45,6 +45,9 @@ func transformPostgresTypes(s snapshot.FullSnapshot, transientState state.Transi
 		idx := int32(len(s.CustomTypeInformations))
 		s.CustomTypeInformations = append(s.CustomTypeInformations, &info)
 		typeOidToIdx[pgType.Oid] = idx
+		if pgType.ArrayOid != 0 {
+			typeOidToIdx[pgType.ArrayOid] = idx
+		}
 	}
 
 	return s, typeOidToIdx

--- a/state/postgres_types.go
+++ b/state/postgres_types.go
@@ -8,6 +8,7 @@ type Xid uint32
 // PostgresType - User-defined custom data types
 type PostgresType struct {
 	Oid               Oid
+	ArrayOid          Oid
 	DatabaseOid       Oid
 	SchemaName        string
 	Name              string


### PR DESCRIPTION
Array types are technically separate in pg_type, but for our use case
all we need to make sure is that we reference the base type on the column
to allow downstream logic to know which custom type definition needs to
be created before running a CREATE TABLE that references said type.