### PR TITLE
Warn if some log lines will be ignored

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,12 +101,15 @@ func run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 		state.WriteStateFile(servers, globalCollectionOpts, logger)
 	}
 
+	if globalCollectionOpts.TestRun {
+		logger.PrintInfo("Running collector test with %s", util.CollectorNameAndVersion)
+	}
+
 	checkAllInitialCollectionStatus(servers, globalCollectionOpts, logger)
 
 	// We intentionally don't do a test-run in the normal mode, since we're fine with
 	// a later SIGHUP that fixes the config (or a temporarily unreachable server at start)
 	if globalCollectionOpts.TestRun {
-		logger.PrintInfo("Running collector test with %s", util.CollectorNameAndVersion)
 		if globalCollectionOpts.TestReport != "" {
 			runner.RunTestReport(servers, globalCollectionOpts, logger)
 			return
@@ -503,6 +506,10 @@ func checkOneInitialCollectionStatus(server *state.Server, opts state.Collection
 		logger.PrintInfo("All monitoring suspended for this server: %s", collectionDisabledReason)
 	} else if logsDisabled {
 		logger.PrintInfo("Log collection suspended for this server: %s", logsDisabledReason)
+	} else if logsIgnoreDuration {
+		logger.PrintInfo("Log duration lines will be ignored for this server: %s", logsDisabledReason)
+	} else if logsIgnoreStatement {
+		logger.PrintInfo("Log statement lines will be ignored for this server: %s", logsDisabledReason)
 	}
 
 	server.CollectionStatusMutex.Lock()


### PR DESCRIPTION
In 9e76ee117019867bd3d5586f1db401fa8fff3b8c, we relaxed collector
restrictions on log line processing. Previously, any unsupported
settings would disable log processing altogether. After that change,
in some cases, unsupported log lines would be ignored and other lines
could still be processed. However, the commit did not add similar
warnings for the new cases. This could be confusing, since it can lead
to log lines silently being ignored.

Add a warning for the cases when log lines are dropped. Only emit the
warning on startup (including during a test), since this is an
expected situation and impact is limited.
