### PR TITLE
Allow using "pg_read_file" for self-managed servers to read log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,34 @@ text. This is to minimize collector access to your data: it ensures
 that the collector cannot piggyback other queries that could
 exfiltrate data.
 
+Setting up log pg_read_file helper
+----------------------------------
+
+Create the following helper as a superuser (note this needs to be an actual
+superuser, i.e. not available on systems like Amazon RDS), to read logs using the
+`pg_read_file` function with the restricted monitoring user:
+
+```sql
+CREATE OR REPLACE FUNCTION pganalyze.read_log_file(log_filename text, read_offset bigint, read_length bigint) RETURNS text AS
+$$
+DECLARE
+  result text;
+BEGIN
+  IF log_filename !~ '\A[\w\.-]+\Z' THEN
+    RAISE EXCEPTION 'invalid log filename';
+  END IF;
+
+  SELECT pg_catalog.pg_read_file(
+    pg_catalog.current_setting('data_directory') || '/' || pg_catalog.current_setting('log_directory') || '/' || log_filename,
+    read_offset,
+    read_length
+  ) INTO result;
+
+  RETURN result;
+END
+$$ LANGUAGE plpgsql VOLATILE SECURITY DEFINER;
+```
+
 
 Example output
 --------------

--- a/config/config.go
+++ b/config/config.go
@@ -126,6 +126,13 @@ type ServerConfig struct {
 	// on the specifed "hostname:port" for Postgres log messages
 	LogSyslogServer string `ini:"db_log_syslog_server"`
 
+	// Configures the collector to use the "pg_read_file" (superuser) or
+	// "pganalyze.read_log_file" (helper) function to retrieve log data
+	// directly over the Postgres connection. This only works when superuser
+	// access to the server is possible, either directly, or via the helper
+	// function. Used by default for Crunchy Bridge.
+	LogPgReadFile bool `ini:"db_log_pg_read_file"`
+
 	// Specifies a table pattern to ignore - no statistics will be collected for
 	// tables that match the name. This uses Golang's filepath.Match function for
 	// comparison, so you can e.g. use "*" for wildcard matching.
@@ -179,7 +186,7 @@ type ServerConfig struct {
 
 // SupportsLogDownload - Determines whether the specified config can download logs
 func (config ServerConfig) SupportsLogDownload() bool {
-	return config.AwsDbInstanceID != "" || config.CrunchyBridgeClusterID != ""
+	return config.AwsDbInstanceID != "" || config.LogPgReadFile
 }
 
 // GetPqOpenString - Gets the database configuration as a string that can be passed to lib/pq for connecting

--- a/config/read.go
+++ b/config/read.go
@@ -194,6 +194,9 @@ func getDefaultConfig() *ServerConfig {
 	if logSyslogServer := os.Getenv("LOG_SYSLOG_SERVER"); logSyslogServer != "" {
 		config.LogSyslogServer = logSyslogServer
 	}
+	if logPgReadFile := os.Getenv("LOG_PG_READ_FILE"); logPgReadFile != "" {
+		config.LogPgReadFile = parseConfigBool(logPgReadFile)
+	}
 	// Note: We don't support LogDockerTail here since it would require the "docker"
 	// binary inside the pganalyze container (as well as full Docker access), instead
 	// the approach for using pganalyze as a sidecar container alongside Postgres
@@ -417,6 +420,10 @@ func preprocessConfig(config *ServerConfig) (*ServerConfig, error) {
 
 	if config.AwsEndpointSigningRegionLegacy != "" && config.AwsEndpointSigningRegion == "" {
 		config.AwsEndpointSigningRegion = config.AwsEndpointSigningRegionLegacy
+	}
+
+	if config.CrunchyBridgeClusterID != "" {
+		config.LogPgReadFile = true
 	}
 
 	return config, nil

--- a/input/system/heroku/http_handler.go
+++ b/input/system/heroku/http_handler.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"github.com/bmizerany/lpx"
-	"github.com/pganalyze/collector/logs"
 	"github.com/pganalyze/collector/state"
 	"github.com/pganalyze/collector/util"
 )
@@ -37,8 +36,4 @@ func SetupHttpHandlerLogs(ctx context.Context, wg *sync.WaitGroup, globalCollect
 		})
 		http.ListenAndServe(":"+os.Getenv("PORT"), nil)
 	}()
-
-	for _, server := range servers {
-		logs.EmitTestLogMsg(server, globalCollectionOpts, logger)
-	}
 }

