### PR TITLE
RDS log download: Ensure we pass through read start offset to log parsing

### DIFF
--- a/input/system/rds/logs.go
+++ b/input/system/rds/logs.go
@@ -134,7 +134,7 @@ func DownloadLogFiles(server *state.Server, logger *util.Logger) (state.Persiste
 			goto ErrorCleanup
 		}
 
-		newLogLines, newSamples, _ = logs.ParseAndAnalyzeBuffer(string(buf), 0, linesNewerThan, server)
+		newLogLines, newSamples, _ = logs.ParseAndAnalyzeBuffer(string(buf), int64(readStart), linesNewerThan, server)
 		logFile.LogLines = append(logFile.LogLines, newLogLines...)
 		samples = append(samples, newSamples...)
 


### PR DESCRIPTION
During log parsing and analysis we set the byte offsets for each log line in respect to a temporary file on disk. In the current implementation we don't use this temporary file during log analysis (but rather an in-memory buffer of just the data that needs to be analyzed), but we do utilize that file when encrypting and uploading the data, and all log line offsets are assumed to be in respect to the file on disk.

Whilst we may want to rework this mechanism to not upload data that was not analyzed, the current logic will incorrectly set the offsets in situations where the temporary log file size exceeds 10 MB (the limit of the maximum data we process per log snapshot on RDS). For now, fix the immediate bug here by passing through the correct start offset.