### PR TITLE
Introduce benchmark flag to support running collector without submitting stats

### DIFF
--- a/main.go
+++ b/main.go
@@ -284,7 +284,7 @@ func main() {
 	flag.StringVar(&configFilename, "config", defaultConfigFile, "Specify alternative path for config file")
 	flag.StringVar(&stateFilename, "statefile", defaultStateFile, "Specify alternative path for state file")
 	flag.StringVar(&pidFilename, "pidfile", "", "Specifies a path that a pidfile should be written to (default is no pidfile being written)")
-	flag.BoolVar(&benchmark, "benchmark", false, "Runs as a benchmark mode (skip submitting the statistics to the server)")
+	flag.BoolVar(&benchmark, "benchmark", false, "Runs collector in benchmark mode (skip submitting the statistics to the server)")
 	flag.Parse()
 
 	if showVersion {

--- a/main.go
+++ b/main.go
@@ -245,6 +245,7 @@ func main() {
 	var logToJSON bool
 	var logNoTimestamps bool
 	var reloadRun bool
+	var benchmark bool
 
 	logFlags := log.LstdFlags
 	logger := &util.Logger{}
@@ -283,6 +284,7 @@ func main() {
 	flag.StringVar(&configFilename, "config", defaultConfigFile, "Specify alternative path for config file")
 	flag.StringVar(&stateFilename, "statefile", defaultStateFile, "Specify alternative path for state file")
 	flag.StringVar(&pidFilename, "pidfile", "", "Specifies a path that a pidfile should be written to (default is no pidfile being written)")
+	flag.BoolVar(&benchmark, "benchmark", false, "Runs as a benchmark mode (skip submitting the statistics to the server)")
 	flag.Parse()
 
 	if showVersion {
@@ -322,7 +324,7 @@ func main() {
 
 	globalCollectionOpts := state.CollectionOpts{
 		StartedAt:                time.Now(),
-		SubmitCollectedData:      true,
+		SubmitCollectedData:      !benchmark && true,
 		TestRun:                  testRun,
 		TestReport:               testReport,
 		TestRunLogs:              testRunLogs || dryRunLogs,
@@ -341,7 +343,8 @@ func main() {
 		CollectSystemInformation: !noSystemInformation,
 		StateFilename:            stateFilename,
 		WriteStateUpdate:         (!dryRun && !dryRunLogs && !testRun) || forceStateUpdate,
-		ForceEmptyGrant:          dryRun || dryRunLogs,
+		ForceEmptyGrant:          dryRun || dryRunLogs || benchmark,
+		OutputAsJson:             !benchmark,
 	}
 
 	if reloadRun && !testRun {

--- a/output/compact.go
+++ b/output/compact.go
@@ -44,7 +44,11 @@ func uploadAndSubmitCompactSnapshot(s pganalyze_collector.CompactSnapshot, grant
 	w.Close()
 
 	if !collectionOpts.SubmitCollectedData {
-		debugCompactOutputAsJSON(logger, compressedData)
+		if collectionOpts.OutputAsJson {
+			debugCompactOutputAsJSON(logger, compressedData)
+		} else if !quiet {
+			logger.PrintInfo("Collected compact %s snapshot successfully", kind)
+		}
 		return nil
 	}
 

--- a/output/full.go
+++ b/output/full.go
@@ -61,7 +61,11 @@ func submitFull(s snapshot.FullSnapshot, server *state.Server, collectionOpts st
 	w.Close()
 
 	if !collectionOpts.SubmitCollectedData {
-		debugOutputAsJSON(logger, compressedData)
+		if collectionOpts.OutputAsJson {
+			debugOutputAsJSON(logger, compressedData)
+		} else if !quiet {
+			logger.PrintInfo("Collected snapshot successfully")
+		}
 		return nil
 	}
 

--- a/state/state.go
+++ b/state/state.go
@@ -203,6 +203,8 @@ type CollectionOpts struct {
 	StateFilename    string
 	WriteStateUpdate bool
 	ForceEmptyGrant  bool
+
+	OutputAsJson bool
 }
 
 type GrantConfig struct {


### PR DESCRIPTION
The new flag `--benchmark` allows you to run collector without submitting stats. With this, you can run collector without connecting to pganalyze, which will be helpful for benchmarking as you can skip the setup, as well as ignore the overhead of that part.

Difference between other flags:

* `test`: this only runs once, and also submit the stats to the server (setup is needed)
* `dry-run`: this also only runs once, and print the JSON data to stdout (which is not needed for benchmarking)