--- a/input/system/system.go
+++ b/input/system/system.go
@@ -4,7 +4,7 @@ import (
 	"os"
 
 	"github.com/pganalyze/collector/config"
-	"github.com/pganalyze/collector/input/system/crunchy_bridge"
+	"github.com/pganalyze/collector/input/postgres"
 	"github.com/pganalyze/collector/input/system/rds"
 	"github.com/pganalyze/collector/input/system/selfhosted"
 	"github.com/pganalyze/collector/state"
@@ -18,8 +18,8 @@ func DownloadLogFiles(server *state.Server, globalCollectionOpts state.Collectio
 		if err != nil {
 			return
 		}
-	} else if server.Config.SystemType == "crunchy_bridge" {
-		psl, files, querySamples, err = crunchy_bridge.DownloadLogFiles(server, globalCollectionOpts, logger)
+	} else if server.Config.LogPgReadFile {
+		psl, files, querySamples, err = postgres.LogPgReadFile(server, globalCollectionOpts, logger)
 		if err != nil {
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 		} else if globalCollectionOpts.TestExplain {
 			for _, server := range servers {
 				prefixedLogger := logger.WithPrefix(server.Config.SectionName)
-				err := logs.EmitTestExplain(server, globalCollectionOpts, prefixedLogger)
+				err := runner.EmitTestExplain(server, globalCollectionOpts, prefixedLogger)
 				if err != nil {
 					prefixedLogger.PrintError("Failed to run test explain: %s", err)
 				}

--- a/runner/emit_test_lines.go
+++ b/runner/emit_test_lines.go
@@ -1,4 +1,4 @@
-package logs
+package runner
 
 import (
 	"fmt"

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -55,6 +55,9 @@ func SetupLogCollection(ctx context.Context, wg *sync.WaitGroup, servers []*stat
 	}
 	if hasAnyHeroku {
 		heroku.SetupHttpHandlerLogs(ctx, wg, globalCollectionOpts, logger, servers, parsedLogStream)
+		for _, server := range servers {
+			EmitTestLogMsg(server, globalCollectionOpts, logger)
+		}
 	}
 	if hasAnyGoogleCloudSQL {
 		google_cloudsql.SetupLogSubscriber(ctx, wg, globalCollectionOpts, logger, servers, parsedLogStream)
@@ -417,7 +420,7 @@ func testLocalLogTail(ctx context.Context, wg *sync.WaitGroup, server *state.Ser
 		return false
 	}
 
-	logs.EmitTestLogMsg(server, globalCollectionOpts, logger)
+	EmitTestLogMsg(server, globalCollectionOpts, logger)
 
 	select {
 	case <-logTestSucceeded:
@@ -458,7 +461,7 @@ func testAzureLogStream(ctx context.Context, wg *sync.WaitGroup, server *state.S
 		return false
 	}
 
-	logs.EmitTestLogMsg(server, globalCollectionOpts, logger)
+	EmitTestLogMsg(server, globalCollectionOpts, logger)
 
 	select {
 	case <-logTestSucceeded:
@@ -485,7 +488,7 @@ func testGoogleCloudsqlLogStream(ctx context.Context, wg *sync.WaitGroup, server
 		return false
 	}
 
-	logs.EmitTestLogMsg(server, globalCollectionOpts, logger)
+	EmitTestLogMsg(server, globalCollectionOpts, logger)
 
 	select {
 	case <-logTestSucceeded:


### PR DESCRIPTION
This is an alternate approach to collecting log data that relies on
built-in Postgres functions to read log files and return the log data to
the collector over the Postgres connection.

Note that this requires superuser (either directly or through a helper)
and thus does not work on managed database providers, with the exception
of Crunchy Bridge, for which this is already the mechanism to fetch logs.

Additionally, this carries higher overhead than directly tailing log
files, or using syslog, and thus should only be used when necessary.

You can enable this by setting the "db_log_pg_read_file" /
"LOG_PG_READ_FILE" setting to "1" or "true", and ensuring that the
"pganalyze.read_log_file" helper exists (or by connecting as a superuser).