### PR TITLE
Quote PATH when spawning shells in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ OUTFILE := pganalyze-collector
 PROTOBUF_FILES := $(wildcard protobuf/*.proto) $(wildcard protobuf/reports/*.proto)
 
 PATH := $(PWD)/protoc/bin:$(PWD)/bin:$(PATH)
-SHELL := env PATH=$(PATH) /bin/sh
+SHELL := env PATH="$(PATH)" /bin/sh
 
 PROTOC_VERSION_NEEDED := 3.14.0
 PROTOC_VERSION := $(shell command -v protoc > /dev/null 2>&1 && protoc --version)


### PR DESCRIPTION
Fixes builds where `$PATH` has a space, e.g. `..:/Applications/VMware Fusion.app/Contents/Public:..`