### PR TITLE
GH actions: Only apply permissions restrictions to build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
 # N.B.: build steps should match the tests we run in ci.yml
-permissions: {}
 
 on:
   create
@@ -9,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions: {}
     # ensure we don't release on create events for branches (only tags)
     if: ${{ startsWith( github.ref, 'refs/tags' ) }}
 


### PR DESCRIPTION
This was added in 8a5387cefb1287d0ed81a3b4a40dab811b2f6e45 to avoid the protoc
action using a more privileged token to do GH downloads, but broke the release
step by accident. For the release action only apply the permission limits to
the build step. For the CI action we keep the limits for the whole action.