### PR TITLE
Package test: Remove rockylinux9 from defaults due to missing /sbin/init

### DIFF
--- a/packages/test/Makefile
+++ b/packages/test/Makefile
@@ -7,7 +7,9 @@ docker_exec = docker exec pga-collector-test $(1)
 docker_test_and_clean = docker exec pga-collector-test /root/systemd_test.sh && \
   docker kill pga-collector-test && docker rm pga-collector-test && docker rmi -f pga-collector-test
 
-DISTROS=centos7 rhel8 rockylinux8 rhel9 rockylinux9 fedora34 fedora35 fedora36 amazonlinux2 ubuntu-xenial ubuntu-bionic ubuntu-focal ubuntu-jammy debian-buster debian-bullseye
+# Note: The default list excludes rockylinux9 since there is an open issue with
+# /sbin/init not being present, see https://github.com/rocky-linux/sig-cloud-instance-images/issues/39
+DISTROS=centos7 rhel8 rockylinux8 rhel9 fedora34 fedora35 fedora36 amazonlinux2 ubuntu-xenial ubuntu-bionic ubuntu-focal ubuntu-jammy debian-buster debian-bullseye
 
 .PHONY: all $(DISTROS)
 


### PR DESCRIPTION
This was broken seemingly by accident, without any upstream updates as of yet. Since we are also testing rhel9 this seems like a "nice to have" and we can re-enable the test once the upstream issue is fixed.

See https://github.com/rocky-linux/sig-cloud-instance-images/issues/39