### PR TITLE
Release 0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## 0.48.0      2023-01-26
 
 * Update to Go 1.19
-* Bugfix: Postgres table stats full frozenxid to be zero with zero relfrozenxid
+* Bugfix: Ensure relfrozenxid = 0 is tracked as full frozenxid = 0 (instead of
+  adding epoch prefix)
 
 
 ## 0.47.0      2023-01-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 * Update to Go 1.19
 * Bugfix: Ensure relfrozenxid = 0 is tracked as full frozenxid = 0 (instead of
   adding epoch prefix)
+* Amazon RDS and Amazon Aurora: Support IAM token authentication
+  - This adds a new configuration setting, `db_use_iam_auth` / `DB_USE_IAM_AUTH`.
+    If enabled, the collector fetches a short-lived token for logging into the
+    database instance from the AWS API, instead of using a hardcoded password
+    in the collector configuration file
+  - In order to use this setting, IAM authentication needs to be enabled on the
+    database instance / cluster, and the pganalyze IAM policy needs to be
+    extended to cover the "rds-db:connect" privilege for the pganalyze user:
+    https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html
+* Amazon RDS: Avoid DescribeDBInstances calls for log downloads for RDS instances
+  - This should reduce issues with rate limiting on this API call in some cases
+* Amazon Aurora: Cache failures in DescribeDBClusters calls for up to 10 minutes
+  - This reduces repeated calls to the AWS API when the cluster identifier is
+    incorrect
+* Log parsing: Add support for timezones specified by number, such as "-03"
 
 
 ## 0.47.0      2023-01-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.48.0      2023-01-26
+
+* Update to Go 1.19
+* Bugfix: Postgres table stats full frozenxid to be zero with zero relfrozenxid
+
+
 ## 0.47.0      2023-01-12
 
 * Fix RDS log processing for large log file sections

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,3 +57,5 @@ Note the integration tests require Docker, and will take a while to run through.
 2. Once PR is merged, create a new tag `git tag v0.x.y`, then push it `git push origin v0.x.y`
 3. Once a new tag is pushed, GitHub Action Release will be kicked and create a new release
 4. Modify a newly created release's description to match to CHANGELOG.md
+5. Release docker images using `make docker_release`
+6. Release packages using `make packages`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,3 +50,10 @@ make integration_test
 ```
 
 Note the integration tests require Docker, and will take a while to run through.
+
+### Release
+
+1. Create a PR to update the version numbers and CHANGELOG.md
+2. Once PR is merged, create a new tag `git tag v0.x.y`, then push it `git push origin v0.x.y`
+3. Once a new tag is pushed, GitHub Action Release will be kicked and create a new release
+4. Modify a newly created release's description to match to CHANGELOG.md

--- a/contrib/helm/pganalyze-collector/Chart.yaml
+++ b/contrib/helm/pganalyze-collector/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: pganalyze-collector
-version: 0.47.0
-appVersion: "v0.47.0"
+version: 0.48.0
+appVersion: "v0.48.0"
 type: application
 description: pganalyze statistics collector
 home: https://pganalyze.com/

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -1,6 +1,6 @@
 export NAME=pganalyze-collector
-export VERSION=0.47.0
-export GIT_VERSION=v0.47.0
+export VERSION=0.48.0
+export GIT_VERSION=v0.48.0
 #export GIT_VERSION=HEAD
 #export GIT_VERSION=618e85ce5ed5365bc7d9d9da866fdeb73bac5a55
 #export VERSION=$(shell git show -s --format=%ct.%h HEAD)

--- a/util/version.go
+++ b/util/version.go
@@ -1,4 +1,4 @@
 package util
 
-const CollectorVersion = "0.47.0"
+const CollectorVersion = "0.48.0"
 const CollectorNameAndVersion = "pganalyze-collector " + CollectorVersion


### PR DESCRIPTION
Cutting a new release for 0.48.0. Bumping the minor version as it includes Go version update + somewhat important bugfix.

Also adding a memo for how to create a new release inside of CONTRIBUTING.md file.