### PR TITLE
Check errors with rows after iterating

### DIFF
--- a/input/postgres/backend_counts.go
+++ b/input/postgres/backend_counts.go
@@ -73,5 +73,9 @@ func GetBackendCounts(logger *util.Logger, db *sql.DB, postgresVersion state.Pos
 		backendCounts = append(backendCounts, row)
 	}
 
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
 	return backendCounts, nil
 }

--- a/input/postgres/backends.go
+++ b/input/postgres/backends.go
@@ -91,5 +91,9 @@ func GetBackends(logger *util.Logger, db *sql.DB, postgresVersion state.Postgres
 		activities = append(activities, row)
 	}
 
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
 	return activities, nil
 }

--- a/input/postgres/buffercache.go
+++ b/input/postgres/buffercache.go
@@ -129,6 +129,10 @@ func GetBuffercache(logger *util.Logger, db *sql.DB, systemType, ignoreRegexp st
 			report.Entries = append(report.Entries, row)
 		}
 	}
+	if err = rows.Err(); err != nil {
+		err = fmt.Errorf("Buffercache/Rows: %s", err)
+		return
+	}
 
 	for idx, row := range report.Entries {
 		if row.SchemaName != nil && *row.SchemaName == "pg_toast" && row.ObjectName != nil {

--- a/input/postgres/databases.go
+++ b/input/postgres/databases.go
@@ -63,5 +63,9 @@ func GetDatabases(logger *util.Logger, db *sql.DB, postgresVersion state.Postgre
 		databaseStats[d.Oid] = ds
 	}
 
+	if err = rows.Err(); err != nil {
+		return nil, nil, err
+	}
+
 	return databases, databaseStats, nil
 }

--- a/input/postgres/extensions.go
+++ b/input/postgres/extensions.go
@@ -43,5 +43,9 @@ func GetExtensions(db *sql.DB, currentDatabaseOid state.Oid) ([]state.PostgresEx
 		extensions = append(extensions, e)
 	}
 
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
 	return extensions, nil
 }

--- a/input/postgres/functions.go
+++ b/input/postgres/functions.go
@@ -85,6 +85,10 @@ func GetFunctions(db *sql.DB, postgresVersion state.PostgresVersion, currentData
 		functions = append(functions, row)
 	}
 
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
 	return functions, nil
 }
 
@@ -115,6 +119,11 @@ func GetFunctionStats(db *sql.DB, postgresVersion state.PostgresVersion, ignoreR
 		}
 
 		functionStats[oid] = stats
+	}
+
+	if err = rows.Err(); err != nil {
+		err = fmt.Errorf("FunctionStats/Rows: %s", err)
+		return
 	}
 
 	return

--- a/input/postgres/log_pg_read_file.go
+++ b/input/postgres/log_pg_read_file.go
@@ -52,14 +52,23 @@ func LogPgReadFile(server *state.Server, globalCollectionOpts state.CollectionOp
 		err = fmt.Errorf("LogFileSql/Query: %s", err)
 		return server.LogPrevState, nil, nil, err
 	}
+	defer rows.Close()
 
 	var fileNames []string
 	for rows.Next() {
 		var fileName string
 		err = rows.Scan(&fileName)
+		if err != nil {
+			err = fmt.Errorf("LogFileSql/Scan: %s", err)
+			return server.LogPrevState, nil, nil, err
+		}
 		fileNames = append(fileNames, fileName)
 	}
-	rows.Close()
+
+	if err = rows.Err(); err != nil {
+		err = fmt.Errorf("LogFileSql/Rows: %s", err)
+		return server.LogPrevState, nil, nil, err
+	}
 
 	useHelper := StatsHelperExists(db, "read_log_file")
 	var logReadSql = SuperUserReadLogFileSql

--- a/input/postgres/relation_bloat.go
+++ b/input/postgres/relation_bloat.go
@@ -215,6 +215,11 @@ func GetRelationBloat(logger *util.Logger, db *sql.DB, columnStatsSourceTable st
 		}
 	}
 
+	if err = rows.Err(); err != nil {
+		err = fmt.Errorf("TableBloat/Rows: %s", err)
+		return nil, err
+	}
+
 	return
 }
 
@@ -238,6 +243,11 @@ func GetIndexBloat(logger *util.Logger, db *sql.DB, columnStatsSourceTable, igno
 		if row.TotalBytes > 0 && row.BloatBytes > 0 {
 			indexBloat = append(indexBloat, row)
 		}
+	}
+
+	if err = rows.Err(); err != nil {
+		err = fmt.Errorf("IndexBloat/Rows: %s", err)
+		return nil, err
 	}
 
 	return

