### PR TITLE
Upgrade to Go 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.19
       id: go
 
     - name: Set up protoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.19
       id: go
 
     - name: Set up protoc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine as base
+FROM golang:1.19-alpine as base
 MAINTAINER team@pganalyze.com
 
 ENV GOPATH /go

--- a/config/config.go
+++ b/config/config.go
@@ -13,11 +13,12 @@ type Config struct {
 }
 
 // ServerIdentifier -
-//   Unique identity of each configured server, for deduplication inside the collector.
 //
-//   Note we intentionally don't include the Fallback variables in the identifier, since that is mostly intended
-//   to help transition systems when their "identity" is altered due to collector changes - in the collector we rely
-//   on the non-Fallback values only.
+//	Unique identity of each configured server, for deduplication inside the collector.
+//
+//	Note we intentionally don't include the Fallback variables in the identifier, since that is mostly intended
+//	to help transition systems when their "identity" is altered due to collector changes - in the collector we rely
+//	on the non-Fallback values only.
 type ServerIdentifier struct {
 	APIKey      string
 	APIBaseURL  string
@@ -27,9 +28,10 @@ type ServerIdentifier struct {
 }
 
 // ServerConfig -
-//   Contains the information how to connect to a Postgres instance,
-//   with optional AWS credentials to get metrics
-//   from AWS CloudWatch as well as RDS logfiles
+//
+//	Contains the information how to connect to a Postgres instance,
+//	with optional AWS credentials to get metrics
+//	from AWS CloudWatch as well as RDS logfiles
 type ServerConfig struct {
 	APIKey     string `ini:"api_key"`
 	APIBaseURL string `ini:"api_base_url"`

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-// +heroku goVersion go1.17
+// +heroku goVersion go1.19
 
 module github.com/pganalyze/collector
 
@@ -88,4 +88,4 @@ require (
 	google.golang.org/grpc v1.32.0 // indirect
 )
 
-go 1.17
+go 1.19

--- a/integration_test/Dockerfile.test-citus
+++ b/integration_test/Dockerfile.test-citus
@@ -2,7 +2,7 @@ FROM citusdata/citus:11.1
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.17
+ENV GOVERSION 1.19
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-guided-setup
+++ b/integration_test/Dockerfile.test-guided-setup
@@ -11,7 +11,7 @@ STOPSIGNAL SIGRTMIN+3
 ENTRYPOINT ["/lib/systemd/systemd"]
 CMD ["--log-level=info"]
 
-ENV GOVERSION 1.17
+ENV GOVERSION 1.19
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg10
+++ b/integration_test/Dockerfile.test-pg10
@@ -2,7 +2,7 @@ FROM postgres:10-bullseye
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.17
+ENV GOVERSION 1.19
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg11
+++ b/integration_test/Dockerfile.test-pg11
@@ -2,7 +2,7 @@ FROM postgres:11-bullseye
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.17
+ENV GOVERSION 1.19
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg12
+++ b/integration_test/Dockerfile.test-pg12
@@ -2,7 +2,7 @@ FROM postgres:12
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.17
+ENV GOVERSION 1.19
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg13
+++ b/integration_test/Dockerfile.test-pg13
@@ -2,7 +2,7 @@ FROM postgres:13
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.17
+ENV GOVERSION 1.19
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg14
+++ b/integration_test/Dockerfile.test-pg14
@@ -2,7 +2,7 @@ FROM postgres:14
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.17
+ENV GOVERSION 1.19
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg15
+++ b/integration_test/Dockerfile.test-pg15
@@ -2,7 +2,7 @@ FROM postgres:15
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.17
+ENV GOVERSION 1.19
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg96
+++ b/integration_test/Dockerfile.test-pg96
@@ -2,7 +2,7 @@ FROM postgres:9.6-bullseye
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.17
+ENV GOVERSION 1.19
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-reload
+++ b/integration_test/Dockerfile.test-reload
@@ -11,7 +11,7 @@ STOPSIGNAL SIGRTMIN+3
 ENTRYPOINT ["/lib/systemd/systemd"]
 CMD ["--log-level=info"]
 
-ENV GOVERSION 1.17
+ENV GOVERSION 1.19
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/packages/src/Dockerfile.build.deb-systemd
+++ b/packages/src/Dockerfile.build.deb-systemd
@@ -2,7 +2,7 @@ FROM debian:buster
 
 ARG TARGETARCH
 ENV GOPATH /go
-ENV GOVERSION 1.17
+ENV GOVERSION 1.19
 ENV CODE_DIR $GOPATH/src/github.com/pganalyze/collector
 ENV PATH $PATH:/usr/local/go/bin
 ENV ROOT_DIR /root

--- a/packages/src/Dockerfile.build.rpm-systemd
+++ b/packages/src/Dockerfile.build.rpm-systemd
@@ -2,7 +2,7 @@ FROM centos:7
 
 ARG TARGETARCH
 ENV GOPATH /go
-ENV GOVERSION 1.17
+ENV GOVERSION 1.19
 ENV CODE_DIR $GOPATH/src/github.com/pganalyze/collector
 ENV PATH $PATH:/usr/local/go/bin
 ENV ROOT_DIR /root


### PR DESCRIPTION
Go 1.17 has been EOL for six months. Reviewing the changelog [1],
there do not appear to be any breaking changes.

[1]: https://tip.golang.org/doc/go1.18 and https://tip.golang.org/doc/go1.19
