### PR TITLE
Stop pretty-printing constraintdefs on collection

### DIFF
--- a/input/postgres/relations.go
+++ b/input/postgres/relations.go
@@ -87,7 +87,7 @@ SELECT c.oid,
 			 i.indisunique,
 			 i.indisvalid,
 			 pg_catalog.pg_get_indexdef(i.indexrelid, 0, FALSE),
-			 pg_catalog.pg_get_constraintdef(con.oid, TRUE),
+			 pg_catalog.pg_get_constraintdef(con.oid, FALSE),
 			 c2.reloptions,
 			 (SELECT a.amname FROM pg_catalog.pg_am a JOIN pg_catalog.pg_opclass o ON (a.oid = o.opcmethod) WHERE o.oid = i.indclass[0])
 	FROM pg_catalog.pg_class c
@@ -110,7 +110,7 @@ const constraintsSQL string = `
 SELECT c.oid,
 			 conname,
 			 contype,
-			 pg_catalog.pg_get_constraintdef(r.oid, TRUE),
+			 pg_catalog.pg_get_constraintdef(r.oid, FALSE),
 			 conkey,
 			 confrelid,
 			 confkey,

--- a/input/postgres/types.go
+++ b/input/postgres/types.go
@@ -19,7 +19,7 @@ SELECT t.oid,
        COALESCE(
          CASE t.typtype
            WHEN 'd' THEN
-             (SELECT pg_catalog.json_agg(pg_catalog.pg_get_constraintdef(oid)) FROM pg_catalog.pg_constraint WHERE contypid = t.oid)::text
+             (SELECT pg_catalog.json_agg(pg_catalog.pg_get_constraintdef(oid, FALSE)) FROM pg_catalog.pg_constraint WHERE contypid = t.oid)::text
            WHEN 'e' THEN
              (SELECT pg_catalog.json_agg(enumlabel ORDER BY enumsortorder) FROM pg_catalog.pg_enum WHERE enumtypid = t.oid)::text
            WHEN 'c' THEN


### PR DESCRIPTION
See 63be3a0d7b2b71a59fe1287b849d3159eb00383f -- a similar problem can
occur with constraintdefs, if those defs are foreign key table references.
