### PR TITLE
Ignore non-postgres URIs in environment

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -534,7 +534,7 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 		}
 	} else {
 		if os.Getenv("DYNO") != "" && os.Getenv("PORT") != "" {
-			pg_uri_regex := regexp.MustCompile("\Apostgres(?:ql)?://.*")
+			pg_uri_regex := regexp.MustCompile(`\Apostgres(?:ql)?://.*`)
 
 			for _, kv := range os.Environ() {
 				parts := strings.SplitN(kv, "=", 2)

--- a/config/read.go
+++ b/config/read.go
@@ -534,7 +534,7 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 		}
 	} else {
 		if os.Getenv("DYNO") != "" && os.Getenv("PORT") != "" {
-			pg_uri_regex, _ := regexp.MustCompile("^postgres(?:ql)?://.*")
+			pg_uri_regex, _ := regexp.MustCompile("\Apostgres(?:ql)?://.*")
 
 			for _, kv := range os.Environ() {
 				parts := strings.SplitN(kv, "=", 2)

--- a/config/read.go
+++ b/config/read.go
@@ -534,7 +534,7 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 		}
 	} else {
 		if os.Getenv("DYNO") != "" && os.Getenv("PORT") != "" {
-			pg_uri_regex, _ := regexp.Compile("^postgres(?:ql)?://.*")
+			pg_uri_regex, _ := regexp.MustCompile("^postgres(?:ql)?://.*")
 
 			for _, kv := range os.Environ() {
 				parts := strings.SplitN(kv, "=", 2)

--- a/config/read.go
+++ b/config/read.go
@@ -534,7 +534,7 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 		}
 	} else {
 		if os.Getenv("DYNO") != "" && os.Getenv("PORT") != "" {
-			pg_uri_regex, _ := regexp.MustCompile("\Apostgres(?:ql)?://.*")
+			pg_uri_regex := regexp.MustCompile("\Apostgres(?:ql)?://.*")
 
 			for _, kv := range os.Environ() {
 				parts := strings.SplitN(kv, "=", 2)

--- a/config/read.go
+++ b/config/read.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -533,9 +534,16 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 		}
 	} else {
 		if os.Getenv("DYNO") != "" && os.Getenv("PORT") != "" {
+			pg_uri_regex, _ := regexp.Compile("^postgres(?:ql)?://.*")
+
 			for _, kv := range os.Environ() {
 				parts := strings.SplitN(kv, "=", 2)
 				if strings.HasSuffix(parts[0], "_URL") {
+					matched := pg_uri_regex.MatchString(parts[1])
+					if !matched {
+						continue
+					}
+
 					config := getDefaultConfig()
 					config, err = preprocessConfig(config)
 					if err != nil {

--- a/config/read.go
+++ b/config/read.go
@@ -538,30 +538,35 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 
 			for _, kv := range os.Environ() {
 				parts := strings.SplitN(kv, "=", 2)
-				if strings.HasSuffix(parts[0], "_URL") {
-					matched := pg_uri_regex.MatchString(parts[1])
-					if !matched {
-						continue
-					}
-
-					config := getDefaultConfig()
-					config, err = preprocessConfig(config)
-					if err != nil {
-						return conf, err
-					}
-					config.SectionName = parts[0]
-					config.SystemID = strings.Replace(parts[0], "_URL", "", 1)
-					config.SystemType = "heroku"
-					config.DbURL = parts[1]
-					config.Identifier = ServerIdentifier{
-						APIKey:      config.APIKey,
-						APIBaseURL:  config.APIBaseURL,
-						SystemID:    config.SystemID,
-						SystemType:  config.SystemType,
-						SystemScope: config.SystemScope,
-					}
-					conf.Servers = append(conf.Servers, *config)
+				parsed_key := parts[0]
+				parsed_value := parts[1]
+				if !strings.HasSuffix(parsed_key, "_URL") {
+					continue
 				}
+
+				matched := pg_uri_regex.MatchString(parsed_value)
+				if !matched {
+					continue
+				}
+
+				config := getDefaultConfig()
+				config, err = preprocessConfig(config)
+				if err != nil {
+					return conf, err
+				}
+
+				config.SectionName = parsed_key
+				config.SystemID = strings.Replace(parsed_key, "_URL", "", 1)
+				config.SystemType = "heroku"
+				config.DbURL = parsed_value
+				config.Identifier = ServerIdentifier{
+					APIKey:      config.APIKey,
+					APIBaseURL:  config.APIBaseURL,
+					SystemID:    config.SystemID,
+					SystemType:  config.SystemType,
+					SystemScope: config.SystemScope,
+				}
+				conf.Servers = append(conf.Servers, *config)
 			}
 		} else if os.Getenv("PGA_API_KEY") != "" {
 			config := getDefaultConfig()


### PR DESCRIPTION
solving #344 

> Hello,
> 
> Thank you for your work.
> 
> I have one of our add-on that add a ENV on our running collector; this env is named HEROKU_METRICS_URL. The problem is that the collector handle it as a PG URL and try to connect to it. There is no immediate problem with this kind of behavior, but there are two glitches.
> 
> The collector adds a DB named HEROKU_METRICS on PGAnalyze website
> when I run collector --test there is some log saying that he can't connect to this DB, as it's an HTTPS URI: (https://app.metrics.heroku.com/[...REDACTED...])
> There are 2 solutions. Add a denylist (or allowlist) OR detect that the URL isn't a pg schema.
> ```
> `postgres(?:ql)?.*\`gm
> ```