### PR TITLE
Statements: Fix Postgres 15 compatibility due to version check bug

### DIFF
--- a/integration_test/Dockerfile.test-pg14
+++ b/integration_test/Dockerfile.test-pg14
@@ -1,0 +1,25 @@
+FROM postgres:14
+
+ARG TARGETARCH
+
+ENV GOVERSION 1.17
+ENV CODE_DIR /collector
+ENV PATH $PATH:/usr/local/go/bin
+
+# Packages required for both building and packaging
+RUN apt-get update -qq && apt-get install -y -q build-essential git curl
+
+# Golang
+RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
+RUN tar -C /usr/local -xzf go.tar.gz
+
+# Build the collector
+COPY . $CODE_DIR
+WORKDIR $CODE_DIR
+RUN make build_dist
+
+# Make sure collector state can be saved
+RUN mkdir /var/lib/pganalyze-collector/
+
+RUN cp $CODE_DIR/pganalyze-collector /usr/bin/
+RUN cp $CODE_DIR/pganalyze-collector-helper /usr/bin/

--- a/integration_test/Dockerfile.test-pg15
+++ b/integration_test/Dockerfile.test-pg15
@@ -1,0 +1,25 @@
+FROM postgres:15
+
+ARG TARGETARCH
+
+ENV GOVERSION 1.17
+ENV CODE_DIR /collector
+ENV PATH $PATH:/usr/local/go/bin
+
+# Packages required for both building and packaging
+RUN apt-get update -qq && apt-get install -y -q build-essential git curl
+
+# Golang
+RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
+RUN tar -C /usr/local -xzf go.tar.gz
+
+# Build the collector
+COPY . $CODE_DIR
+WORKDIR $CODE_DIR
+RUN make build_dist
+
+# Make sure collector state can be saved
+RUN mkdir /var/lib/pganalyze-collector/
+
+RUN cp $CODE_DIR/pganalyze-collector /usr/bin/
+RUN cp $CODE_DIR/pganalyze-collector-helper /usr/bin/

--- a/integration_test/Makefile
+++ b/integration_test/Makefile
@@ -10,9 +10,9 @@ docker_run_cmd = docker run --name pganalyze-collector-test \
   -d pganalyze-collector-test $(1)
 docker_run_cmd_postgres = $(call docker_run_cmd,postgres -c pg_stat_statements.track_utility=off)
 
-.PHONY: pg93 pg94 pg95 pg96 pg10 pg11 pg12 pg13 reload guided-setup installer
+.PHONY: pg93 pg94 pg95 pg96 pg10 pg11 pg12 pg13 pg14 pg15 reload guided-setup installer
 
-all: pg93 pg94 pg95 pg96 pg10 pg11 pg12 pg13 reload guided-setup installer
+all: pg93 pg94 pg95 pg96 pg10 pg11 pg12 pg13 pg14 pg15 reload guided-setup installer
 
 pg93:
 	docker build -f Dockerfile.test-pg93 $(DOCKER_BUILD_OPTS)
@@ -197,6 +197,52 @@ pg13:
 	fi
 	jq '.queryInformations[].normalizedQuery' pg13_2.json | sort --version-sort -f > pg13.out
 	diff -Naur pg13.expected pg13.out && echo 'success'
