### PR TITLE
Add missing slash to Dockerfile COPY command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN adduser -D pganalyze pganalyze \
   && mkdir /state  \
   && chown pganalyze:pganalyze /state 
 
-COPY --from=base --chown=pganalyze:pganalyze /home/pganalyze/docker-entrypoint.sh /home/pganalyze/collector /home/pganalyze
+COPY --from=base --chown=pganalyze:pganalyze /home/pganalyze/docker-entrypoint.sh /home/pganalyze/collector /home/pganalyze/
 COPY --from=base /usr/share/pganalyze-collector/sslrootcert/ /usr/share/pganalyze-collector/sslrootcert/
 
 VOLUME ["/state"]


### PR DESCRIPTION
Currently, attempting to build the main Dockerfile on my machine fails
on step 17:

Step 17/22 : COPY --from=base --chown=pganalyze:pganalyze /home/pganalyze/docker-entrypoint.sh /home/pganalyze/collector /home/pganalyze
When using COPY with more than one source file, the destination must be a directory and end with a /

I'm using the latest Docker (version 20.10.22, build 3a2c30b).

The documentation [1] also claims

    If multiple <src> resources are specified, either directly or due
    to the use of a wildcard, then <dest> must be a directory, and it
    must end with a slash /.

so it's not clear how this is working in other situations.

Adding a trailing slash to this COPY's destination (i.e., change it to
"/home/pganalyze/") makes the build succeed here (and should not
affect the build otherwise).

[1]: https://docs.docker.com/engine/reference/builder/#copy
