### PR TITLE
Add additional log_line_prefix "%m [%p] %q%u@%d " + variant with %h

### DIFF
--- a/logs/parse_test.go
+++ b/logs/parse_test.go
@@ -427,6 +427,56 @@ var parseTests = []parseTestpair{
 		},
 		true,
 	},
+	// Custom 15 format
+	{
+		"",
+		"2022-07-22 06:13:13.389 UTC [1] LOG:  database system is ready to accept connections",
+		state.LogLine{
+			OccurredAt: time.Date(2022, time.July, 22, 6, 13, 13, 389*1000*1000, time.UTC),
+			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
+			BackendPid: 1,
+			Content:    "database system is ready to accept connections",
+		},
+		true,
+	},
+	{
+		"",
+		"2022-07-22 06:13:45.781 UTC [75] myuser@mydb LOG:  connection authorized: user=myuser database=mydb application_name=psql",
+		state.LogLine{
+			OccurredAt: time.Date(2022, time.July, 22, 6, 13, 45, 781*1000*1000, time.UTC),
+			Username:   "myuser",
+			Database:   "mydb",
+			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
+			BackendPid: 75,
+			Content:    "connection authorized: user=myuser database=mydb application_name=psql",
+		},
+		true,
+	},
+	// Custom 16 format
+	{
+		"",
+		"2022-07-22 06:13:12 UTC [1] LOG:  starting PostgreSQL 14.2 (Debian 14.2-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit",
+		state.LogLine{
+			OccurredAt: time.Date(2022, time.July, 22, 6, 13, 12, 0, time.UTC),
+			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
+			BackendPid: 1,
+			Content:    "starting PostgreSQL 14.2 (Debian 14.2-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit",
+		},
+		true,
+	},
+	{
+		"",
+		"2022-07-22 06:14:23 UTC [76] my-user@my-db 1.2.3.4 LOG:  disconnection: session time: 0:00:01.667 user=my-user database=my-db host=1.2.3.4 port=5678",
+		state.LogLine{
+			OccurredAt: time.Date(2022, time.July, 22, 6, 14, 23, 0, time.UTC),
+			Username:   "my-user",
+			Database:   "my-db",
+			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
+			BackendPid: 76,
+			Content:    "disconnection: session time: 0:00:01.667 user=my-user database=my-db host=1.2.3.4 port=5678",
+		},
+		true,
+	},
 	// Simple format
 	{
 		"",


### PR DESCRIPTION
This covers a typical log_line_prefix setting used by the Ubuntu Postgres
packages, and adds a variant with hostname, that was requested.