+
+pg14:
+	docker build -f Dockerfile.test-pg14 $(DOCKER_BUILD_OPTS)
+	$(docker_run_cmd_postgres)
+	sleep 10
+	docker exec pganalyze-collector-test pgbench -U postgres postgres -i
+	docker exec pganalyze-collector-test pgbench -U postgres postgres
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg14_1.json
+	docker exec pganalyze-collector-test pgbench -U postgres postgres
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg14_2.json
+	docker rm -f pganalyze-collector-test
+	docker rmi pganalyze-collector-test
+	if [ "`jq '.collectorErrors' pg14_2.json | tr -d ' \n\r\t '`" != "null" ]; then \
+		jq '.collectorErrors' pg14_2.json; \
+		exit 1; \
+	fi
+	if jq '.relationReferences' pg14_2.json | grep --quiet pgbench_history; then \
+                echo "failed to ignore table according to IGNORE_SCHEMA_REGEXP=pgbench_history" \
+		jq '.relationReferences' pg14_2.json; \
+		exit 1; \
+	fi
+	jq '.queryInformations[].normalizedQuery' pg14_2.json | sort --version-sort -f > pg14.out
+	diff -Naur pg14.expected pg14.out && echo 'success'
+
+pg15:
+	docker build -f Dockerfile.test-pg15 $(DOCKER_BUILD_OPTS)
+	$(docker_run_cmd_postgres)
+	sleep 10
+	docker exec pganalyze-collector-test pgbench -U postgres postgres -i
+	docker exec pganalyze-collector-test pgbench -U postgres postgres
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg15_1.json
+	docker exec pganalyze-collector-test pgbench -U postgres postgres
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > pg15_2.json
+	docker rm -f pganalyze-collector-test
+	docker rmi pganalyze-collector-test
+	if [ "`jq '.collectorErrors' pg15_2.json | tr -d ' \n\r\t '`" != "null" ]; then \
+		jq '.collectorErrors' pg15_2.json; \
+		exit 1; \
+	fi
+	if jq '.relationReferences' pg15_2.json | grep --quiet pgbench_history; then \
+                echo "failed to ignore table according to IGNORE_SCHEMA_REGEXP=pgbench_history" \
+		jq '.relationReferences' pg15_2.json; \
+		exit 1; \
+	fi
+	jq '.queryInformations[].normalizedQuery' pg15_2.json | sort --version-sort -f > pg15.out
+	diff -Naur pg15.expected pg15.out && echo 'success'
 
 # Test reload both with an empty config and a server present
 #

--- a/integration_test/pg14.expected
+++ b/integration_test/pg14.expected
@@ -1,0 +1,8 @@
+"INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)"
+"SELECT abalance FROM pgbench_accounts WHERE aid = $1"
+"select count(*) from pgbench_branches"
+"select o.n, p.partstrat, pg_catalog.count(i.inhparent) from pg_catalog.pg_class as c join pg_catalog.pg_namespace as n on (n.oid = c.relnamespace) cross join lateral (select pg_catalog.array_position(pg_catalog.current_schemas($1), n.nspname)) as o(n) left join pg_catalog.pg_partitioned_table as p on (p.partrelid = c.oid) left join pg_catalog.pg_inherits as i on (c.oid = i.inhparent) where c.relname = $2 and o.n is not null group by 1, 2 order by 1 asc limit $3"
+"UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2"
+"UPDATE pgbench_branches SET bbalance = bbalance + $1 WHERE bid = $2"
+"UPDATE pgbench_tellers SET tbalance = tbalance + $1 WHERE tid = $2"
+"<pganalyze-collector>"

--- a/integration_test/pg15.expected
+++ b/integration_test/pg15.expected
@@ -1,0 +1,8 @@
+"INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)"
+"SELECT abalance FROM pgbench_accounts WHERE aid = $1"
+"select count(*) from pgbench_branches"
+"select o.n, p.partstrat, pg_catalog.count(i.inhparent) from pg_catalog.pg_class as c join pg_catalog.pg_namespace as n on (n.oid = c.relnamespace) cross join lateral (select pg_catalog.array_position(pg_catalog.current_schemas($1), n.nspname)) as o(n) left join pg_catalog.pg_partitioned_table as p on (p.partrelid = c.oid) left join pg_catalog.pg_inherits as i on (c.oid = i.inhparent) where c.relname = $2 and o.n is not null group by 1, 2 order by 1 asc limit $3"
+"UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2"
+"UPDATE pgbench_branches SET bbalance = bbalance + $1 WHERE bid = $2"
+"UPDATE pgbench_tellers SET tbalance = tbalance + $1 WHERE tid = $2"
+"<pganalyze-collector>"

--- a/state/postgres_version.go
+++ b/state/postgres_version.go
@@ -10,6 +10,8 @@ const (
 	PostgresVersion11 = 110000
 	PostgresVersion12 = 120000
 	PostgresVersion13 = 130000
+	PostgresVersion14 = 140000
+	PostgresVersion15 = 150000
 
 	// MinRequiredPostgresVersion - We require PostgreSQL 9.3 or newer
 	MinRequiredPostgresVersion = PostgresVersion93


### PR DESCRIPTION
There was a bug in our version check mechanism that caused the minor version "1.10" to be treated as smaller than "1.8", effectively causing us to look for the wrong fields.

Fix the relevant version comparisons to use integer instead of floats, and in passing cleanup some old references to Postgres version numbers as compared to pg_stat_statements version numbers.

In passing add the version strings for Postgres 14 and 15, in case we add version-specific checks in the future.