### PR TITLE
Add `always_collect_system_data` config option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -37,10 +37,10 @@ type ServerConfig struct {
 	ErrorCallback   string `ini:"error_callback"`
 	SuccessCallback string `ini:"success_callback"`
 
-	EnableReports           bool `ini:"enable_reports"`
-	DisableLogs             bool `ini:"disable_logs"`
-	DisableActivity         bool `ini:"disable_activity"`
-	EnableLogExplain        bool `ini:"enable_log_explain"`
+	EnableReports    bool `ini:"enable_reports"`
+	DisableLogs      bool `ini:"disable_logs"`
+	DisableActivity  bool `ini:"disable_activity"`
+	EnableLogExplain bool `ini:"enable_log_explain"`
 
 	DbURL                 string `ini:"db_url"`
 	DbName                string `ini:"db_name"`

--- a/config/config.go
+++ b/config/config.go
@@ -37,10 +37,11 @@ type ServerConfig struct {
 	ErrorCallback   string `ini:"error_callback"`
 	SuccessCallback string `ini:"success_callback"`
 
-	EnableReports    bool `ini:"enable_reports"`
-	DisableLogs      bool `ini:"disable_logs"`
-	DisableActivity  bool `ini:"disable_activity"`
-	EnableLogExplain bool `ini:"enable_log_explain"`
+	EnableReports           bool `ini:"enable_reports"`
+	DisableLogs             bool `ini:"disable_logs"`
+	DisableActivity         bool `ini:"disable_activity"`
+	EnableLogExplain        bool `ini:"enable_log_explain"`
+	AlwaysCollectSystemData bool `ini:"always_collect_system_data"`
 
 	DbURL                 string `ini:"db_url"`
 	DbName                string `ini:"db_name"`

--- a/config/config.go
+++ b/config/config.go
@@ -41,7 +41,6 @@ type ServerConfig struct {
 	DisableLogs             bool `ini:"disable_logs"`
 	DisableActivity         bool `ini:"disable_activity"`
 	EnableLogExplain        bool `ini:"enable_log_explain"`
-	AlwaysCollectSystemData bool `ini:"always_collect_system_data"`
 
 	DbURL                 string `ini:"db_url"`
 	DbName                string `ini:"db_name"`
@@ -115,6 +114,8 @@ type ServerConfig struct {
 	SystemIDFallback    string `ini:"api_system_id_fallback"`
 	SystemTypeFallback  string `ini:"api_system_type_fallback"`
 	SystemScopeFallback string `ini:"api_system_scope_fallback"`
+
+	AlwaysCollectSystemData bool `ini:"always_collect_system_data"`
 
 	// Configures the location where logfiles are - this can either be a directory,
 	// or a file - needs to readable by the regular pganalyze user

--- a/config/read.go
+++ b/config/read.go
@@ -71,6 +71,9 @@ func getDefaultConfig() *ServerConfig {
 	if enableLogExplain := os.Getenv("PGA_ENABLE_LOG_EXPLAIN"); enableLogExplain != "" {
 		config.EnableLogExplain = parseConfigBool(enableLogExplain)
 	}
+	if alwaysCollectSystemData := os.Getenv("PGA_ALWAYS_COLLECT_SYSTEM_DATA"); alwaysCollectSystemData != "" {
+		config.AlwaysCollectSystemData = parseConfigBool(alwaysCollectSystemData)
+	}
 	if dbURL := os.Getenv("DB_URL"); dbURL != "" {
 		config.DbURL = dbURL
 	}

--- a/config/read.go
+++ b/config/read.go
@@ -71,9 +71,6 @@ func getDefaultConfig() *ServerConfig {
 	if enableLogExplain := os.Getenv("PGA_ENABLE_LOG_EXPLAIN"); enableLogExplain != "" {
 		config.EnableLogExplain = parseConfigBool(enableLogExplain)
 	}
-	if alwaysCollectSystemData := os.Getenv("PGA_ALWAYS_COLLECT_SYSTEM_DATA"); alwaysCollectSystemData != "" {
-		config.AlwaysCollectSystemData = parseConfigBool(alwaysCollectSystemData)
-	}
 	if dbURL := os.Getenv("DB_URL"); dbURL != "" {
 		config.DbURL = dbURL
 	}
@@ -212,6 +209,9 @@ func getDefaultConfig() *ServerConfig {
 	}
 	if logSyslogServer := os.Getenv("LOG_SYSLOG_SERVER"); logSyslogServer != "" {
 		config.LogSyslogServer = logSyslogServer
+	}
+	if alwaysCollectSystemData := os.Getenv("PGA_ALWAYS_COLLECT_SYSTEM_DATA"); alwaysCollectSystemData != "" {
+		config.AlwaysCollectSystemData = parseConfigBool(alwaysCollectSystemData)
 	}
 	if logPgReadFile := os.Getenv("LOG_PG_READ_FILE"); logPgReadFile != "" {
 		config.LogPgReadFile = parseConfigBool(logPgReadFile)

--- a/input/system/system.go
+++ b/input/system/system.go
@@ -1,8 +1,6 @@
 package system
 
 import (
-	"os"
-
 	"github.com/pganalyze/collector/config"
 	"github.com/pganalyze/collector/input/postgres"
 	"github.com/pganalyze/collector/input/system/rds"
@@ -46,7 +44,7 @@ func GetSystemState(config config.ServerConfig, logger *util.Logger) (system sta
 		// runs on the database server itself and can gather local statistics
 		system = selfhosted.GetSystemState(config, logger)
 		system.Info.Type = state.CrunchyBridgeSystem
-	} else if dbHost == "" || dbHost == "localhost" || dbHost == "127.0.0.1" || os.Getenv("PGA_ALWAYS_COLLECT_SYSTEM_DATA") != "" {
+	} else if dbHost == "" || dbHost == "localhost" || dbHost == "127.0.0.1" || config.AlwaysCollectSystemData {
 		system = selfhosted.GetSystemState(config, logger)
 	}
 


### PR DESCRIPTION
Now we try to read the value of `always_collect_system_data` in the config file, as well as the original `PGA_ALWAYS_COLLECT_SYSTEM_DATA` environment variable.

This is useful for ~~non-container setups which connect to remote servers~~ package-based setups which monitor the local server by a non-local IP.