### PR TITLE
Add "-q" / "--quiet" flag to hide all log messages except errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -257,6 +257,7 @@ func main() {
 	flag.StringVar(&testSection, "test-section", "", "Tests a particular section of the config file, i.e. a specific server, and ignores all other config sections")
 	flag.BoolVar(&reloadRun, "reload", false, "Reloads the collector daemon thats running on the host")
 	flag.BoolVarP(&logger.Verbose, "verbose", "v", false, "Outputs additional debugging information, use this if you're encoutering errors or other problems")
+	flag.BoolVarP(&logger.Quiet, "quiet", "q", false, "Only outputs error messages to the logs and hides informational and warning messages")
 	flag.BoolVar(&logToSyslog, "syslog", false, "Write all log output to syslog instead of stderr (disabled by default)")
 	flag.BoolVar(&logToJSON, "json-logs", false, "Write all log output to stderr as newline delimited json (disabled by default, ignored if --syslog is set)")
 	flag.BoolVar(&logNoTimestamps, "no-log-timestamps", false, "Disable timestamps in the log output (automatically done when syslog is enabled)")

--- a/util/logger.go
+++ b/util/logger.go
@@ -80,6 +80,10 @@ func (logger *Logger) PrintInfo(format string, args ...interface{}) {
 }
 
 func (logger *Logger) PrintWarning(format string, args ...interface{}) {
+	if logger.Quiet {
+		return
+	}
+
 	logger.print("W", format, args...)
 }
 


### PR DESCRIPTION
This re-uses an existing code path for Quiet in the logger (not used
before this change), and adds warnings to be hidden as well when quiet
is active.

See #310 for related discussion.