### PR TITLE
Docker: Allow setting CONFIG_CONTENTS to pass ini-style configuration

### DIFF
--- a/contrib/docker-entrypoint.sh
+++ b/contrib/docker-entrypoint.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+if [ -n "$CONFIG_CONTENTS" ]; then
+  echo "$CONFIG_CONTENTS" > /home/pganalyze/.pganalyze_collector.conf
+fi
+
 CMD_PREFIX=exec
 if [ $(id -u) = 0 ]; then
   CMD_PREFIX="exec setpriv --reuid=pganalyze --regid=pganalyze --inh-caps=-all --clear-groups"


### PR DESCRIPTION
This allows easier configuration of multiple servers to be monitored by
the same Docker container. Previously this required use of a volume
mount, which can be harder to make work successfully.

CONFIG_CONTENTS needs to match the regular configuration file format that
uses separate sections for each server.

This can be combined with environment-variable style configuration for
settings that apply to all servers (e.g. PGA_API_KEY) but all
server-specific configuration should only be passed in through the
CONFIG_CONTENTS variable.