### PR TITLE
RDS log download: Fix edge case that caused errors with multiple files

### DIFF
--- a/input/system/rds/logs.go
+++ b/input/system/rds/logs.go
@@ -56,10 +56,10 @@ func DownloadLogFiles(server *state.Server, logger *util.Logger) (state.Persiste
 	}
 
 	var newMarkers = make(map[string]string)
-	var bytesWritten = 0
 
 	for _, rdsLogFile := range resp.DescribeDBLogFiles {
 		var lastMarker *string
+		var bytesWritten = 0
 
 		prevMarker, ok := psl.AwsMarkers[*rdsLogFile.LogFileName]
 		if ok {


### PR DESCRIPTION
The RDS log download looks at any log file that was modified in the last
two minutes, to make sure to not miss any data when a new log files is
started. Each log file is processed separately with its own tempfile
that stores the downloaded log data. However the amount of data written
to the files was kept in a single variable that was not reset between
files causing errors like the following:

Error reading 65817 bytes from tempfile: unexpected EOF

Fix by moving the variable into the loop that handles each file. This is a
long-standing error that was hidden before due to the bug now fixed in
d31e3af77b087338d02b2e7e5eeb8fc4c0ba912e.