### PR TITLE
Log parsing: Add support for timezones specified by number, such as "-03"

### DIFF
--- a/logs/parse.go
+++ b/logs/parse.go
@@ -486,10 +486,16 @@ func ParseLogLineWithPrefix(prefix string, line string) (logLine state.LogLine, 
 		// https://pkg.go.dev/time#Parse
 		zone, offset := logLine.OccurredAt.Zone()
 		if offset == 0 && zone != "UTC" && zone != "" {
-			zoneLocation, err := time.LoadLocation(zone)
-			if err != nil {
-				// We don't know which timezone this is (and a timezone name is present), so we can't process this log line
-				return
+			var zoneLocation *time.Location
+			zoneNum, err := strconv.Atoi(zone)
+			if err == nil {
+				zoneLocation = time.FixedZone(zone, zoneNum*3600)
+			} else {
+				zoneLocation, err = time.LoadLocation(zone)
+				if err != nil {
+					// We don't know which timezone this is (and a timezone name is present), so we can't process this log line
+					return
+				}
 			}
 			logLine.OccurredAt, err = time.ParseInLocation(timeFormat, timePart, zoneLocation)
 			if err != nil {

--- a/logs/parse_test.go
+++ b/logs/parse_test.go
@@ -523,6 +523,17 @@ var parseTests = []parseTestpair{
 		},
 		true,
 	},
+	{
+		"",
+		"2022-12-23 09:53:43.862 -03 [790081] LOG: pganalyze-collector-identify: server1",
+		state.LogLine{
+			OccurredAt: time.Date(2022, time.December, 23, 9, 53, 43, 862*1000*1000, time.FixedZone("-03", -3*3600)),
+			LogLevel:   6,
+			BackendPid: 790081,
+			Content:    "pganalyze-collector-identify: server1",
+		},
+		true,
+	},
 }
 
 func TestParseLogLineWithPrefix(t *testing.T) {


### PR DESCRIPTION
Some of the timezone abbreviations don't use a name like "EST" but instead use the offset from UTC in hours. It seems that Golang's time.LoadLocation does not support this correctly, and thus parsing fails.

To fix this, add handling for parsing numeric offsets directly without going through the timezone database.