### PR TITLE
Return full frozen XID as zero if the original one is zero

### DIFF
--- a/state/postgres_relations.go
+++ b/state/postgres_relations.go
@@ -100,6 +100,9 @@ func (i PostgresIndex) Fillfactor() int32 {
 
 // FullFrozenXID - Returns frozenXid in 64-bit FullTransactionId, by calculating and adding an epoch from current transaction ID
 func (r PostgresRelation) FullFrozenXID(currentXactId int64) int64 {
+	if r.FrozenXID == 0 {
+		return 0
+	}
 	// If we simply shift the currentXactId, it'll give the epoch of the current transaction ID, which may be different
 	// from the epoch of the frozen XID (the one we want to add).
 	// By subtracting the frozen XID from the current one, we can get the epoch of the frozen XID

--- a/state/postgres_relations_test.go
+++ b/state/postgres_relations_test.go
@@ -30,6 +30,11 @@ var fullFrozenXIDTests = []struct {
 		12345,
 		(2 << 32) + 12345,
 	},
+	{
+		(2 << 32) + 12345,
+		0,
+		0,
+	},
 }
 
 func TestFullFrozenXID(t *testing.T) {


### PR DESCRIPTION
A fix for the bug introduced in https://github.com/pganalyze/collector/pull/350.
Currently, when the zero of frozen XID is provided, `FullFrozenXID` will return the first XID of the current epoch. This is a wrong behavior and we should return 0 as frozen XID instead as it has the different meaning.