### PR TITLE
Crunchy Bridge: Fix collection of system metrics

### DIFF
--- a/input/system/system.go
+++ b/input/system/system.go
@@ -42,6 +42,9 @@ func GetSystemState(config config.ServerConfig, logger *util.Logger) (system sta
 	} else if config.SystemType == "heroku" {
 		system.Info.Type = state.HerokuSystem
 	} else if config.SystemType == "crunchy_bridge" {
+		// We are assuming container apps are used, which means the collector
+		// runs on the database server itself and can gather local statistics
+		system = selfhosted.GetSystemState(config, logger)
 		system.Info.Type = state.CrunchyBridgeSystem
 	} else if dbHost == "" || dbHost == "localhost" || dbHost == "127.0.0.1" || os.Getenv("PGA_ALWAYS_COLLECT_SYSTEM_DATA") != "" {
 		system = selfhosted.GetSystemState(config, logger)


### PR DESCRIPTION
This stopped working when we introduced the dedicated Crunchy Bridge
system type. Since container apps run directly on the database server,
we can use the same mechanism to get system metrics as we do for self
hosted servers.