--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -141,6 +141,11 @@ func GetRelationStats(db *sql.DB, postgresVersion state.PostgresVersion, ignoreR
 		relStats[oid] = stats
 	}
 
+	if err = rows.Err(); err != nil {
+		err = fmt.Errorf("RelationStats/Rows: %s", err)
+		return
+	}
+
 	relStats, err = handleRelationStatsExt(db, relStats, postgresVersion, ignoreRegexp)
 
 	return
@@ -174,6 +179,11 @@ func GetIndexStats(db *sql.DB, postgresVersion state.PostgresVersion, ignoreRege
 		}
 
 		indexStats[oid] = stats
+	}
+
+	if err = rows.Err(); err != nil {
+		err = fmt.Errorf("IndexStats/Rows: %s", err)
+		return
 	}
 
 	indexStats, err = handleIndexStatsExt(db, indexStats, postgresVersion, ignoreRegexp)
@@ -224,6 +234,10 @@ func GetColumnStats(logger *util.Logger, db *sql.DB, globalCollectionOpts state.
 
 		key := state.PostgresColumnStatsKey{SchemaName: s.SchemaName, TableName: s.TableName, ColumnName: s.ColumnName}
 		statsMap[key] = append(statsMap[key], s)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
 	}
 
 	return statsMap, nil

--- a/input/postgres/relation_stats_ext.go
+++ b/input/postgres/relation_stats_ext.go
@@ -47,6 +47,10 @@ func handleRelationStatsExt(db *sql.DB, relStats state.PostgresRelationStatsMap,
 			s.ToastSizeBytes = 0
 			relStats[oid] = s
 		}
+
+		if err = rows.Err(); err != nil {
+			return relStats, fmt.Errorf("RelationStatsExt/Rows: %s", err)
+		}
 	}
 
 	return relStats, nil
@@ -123,6 +127,10 @@ func handleIndexStatsExt(db *sql.DB, idxStats state.PostgresIndexStatsMap, postg
 			s := idxStats[oid]
 			s.SizeBytes = sizeBytes
 			idxStats[oid] = s
+		}
+
+		if err = rows.Err(); err != nil {
+			return idxStats, fmt.Errorf("IndexStatsExt/Rows: %s", err)
 		}
 	}
 

--- a/input/postgres/relations.go
+++ b/input/postgres/relations.go
@@ -207,6 +207,11 @@ func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentData
 		relations[row.Oid] = row
 	}
 
+	if err := rows.Err(); err != nil {
+		err = fmt.Errorf("Relations/Rows: %s", err)
+		return nil, err
+	}
+
 	// Columns
 	rows, err = db.Query(QueryMarkerSQL+columnsSQL, ignoreRegexp)
 	if err != nil {
@@ -229,6 +234,11 @@ func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentData
 		relation := relations[row.RelationOid]
 		relation.Columns = append(relation.Columns, row)
 		relations[row.RelationOid] = relation
+	}
+
+	if err := rows.Err(); err != nil {
+		err = fmt.Errorf("Columns/Rows: %s", err)
+		return nil, err
 	}
 
 	// Indices
@@ -268,6 +278,11 @@ func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentData
 		relation := relations[row.RelationOid]
 		relation.Indices = append(relation.Indices, row)
 		relations[row.RelationOid] = relation
+	}
+
+	if err := rows.Err(); err != nil {
+		err = fmt.Errorf("Indices/Rows: %s", err)
+		return nil, err
 	}
 
 	// Constraints
@@ -319,6 +334,11 @@ func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentData
 		relations[row.RelationOid] = relation
 	}
 
+	if err := rows.Err(); err != nil {
+		err = fmt.Errorf("Constraints/Rows: %s", err)
+		return nil, err
+	}
+
 	// View definitions
 	rows, err = db.Query(QueryMarkerSQL+viewDefinitionSQL, ignoreRegexp)
 	if err != nil {
@@ -341,6 +361,11 @@ func GetRelations(db *sql.DB, postgresVersion state.PostgresVersion, currentData
 		relation := relations[relationOid]
 		relation.ViewDefinition = viewDefinition
 		relations[relationOid] = relation
+	}
+
+	if err := rows.Err(); err != nil {
+		err = fmt.Errorf("Views/Rows: %s", err)
+		return nil, err
 	}
 
 	// Flip the oid-based map into an array

--- a/input/postgres/replication.go
+++ b/input/postgres/replication.go
@@ -137,6 +137,10 @@ func GetReplication(logger *util.Logger, db *sql.DB, postgresVersion state.Postg
 		repl.Standbys = append(repl.Standbys, s)
 	}
 
+	if err = rows.Err(); err != nil {
+		return repl, err
+	}
+
 	return repl, nil
 }
 

