### PR TITLE
Add Citus integration smoke test

### DIFF
--- a/integration_test/Dockerfile.test-citus
+++ b/integration_test/Dockerfile.test-citus
@@ -1,0 +1,25 @@
+FROM citusdata/citus:11.1
+
+ARG TARGETARCH
+
+ENV GOVERSION 1.17
+ENV CODE_DIR /collector
+ENV PATH $PATH:/usr/local/go/bin
+
+# Packages required for both building and packaging
+RUN apt-get update -qq && apt-get install -y -q build-essential git curl
+
+# Golang
+RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
+RUN tar -C /usr/local -xzf go.tar.gz
+
+# Build the collector
+COPY . $CODE_DIR
+WORKDIR $CODE_DIR
+RUN make build_dist
+
+# Make sure collector state can be saved
+RUN mkdir /var/lib/pganalyze-collector/
+
+RUN cp $CODE_DIR/pganalyze-collector /usr/bin/
+RUN cp $CODE_DIR/pganalyze-collector-helper /usr/bin/

--- a/integration_test/Makefile
+++ b/integration_test/Makefile
@@ -13,9 +13,9 @@ docker_run_cmd = docker run --name pganalyze-collector-test \
   -d pganalyze-collector-test $(1)
 docker_run_cmd_postgres = $(call docker_run_cmd,postgres -c pg_stat_statements.track_utility=off)
 
-.PHONY: pg96 pg10 pg11 pg12 pg13 pg14 pg15 reload guided-setup installer
+.PHONY: pg96 pg10 pg11 pg12 pg13 pg14 pg15 citus reload guided-setup installer
 
-all: pg96 pg10 pg11 pg12 pg13 pg14 pg15 reload guided-setup installer
+all: pg96 pg10 pg11 pg12 pg13 pg14 pg15 citus reload guided-setup installer
 
 pg96:
 	docker build -f Dockerfile.test-pg96 $(DOCKER_BUILD_OPTS)
@@ -177,6 +177,30 @@ pg15:
 	fi
 	jq '.queryInformations[].normalizedQuery' pg15_2.json | sort --version-sort -f > pg15.out
 	diff -Naur pg15.expected pg15.out && echo 'success'
+
+citus:
+	docker build -f Dockerfile.test-citus $(DOCKER_BUILD_OPTS)
+	$(docker_run_cmd_postgres)
+	sleep 10
+	docker exec pganalyze-collector-test pgbench -U postgres postgres -i
+	docker exec pganalyze-collector-test psql -U postgres postgres < citus-pgbench-ddl.sql
+	docker exec pganalyze-collector-test pgbench -U postgres postgres
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > citus_1.json
+	docker exec pganalyze-collector-test pgbench -U postgres postgres
+	docker exec pganalyze-collector-test sh -c "DB_USERNAME=postgres PGA_API_KEY=dummy PGA_DISABLE_ACTIVITY=1 IGNORE_SCHEMA_REGEXP=pgbench_history pganalyze-collector --dry-run --force-state-update -v" > citus_2.json
+	docker rm -f pganalyze-collector-test
+	docker rmi pganalyze-collector-test
+	if [ "`jq '.collectorErrors' citus_2.json | tr -d ' \n\r\t '`" != "null" ]; then \
+		jq '.collectorErrors' citus_2.json; \
+		exit 1; \
+	fi
+	if jq '.relationReferences' citus_2.json | grep --quiet pgbench_history; then \
+                echo "failed to ignore table according to IGNORE_SCHEMA_REGEXP=pgbench_history" \
+		jq '.relationReferences' citus_2.json; \
+		exit 1; \
+	fi
+	jq '.queryInformations[].normalizedQuery' citus_2.json | sort --version-sort -f > citus.out
+	diff -Naur citus.expected citus.out && echo 'success'
 
 # Test reload both with an empty config and a server present
 #

--- a/integration_test/citus-pgbench-ddl.sql
+++ b/integration_test/citus-pgbench-ddl.sql
@@ -1,0 +1,8 @@
+ALTER TABLE pgbench_accounts DROP CONSTRAINT pgbench_accounts_pkey;
+ALTER TABLE pgbench_accounts ADD PRIMARY KEY (aid, bid);
+ALTER TABLE pgbench_tellers DROP CONSTRAINT pgbench_tellers_pkey;
+ALTER TABLE pgbench_tellers ADD PRIMARY KEY (tid, bid);
+SELECT create_distributed_table('pgbench_accounts', 'bid');
+SELECT create_distributed_table('pgbench_branches', 'bid');
+SELECT create_distributed_table('pgbench_history', 'bid');
+SELECT create_distributed_table('pgbench_tellers', 'bid');

--- a/integration_test/citus.expected
+++ b/integration_test/citus.expected
@@ -1,0 +1,8 @@
+"INSERT INTO pgbench_history (tid, bid, aid, delta, mtime) VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)"
+"SELECT abalance FROM pgbench_accounts WHERE aid = $1"
+"select count(*) from pgbench_branches"
+"select o.n, p.partstrat, pg_catalog.count(i.inhparent) from pg_catalog.pg_class as c join pg_catalog.pg_namespace as n on (n.oid = c.relnamespace) cross join lateral (select pg_catalog.array_position(pg_catalog.current_schemas($1), n.nspname)) as o(n) left join pg_catalog.pg_partitioned_table as p on (p.partrelid = c.oid) left join pg_catalog.pg_inherits as i on (c.oid = i.inhparent) where c.relname = $2 and o.n is not null group by 1, 2 order by 1 asc limit $3"
+"UPDATE pgbench_accounts SET abalance = abalance + $1 WHERE aid = $2"
+"UPDATE pgbench_branches SET bbalance = bbalance + $1 WHERE bid = $2"
+"UPDATE pgbench_tellers SET tbalance = tbalance + $1 WHERE tid = $2"
+"<pganalyze-collector>"

--- a/integration_test/docker-entrypoint-initdb.d/postgres-pgss.sh
+++ b/integration_test/docker-entrypoint-initdb.d/postgres-pgss.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
-perl -pi -e "s/#shared_preload_libraries = ''/shared_preload_libraries = 'pg_stat_statements'/g" /var/lib/postgresql/data/postgresql.conf
+if grep -q citus /var/lib/postgresql/data/postgresql.conf;
+then
+  perl -pi -e "s/shared_preload_libraries='citus'/shared_preload_libraries = 'citus,pg_stat_statements'/g" /var/lib/postgresql/data/postgresql.conf
+else
+  perl -pi -e "s/#shared_preload_libraries = ''/shared_preload_libraries = 'pg_stat_statements'/g" /var/lib/postgresql/data/postgresql.conf
+fi
 
 echo "Enabled pg_stat_statements"


### PR DESCRIPTION
This adds a very basic run-through of pganalyze on a Citus
workload. It uses the latest Citus image and modifies the default
pgbench schema we use in stock Postgres tests to use Citus distributed
tables. This ensures monitoring features like calculating distributed
table sizes on Citus are properly exercised.
