### PR TITLE
Do not hit AWS API when RDS idenfier is in config

### DIFF
--- a/util/awsutil/rds.go
+++ b/util/awsutil/rds.go
@@ -17,6 +17,11 @@ var IdentifierMap *util.TTLMap = util.NewTTLMap(5 * 60)
 var ErrorCache *util.TTLMap = util.NewTTLMap(10 * 60)
 
 func FindRdsIdentifier(config config.ServerConfig, sess *session.Session) (identifier string, err error) {
+	if config.AwsDbInstanceID != "" {
+		identifier = config.AwsDbInstanceID
+		return
+	}
+
 	identifier = IdentifierMap.Get(config.AwsDbInstanceID)
 	if identifier != "" {
 		return


### PR DESCRIPTION
When the pganalyze collector is trying to download logs for a configured RDS instance, it is currently taking the RDS instance identifier in the config, calling the AWS API to describe DB instances with that identifier, and then taking the same identifier in the response.

This just skips the AWS API call when we already know the identifier in the config.