### PR TITLE
Pass GitHub token to setup-protoc action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
 # N.B.: release.yml should be updated to match as necessary
+permissions: {}
+
 on:
   push:
     branches: [ main ]
@@ -20,9 +22,10 @@ jobs:
       id: go
 
     - name: Set up protoc
-      uses: arduino/setup-protoc@v1.1.2
+      uses: pganalyze/setup-protoc@v1.1.2
       with:
         version: 3.14.0
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
 # N.B.: build steps should match the tests we run in ci.yml
+permissions: {}
+
 on:
   create
 
@@ -19,9 +21,10 @@ jobs:
       id: go
 
     - name: Set up protoc
-      uses: arduino/setup-protoc@v1.1.2
+      uses: pganalyze/setup-protoc@v1.1.2
       with:
         version: 3.14.0
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Check out code
       uses: actions/checkout@v2


### PR DESCRIPTION
We sometimes hit GitHub rate limits in the setup-protoc action, which
causes the build to fail [1]. The action documentation recommends
passing your workflow's GITHUB_TOKEN to make an authenticated request
for protobuf version lookups: even though the API endpoint is public,
unauthenticated requests have lower IP-based rate limits.

Pass the token to the action, but also fork the action into our own
repo and remove unnecessary permissions from the token as extra
defensive measures.

I've reviewed the existing action code and the token is only used for
the GitHub API request to fetch protobuf releases.

[1]: https://github.com/pganalyze/collector/runs/7732070234?check_suite_focus=true#step:3:8
