### PR TITLE
Show RDS instance role hint when running collector test

### DIFF
--- a/runner/logs.go
+++ b/runner/logs.go
@@ -439,6 +439,10 @@ func testLogDownload(ctx context.Context, wg *sync.WaitGroup, server *state.Serv
 	_, _, err := downloadLogsForServer(server, globalCollectionOpts, prefixedLogger)
 	if err != nil {
 		prefixedLogger.PrintError("ERROR - Could not download logs: %s", err)
+		msg := err.Error()
+		if server.Config.SystemType == "amazon_rds" && strings.Contains(msg, "NoCredentialProviders") {
+			prefixedLogger.PrintInfo("HINT - This may occur if you have not assigned an IAM role to the collector EC2 instance, and have not provided AWS credentials through another method")
+		}
 		return false
 	}
 


### PR DESCRIPTION
In fd65610fd60b0aaa2b2784ba23bb7f7e09c7f71e, we added a hint to
instruct users to check the instance role when hitting RDS credential
erros in log download. This works, but only in the live code path,
because the test code logs the download error from a different entry
point.

To work around this, add the same warning to the test code path.

Alternately, we could push the logging down into the download method
itself (in code that both code paths end up calling), but that breaks
up the logging success/failure cases in a weird way, especially for
the test path. Or we could build an error that includes the hint,
though there's less flexibility in formatting (the hint cannot be its
own line) if we do that. Finally, we could also use an error type that
includes separate message and hint fields, but that would require a
larger refactoring.
