### PR TITLE
Use query ID cache to skip query fingerprint calculation

### DIFF
--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -236,14 +236,14 @@ func GetStatements(server *state.Server, logger *util.Logger, db *sql.DB, global
 		if showtext {
 			statementTexts[key] = receivedQuery.String
 		}
-		if queryID.Valid {
+		if queryID.Valid && showtext {
 			if server.PrevState.QueryIdentities == nil {
 				server.PrevState.QueryIdentities = make(state.QueryIdentityMap)
 			}
 			if identity, ok := server.PrevState.QueryIdentities[queryID.Int64]; ok {
 				identity.LastSeen = time.Now()
 				statementFingerprints[key] = identity.Fingerprint
-			} else if showtext {
+			} else {
 				server.PrevState.QueryIdentities[queryID.Int64] = state.QueryIdentity{
 					QueryID:     queryID.Int64,
 					Fingerprint: util.FingerprintQuery(receivedQuery.String, server.Config.FilterQueryText, -1),


### PR DESCRIPTION
Query fingerprinting takes around half of `GetStatements` runtime (0.9 of 1.9 seconds in the below pprof screenshot). Since #339 adds a query_id/fingerprint cache, we can rely on that to skip this expensive step.

<img width="1331" alt="Screenshot 2022-12-16 at 9 23 40 AM" src="https://user-images.githubusercontent.com/688886/208191209-b3d8fc5a-af9f-4f88-b7ad-f7ef86a05eab.png">
