### PR TITLE
Improve Aiven Service ID and Project ID detection from hostname

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -401,12 +401,21 @@ func preprocessConfig(config *ServerConfig) (*ServerConfig, error) {
 	} else if strings.HasSuffix(host, ".aivencloud.com") {
 		parts := strings.SplitN(host, ".", 2)
 		if len(parts) == 2 && (parts[1] == "aivencloud.com") { // Safety check for any escaping issues
-			projSvcParts := strings.SplitN(parts[0], "-", 3)
+			// Aiven domains encode the project id and service id in the subdomain:
+			//    <SERVICE_NAME>-<PROJECT_NAME>.aivencloud.com
+			// (see https://docs.aiven.io/docs/platform/reference/service-ip-address#default-service-hostname)
+			//
+			// It's not documented whether the project name can contain dashes, but the
+			// default service names do, so we assume that everything before the last
+			// dash is the service name.
+			subdomain := parts[0]
+			projSvcParts := strings.Split(subdomain, "-")
+			lastEntryIdx := len(projSvcParts) - 1
 			if config.AivenServiceID == "" {
-				config.AivenServiceID = strings.Join(projSvcParts[0:2], "-")
+				config.AivenServiceID = strings.Join(projSvcParts[0:lastEntryIdx], "-")
 			}
 			if config.AivenProjectID == "" {
-				config.AivenProjectID = projSvcParts[2]
+				config.AivenProjectID = projSvcParts[lastEntryIdx]
 			}
 		}
 	}

--- a/config/read_test.go
+++ b/config/read_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"testing"
+)
+
+type aivenTestItem struct {
+	input        string
+	expectedSvc  string
+	expectedProj string
+}
+
+var aivenTests = []aivenTestItem{
+	{"my-service-myproject.aivencloud.com", "my-service", "myproject"},
+	{"myservice-myproject.aivencloud.com", "myservice", "myproject"},
+	// probably not what's expected, but this can be overridden manually, and if
+	// project names with dashes do exist, there's not much we can do to
+	// disambiguate
+	{"my-service-my-project.aivencloud.com", "my-service-my", "project"},
+}
+
+func TestPreprocessConfigAiven(t *testing.T) {
+	for idx, item := range aivenTests {
+		var config ServerConfig
+		config.DbHost = item.input
+		processed, err := preprocessConfig(&config)
+		if err != nil {
+			t.Errorf("%d: want nil; got %v", idx, err)
+		}
+
+		if processed.AivenServiceID != item.expectedSvc {
+			t.Errorf("%d: want %v; got %v", idx, item.expectedSvc, processed.AivenServiceID)
+		}
+		if processed.AivenProjectID != item.expectedProj {
+			t.Errorf("%d: want %v; got %v", idx, item.expectedProj, processed.AivenProjectID)
+		}
+	}
+}

--- a/config/read_test.go
+++ b/config/read_test.go
@@ -35,4 +35,23 @@ func TestPreprocessConfigAiven(t *testing.T) {
 			t.Errorf("%d: want %v; got %v", idx, item.expectedProj, processed.AivenProjectID)
 		}
 	}
+
+	{
+		// ensure we avoid overwriting explicitly-specified config values
+		var config ServerConfig
+		config.DbHost = "my-service-my-project.aivencloud.com"
+		config.AivenServiceID = "my-service"
+		config.AivenProjectID = "my-project"
+		processed, err := preprocessConfig(&config)
+		if err != nil {
+			t.Errorf("want nil; got %v", err)
+		}
+		if processed.AivenServiceID != "my-service" {
+			t.Errorf("want %v; got %v", "my-service", processed.AivenServiceID)
+		}
+		if processed.AivenProjectID != "my-project" {
+			t.Errorf("want %v; got %v", "my-project", processed.AivenProjectID)
+		}
+	}
+
 }


### PR DESCRIPTION
Currently, we assume that Aiven hostnames follow the pattern

    {service-id-part1}-{service-id-part2}-{project-id}.aivencloud.com

This is the case for default service names, but a service name does
not need to be dash-separated.

Update our detection logic to account for arbitrary project names that
follow Aiven's documented pattern

    <SERVICE_NAME>-<PROJECT_NAME>.aivencloud.com

Assume that project names do not contain dashes (setting
aiven_project_id and aiven_service_id manually is still an option if
that's not the case).
