### PR TITLE
Fix Heroku blank log line parsing

### DIFF
--- a/input/system/heroku/logs.go
+++ b/input/system/heroku/logs.go
@@ -154,7 +154,7 @@ func logStreamItemToLogLine(item HerokuLogStreamItem, servers []*state.Server, s
 	}
 	backendPid, _ := strconv.ParseInt(parts[1], 10, 32)
 
-	lineParts := regexp.MustCompile(`^\[(\w+)\] \[(\d+)-(\d+)\] (.+)`).FindStringSubmatch(string(item.Content))
+	lineParts := regexp.MustCompile(`^\[(\w+)\] \[(\d+)-(\d+)\](?: (.+))?`).FindStringSubmatch(string(item.Content))
 	if len(lineParts) != 5 {
 		fmt.Printf("ERR: %s\n", string(item.Content))
 		return sourceToServer, nil, ""


### PR DESCRIPTION
On Heroku, Postgres log messages that include newlines don't render a
space between the standard line header and the (empty) output. Note the
log message:

```
2022-07-02T00:54:04.000000+00:00 app[postgres.1167776]: [YELLOW] [13-1]  sql_error_code = 00000 time_ms = "2022-07-02 00:54:04.414 UTC" pid="1299178" proc_start_time="2022-07-02 00:51:59 UTC" session_id="62bf96af.13d2ea" vtid="4/9659035" tid="0" log_line="6" database="d4anv5h51mo8t8" connection_source="44.197.170.157(34910)" user="uablvp9bo3lp3h" application_name="psql" NOTICE:  hello
2022-07-02T00:54:04.000000+00:00 app[postgres.1167776]: [YELLOW] [13-2]
2022-07-02T00:54:04.000000+00:00 app[postgres.1167776]: [YELLOW] [13-3]
2022-07-02T00:54:04.000000+00:00 app[postgres.1167776]: [YELLOW] [13-4] 	world
```

and the hexdump it generates:

```
00001c00  22 70 73 71 6c 22 20 4e  4f 54 49 43 45 3a 20 20  |"psql" NOTICE:  |
00001c10  68 65 6c 6c 6f 0a 32 30  32 32 2d 30 37 2d 30 32  |hello.2022-07-02|
00001c20  54 30 30 3a 35 35 3a 35  33 2e 30 30 30 30 30 30  |T00:55:53.000000|
00001c30  2b 30 30 3a 30 30 20 61  70 70 5b 70 6f 73 74 67  |+00:00 app[postg|
00001c40  72 65 73 2e 31 31 36 37  37 37 36 5d 3a 20 5b 59  |res.1167776]: [Y|
00001c50  45 4c 4c 4f 57 5d 20 5b  31 34 2d 32 5d 0a 32 30  |ELLOW] [14-2].20|
00001c60  32 32 2d 30 37 2d 30 32  54 30 30 3a 35 35 3a 35  |22-07-02T00:55:5|
00001c70  33 2e 30 30 30 30 30 30  2b 30 30 3a 30 30 20 61  |3.000000+00:00 a|
00001c80  70 70 5b 70 6f 73 74 67  72 65 73 2e 31 31 36 37  |pp[postgres.1167|
00001c90  37 37 36 5d 3a 20 5b 59  45 4c 4c 4f 57 5d 20 5b  |776]: [YELLOW] [|
00001ca0  31 34 2d 33 5d 0a 32 30  32 32 2d 30 37 2d 30 32  |14-3].2022-07-02|
00001cb0  54 30 30 3a 35 35 3a 35  33 2e 30 30 30 30 30 30  |T00:55:53.000000|
00001cc0  2b 30 30 3a 30 30 20 61  70 70 5b 70 6f 73 74 67  |+00:00 app[postg|
00001cd0  72 65 73 2e 31 31 36 37  37 37 36 5d 3a 20 5b 59  |res.1167776]: [Y|
00001ce0  45 4c 4c 4f 57 5d 20 5b  31 34 2d 34 5d 20 09 77  |ELLOW] [14-4] .w|
00001cf0  6f 72 6c 64 0a 32 30 32  32 2d 30 37 2d 30 32 54  |orld.2022-07-02T|
```
Note the newline (0x0a) immediately after the closing square bracket of the
line prefix in the two blank lines. We treat these as errors.

Treat the line content as optional (but always expect a preceding
space if there is content).
