### PR TITLE
Fix Heroku log handling when consuming logs for multiple databases

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -499,6 +499,13 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 					config.SystemID = strings.Replace(parts[0], "_URL", "", 1)
 					config.SystemType = "heroku"
 					config.DbURL = parts[1]
+					config.Identifier = ServerIdentifier{
+						APIKey:      config.APIKey,
+						APIBaseURL:  config.APIBaseURL,
+						SystemID:    config.SystemID,
+						SystemType:  config.SystemType,
+						SystemScope: config.SystemScope,
+					}
 					conf.Servers = append(conf.Servers, *config)
 				}
 			}


### PR DESCRIPTION
Currently, we track which database logs belong to through
server.Config.Identifier, but that's not set for servers when running
on Heroku, which leads to all logs being sent to an arbitrary server.

Define server.Config.Identifier for Heroku servers like we do when
reading the config file.

This may have been broken in the refactoring in #240