### PR TITLE
Collect Citus distributed index sizes

### DIFF
--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -174,6 +174,8 @@ func GetIndexStats(db *sql.DB, postgresVersion state.PostgresVersion, ignoreRege
 		indexStats[oid] = stats
 	}
 
+	indexStats, err = handleIndexStatsExt(db, indexStats, postgresVersion, ignoreRegexp)
+
 	return
 }
 

--- a/input/postgres/relation_stats_ext.go
+++ b/input/postgres/relation_stats_ext.go
@@ -51,3 +51,80 @@ func handleRelationStatsExt(db *sql.DB, relStats state.PostgresRelationStatsMap,
 
 	return relStats, nil
 }
+
+const citusIndexSizeSQL = `
+WITH dist_idx_shard_stats_raw AS (
+	SELECT
+		dp.logicalrelid::regclass,
+		(pg_catalog.run_command_on_shards(logicalrelid::regclass::text, $$
+			SELECT
+				jsonb_agg(shard_idx_stats)
+			FROM (
+				SELECT
+					relnamespace::regnamespace AS idx_shard_schema,
+					indexrelid::regclass AS idx_shard_name,
+					COALESCE(pg_catalog.pg_relation_size(indexrelid), 0) AS idx_shard_bytes
+				FROM
+					pg_stat_user_indexes pgsui INNER JOIN pg_class pgc ON pgc.oid = pgsui.relid
+				WHERE
+					relid = '%s'::regclass
+			) AS shard_idx_stats
+		$$)).*
+	FROM
+		pg_dist_partition dp INNER JOIN pg_catalog.pg_class c ON (dp.logicalrelid::oid = c.oid)
+			 INNER JOIN pg_catalog.pg_namespace n ON (c.relnamespace = n.oid)
+	WHERE
+		($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)
+), dist_idx_shard_stats AS (
+	SELECT
+		shardid,
+		bool_and(success) OVER() AS all_success,
+		jsonb_array_elements(result::jsonb) AS shard_info
+	FROM
+		dist_idx_shard_stats_raw
+)
+SELECT
+	pgc.oid,
+	sum((shard_info ->> 'idx_shard_bytes')::bigint) AS total_size_bytes
+FROM
+  pg_class pgc INNER JOIN dist_idx_shard_stats ON (
+		pgc.relkind = 'i'
+			AND pgc.relnamespace::regnamespace::text = (shard_info ->> 'idx_shard_schema')
+			AND pgc.relname = pg_catalog.regexp_replace(shard_info ->> 'idx_shard_name', '_' || shardid || '$', '')
+	)
+WHERE
+	all_success
+GROUP BY
+  oid;
+`
+
+func handleIndexStatsExt(db *sql.DB, idxStats state.PostgresIndexStatsMap, postgresVersion state.PostgresVersion, ignoreRegexp string) (state.PostgresIndexStatsMap, error) {
+	if postgresVersion.IsCitus {
+		stmt, err := db.Prepare(QueryMarkerSQL + citusIndexSizeSQL)
+		if err != nil {
+			return idxStats, fmt.Errorf("IndexStatsExt/Prepare: %s", err)
+		}
+		defer stmt.Close()
+
+		rows, err := stmt.Query(ignoreRegexp)
+		if err != nil {
+			return idxStats, fmt.Errorf("IndexStatsExt/Query: %s", err)
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var oid state.Oid
+			var sizeBytes int64
+
+			err = rows.Scan(&oid, &sizeBytes)
+			if err != nil {
+				return idxStats, fmt.Errorf("IndexStatsExt/Scan: %s", err)
+			}
+			s := idxStats[oid]
+			s.SizeBytes = sizeBytes
+			idxStats[oid] = s
+		}
+	}
+
+	return idxStats, nil
+}


### PR DESCRIPTION
Currently, when monitoring Citus databases, we collect distributed
table sizes with Citus' `citus_table_size` helper function, but we
ignore indexes on these distributed tables.

Add a similar calculation for index sizes. While there is a similar
`citus_relation_size` that is documented to work for distributed
indexes, it does not [1]. Instead, we use `run_command_on_shards` to
get this information from the underlying catalog objects and stats
directly.

[1]: I filed https://github.com/citusdata/citus/issues/6496 which
     seems to be getting some attention, so maybe there is hope for a
     better fix