--- a/input/postgres/roles.go
+++ b/input/postgres/roles.go
@@ -71,5 +71,9 @@ func GetRoles(logger *util.Logger, db *sql.DB, postgresVersion state.PostgresVer
 		roles = append(roles, r)
 	}
 
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
 	return roles, nil
 }

--- a/input/postgres/settings.go
+++ b/input/postgres/settings.go
@@ -61,5 +61,10 @@ func GetSettings(db *sql.DB) ([]state.PostgresSetting, error) {
 		settings = append(settings, row)
 	}
 
+	if err = rows.Err(); err != nil {
+		err = fmt.Errorf("Settings/Rows: %s", err)
+		return nil, err
+	}
+
 	return settings, nil
 }

--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -240,8 +240,8 @@ func GetStatements(server *state.Server, logger *util.Logger, db *sql.DB, global
 		}
 		statementStats[key] = stats
 	}
-	err = rows.Err()
-	if err != nil {
+
+	if err = rows.Err(); err != nil {
 		return nil, nil, nil, err
 	}
 

--- a/input/postgres/types.go
+++ b/input/postgres/types.go
@@ -77,5 +77,9 @@ func GetTypes(db *sql.DB, postgresVersion state.PostgresVersion, currentDatabase
 		types = append(types, t)
 	}
 
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
 	return types, nil
 }

--- a/input/postgres/vacuum_progress.go
+++ b/input/postgres/vacuum_progress.go
@@ -134,6 +134,10 @@ func GetVacuumProgress(logger *util.Logger, db *sql.DB, postgresVersion state.Po
 		vacuums = append(vacuums, row)
 	}
 
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
 	for idx, row := range vacuums {
 		if row.SchemaName == "pg_toast" {
 			schemaName, relationName, err := resolveToastTable(db, row.RelationName)

--- a/input/postgres/vacuum_stats.go
+++ b/input/postgres/vacuum_stats.go
@@ -46,7 +46,10 @@ func GetVacuumStats(logger *util.Logger, db *sql.DB, ignoreRegexp string) (repor
 		var name string
 		var value string
 
-		configRows.Scan(&name, &value)
+		err = configRows.Scan(&name, &value)
+		if err != nil {
+			return
+		}
 
 		switch name {
 		case "autovacuum":
@@ -99,11 +102,14 @@ func GetVacuumStats(logger *util.Logger, db *sql.DB, ignoreRegexp string) (repor
 		var entry state.PostgresVacuumStatsEntry
 		var relopts string
 
-		rows.Scan(&entry.SchemaName, &entry.RelationName, &entry.LiveRowCount,
+		err = rows.Scan(&entry.SchemaName, &entry.RelationName, &entry.LiveRowCount,
 			&entry.DeadRowCount, &entry.Relfrozenxid, &entry.Relminmxid,
 			&entry.LastManualVacuumRun, &entry.LastAutoVacuumRun,
 			&entry.LastManualAnalyzeRun, &entry.LastAutoAnalyzeRun,
 			&relopts)
+		if err != nil {
+			return
+		}
 
 		entry.AutovacuumEnabled = report.AutovacuumEnabled
 		entry.AutovacuumVacuumThreshold = report.AutovacuumVacuumThreshold

--- a/input/postgres/vacuum_stats.go
+++ b/input/postgres/vacuum_stats.go
@@ -84,6 +84,10 @@ func GetVacuumStats(logger *util.Logger, db *sql.DB, ignoreRegexp string) (repor
 		}
 	}
 
+	if err = configRows.Err(); err != nil {
+		return
+	}
+
 	rows, err := db.Query(QueryMarkerSQL + tableVacuumSQL)
 	if err != nil {
 		return
@@ -148,6 +152,10 @@ func GetVacuumStats(logger *util.Logger, db *sql.DB, ignoreRegexp string) (repor
 		}
 
 		report.Relations = append(report.Relations, entry)
+	}
+
+	if err = rows.Err(); err != nil {
+		return
 	}
 
 	report.DatabaseName, err = CurrentDatabaseName(db)


### PR DESCRIPTION
When we're reading rows data, we usually check if the scan was good in each row, but we don't check the error after iterating over rows. This is not following the suggested usage (http://go-database-sql.org/retrieving.html), and unfortunately ignoring errors like query timeout.

This is especially problematic when the subsequent code is using the result of these rows, as if it timed out in the middle, it will have incomplete rows data (e.g. `GetRelations()` in `input/postgres/relations.go`, where it gets the table list first, then use that table list with the other query like columns info).

With this PR, introducing such check for every place that we're doing `rows.Next()`. I also double checked if we're doing `defer rows.Close()` properly (fixed one place). Hopefully this will improve the 