### PR TITLE
Do not ignore errors when writing out SSL config to temp files

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -443,10 +443,16 @@ func preprocessConfig(config *ServerConfig) (*ServerConfig, error) {
 
 	if config.DbSslCertContents != "" {
 		config.DbSslCert, err = writeValueToTempfile(config.DbSslCertContents)
+		if err != nil {
+			return config, err
+		}
 	}
 
 	if config.DbSslKeyContents != "" {
 		config.DbSslKey, err = writeValueToTempfile(config.DbSslKeyContents)
+		if err != nil {
+			return config, err
+		}
 	}
 
 	if config.AwsEndpointSigningRegionLegacy != "" && config.AwsEndpointSigningRegion == "" {


### PR DESCRIPTION
We write these out to temporary files since we need to hand these to
pq via file names. We check for errors writing out the root cert, but
not the cert or the key.

Add the error checks.

Found while adding tests for #358.