### PR TITLE
RDS logs: Don't silence errors by accident due to variable shadowing

### DIFF
--- a/input/system/rds/logs.go
+++ b/input/system/rds/logs.go
@@ -76,7 +76,8 @@ func DownloadLogFiles(server *state.Server, logger *util.Logger) (state.Persiste
 		logFile.OriginalName = *rdsLogFile.LogFileName
 
 		for {
-			resp, err := rdsSvc.DownloadDBLogFilePortion(&rds.DownloadDBLogFilePortionInput{
+			var resp *rds.DownloadDBLogFilePortionOutput
+			resp, err = rdsSvc.DownloadDBLogFilePortion(&rds.DownloadDBLogFilePortionInput{
 				DBInstanceIdentifier: &identifier,
 				LogFileName:          rdsLogFile.LogFileName,
 				Marker:               lastMarker, // This is not set for the initial call, so we only get the most recent lines
@@ -94,7 +95,7 @@ func DownloadLogFiles(server *state.Server, logger *util.Logger) (state.Persiste
 			}
 
 			if len(*resp.LogFileData) > 0 {
-				_, err := logFile.TmpFile.WriteString(*resp.LogFileData)
+				_, err = logFile.TmpFile.WriteString(*resp.LogFileData)
 				if err != nil {
 					err = fmt.Errorf("Error writing to tempfile: %s", err)
 					logFile.Cleanup()
@@ -117,7 +118,7 @@ func DownloadLogFiles(server *state.Server, logger *util.Logger) (state.Persiste
 		if readStart < 0 {
 			readStart = 0
 		}
-		_, err := logFile.TmpFile.Seek(int64(readStart), io.SeekStart)
+		_, err = logFile.TmpFile.Seek(int64(readStart), io.SeekStart)
 		if err != nil {
 			err = fmt.Errorf("Error seeking tempfile: %s", err)
 			logFile.Cleanup()


### PR DESCRIPTION
The way the existing code was written was creating a new local
variable called "err" that shadowed the top-level "err" variable. This
then lead to errors being silenced since the ErrorCleanup code path
was referencing the top-level "err" which was set to nil even in error
conditions.

The practical consequence of this was that if an IAM policy was in use
that permitted DescribeDBLogFiles but not DownloadDBLogFilePortion, the
log data would be empty, without any errors shown in the logs. This
can occur when someone grants the RDS Read Only predefined IAM policy
instead of a custom policy with our recommended permissions.