### PR TITLE
Add go vet linting to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ vendor:
 
 test: build
 	go test -coverprofile=coverage.out ./...
+	go vet ./...
 	# go tool cover -html=coverage.out
 
 integration_test:


### PR DESCRIPTION
Currently, this fails with a lot of 'copies lock by value' errors
(see, e.g.,
https://medium.com/golangspec/detect-locks-passed-by-value-in-go-efb4ac9a3f2b
). I think many of them are moot, but we should address these so we
can add go vet since it can find real issues.
