### PR TITLE
Support IAM token authentication for Amazon RDS and Amazon Aurora

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -113,6 +113,9 @@ func getDefaultConfig() *ServerConfig {
 	if dbSslKey := os.Getenv("DB_SSLKEY"); dbSslKey != "" {
 		config.DbSslKey = dbSslKey
 	}
+	if dbUseIamAuth := os.Getenv("DB_USE_IAM_AUTH"); dbUseIamAuth != "" {
+		config.DbUseIamAuth = parseConfigBool(dbUseIamAuth)
+	}
 	if dbSslKeyContents := os.Getenv("DB_SSLKEY_CONTENTS"); dbSslKeyContents != "" {
 		config.DbSslKeyContents = dbSslKeyContents
 	}

--- a/go.sum
+++ b/go.sum
@@ -370,7 +370,6 @@ golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200904194848-62affa334b73/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200927032502-5d4f70055728/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210929193557-e81a3d93ecf6 h1:Z04ewVs7JhXaYkmDhBERPi41gnltfQpMWDnTnQbaCqk=
 golang.org/x/net v0.0.0-20210929193557-e81a3d93ecf6/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -424,8 +423,6 @@ golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71 h1:ikCpsnYR+Ew0vu99XlDp55lGgDJdIMx3f4a18jfse/s=
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=

--- a/setup/steps/ensure_monitoring_user_password.go
+++ b/setup/steps/ensure_monitoring_user_password.go
@@ -32,7 +32,10 @@ var EnsureMonitoringUserPassword = &s.Step{
 			return false, fmt.Errorf("expected one server in config; found %d", len(cfg.Servers))
 		}
 		serverCfg := cfg.Servers[0]
-		pqStr := serverCfg.GetPqOpenString("")
+		pqStr, err := serverCfg.GetPqOpenString("", "")
+		if err != nil {
+			return false, err
+		}
 		conn, err := sql.Open("postgres", pqStr)
 		err = conn.Ping()
 		if err != nil {

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/rdsutils/builder.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/rdsutils/builder.go
@@ -1,0 +1,127 @@
+package rdsutils
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+)
+
+// ConnectionFormat is the type of connection that will be
+// used to connect to the database
+type ConnectionFormat string
+
+// ConnectionFormat enums
+const (
+	NoConnectionFormat ConnectionFormat = ""
+	TCPFormat          ConnectionFormat = "tcp"
+)
+
+// ErrNoConnectionFormat will be returned during build if no format had been
+// specified
+var ErrNoConnectionFormat = awserr.New("NoConnectionFormat", "No connection format was specified", nil)
+
+// ConnectionStringBuilder is a builder that will construct a connection
+// string with the provided parameters. params field is required to have
+// a tls specification and allowCleartextPasswords must be set to true.
+type ConnectionStringBuilder struct {
+	dbName   string
+	endpoint string
+	region   string
+	user     string
+	creds    *credentials.Credentials
+
+	connectFormat ConnectionFormat
+	params        url.Values
+}
+
+// NewConnectionStringBuilder will return an ConnectionStringBuilder
+func NewConnectionStringBuilder(endpoint, region, dbUser, dbName string, creds *credentials.Credentials) ConnectionStringBuilder {
+	return ConnectionStringBuilder{
+		dbName:   dbName,
+		endpoint: endpoint,
+		region:   region,
+		user:     dbUser,
+		creds:    creds,
+	}
+}
+
+// WithEndpoint will return a builder with the given endpoint
+func (b ConnectionStringBuilder) WithEndpoint(endpoint string) ConnectionStringBuilder {
+	b.endpoint = endpoint
+	return b
+}
+
+// WithRegion will return a builder with the given region
+func (b ConnectionStringBuilder) WithRegion(region string) ConnectionStringBuilder {
+	b.region = region
+	return b
+}
+
+// WithUser will return a builder with the given user
+func (b ConnectionStringBuilder) WithUser(user string) ConnectionStringBuilder {
+	b.user = user
+	return b
+}
+
+// WithDBName will return a builder with the given database name
+func (b ConnectionStringBuilder) WithDBName(dbName string) ConnectionStringBuilder {
+	b.dbName = dbName
+	return b
+}
+
+// WithParams will return a builder with the given params. The parameters
+// will be included in the connection query string
+//
+//	Example:
+//	v := url.Values{}
+//	v.Add("tls", "rds")
+//	b := rdsutils.NewConnectionBuilder(endpoint, region, user, dbname, creds)
+//	connectStr, err := b.WithParams(v).WithTCPFormat().Build()
+func (b ConnectionStringBuilder) WithParams(params url.Values) ConnectionStringBuilder {
+	b.params = params
+	return b
+}
+
+// WithFormat will return a builder with the given connection format
+func (b ConnectionStringBuilder) WithFormat(f ConnectionFormat) ConnectionStringBuilder {
+	b.connectFormat = f
+	return b
+}
+
+// WithTCPFormat will set the format to TCP and return the modified builder
+func (b ConnectionStringBuilder) WithTCPFormat() ConnectionStringBuilder {
+	return b.WithFormat(TCPFormat)
+}
+
+// Build will return a new connection string that can be used to open a connection
+// to the desired database.
+//
+//	Example:
+//	b := rdsutils.NewConnectionStringBuilder(endpoint, region, user, dbname, creds)
+//	connectStr, err := b.WithTCPFormat().Build()
+//	if err != nil {
+//		panic(err)
+//	}
+//	const dbType = "mysql"
+//	db, err := sql.Open(dbType, connectStr)
+func (b ConnectionStringBuilder) Build() (string, error) {
+	if b.connectFormat == NoConnectionFormat {
+		return "", ErrNoConnectionFormat
+	}
+
+	authToken, err := BuildAuthToken(b.endpoint, b.region, b.user, b.creds)
+	if err != nil {
+		return "", err
+	}
+
+	connectionStr := fmt.Sprintf("%s:%s@%s(%s)/%s",
+		b.user, authToken, string(b.connectFormat), b.endpoint, b.dbName,
+	)
+
+	if len(b.params) > 0 {
+		connectionStr = fmt.Sprintf("%s?%s", connectionStr, b.params.Encode())
+	}
+	return connectionStr, nil
+}

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/rdsutils/connect.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/rdsutils/connect.go
@@ -1,0 +1,67 @@
+package rdsutils
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/signer/v4"
+)
+
+// BuildAuthToken will return an authorization token used as the password for a DB
+// connection.
+//
+// * endpoint - Endpoint consists of the port needed to connect to the DB. <host>:<port>
+// * region - Region is the location of where the DB is
+// * dbUser - User account within the database to sign in with
+// * creds - Credentials to be signed with
+//
+// The following example shows how to use BuildAuthToken to create an authentication
+// token for connecting to a MySQL database in RDS.
+//
+//   authToken, err := BuildAuthToken(dbEndpoint, awsRegion, dbUser, awsCreds)
+//
+//   // Create the MySQL DNS string for the DB connection
+//   // user:password@protocol(endpoint)/dbname?<params>
+//   connectStr = fmt.Sprintf("%s:%s@tcp(%s)/%s?allowCleartextPasswords=true&tls=rds",
+//      dbUser, authToken, dbEndpoint, dbName,
+//   )
+//
+//   // Use db to perform SQL operations on database
+//   db, err := sql.Open("mysql", connectStr)
+//
+// See http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html
+// for more information on using IAM database authentication with RDS.
+func BuildAuthToken(endpoint, region, dbUser string, creds *credentials.Credentials) (string, error) {
+	// the scheme is arbitrary and is only needed because validation of the URL requires one.
+	if !(strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://")) {
+		endpoint = "https://" + endpoint
+	}
+
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		return "", err
+	}
+	values := req.URL.Query()
+	values.Set("Action", "connect")
+	values.Set("DBUser", dbUser)
+	req.URL.RawQuery = values.Encode()
+
+	signer := v4.Signer{
+		Credentials: creds,
+	}
+	_, err = signer.Presign(req, nil, "rds-db", region, 15*time.Minute, time.Now())
+	if err != nil {
+		return "", err
+	}
+
+	url := req.URL.String()
+	if strings.HasPrefix(url, "http://") {
+		url = url[len("http://"):]
+	} else if strings.HasPrefix(url, "https://") {
+		url = url[len("https://"):]
+	}
+
+	return url, nil
+}

--- a/vendor/github.com/aws/aws-sdk-go/service/rds/rdsutils/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/rds/rdsutils/doc.go
@@ -1,0 +1,18 @@
+// Package rdsutils is used to generate authentication tokens used to
+// connect to a givent Amazon Relational Database Service (RDS) database.
+//
+// Before using the authentication please visit the docs here to ensure
+// the database has the proper policies to allow for IAM token authentication.
+// https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html#UsingWithRDS.IAMDBAuth.Availability
+//
+// When building the connection string, there are two required parameters that are needed to be set on the query.
+//	* tls
+//	* allowCleartextPasswords must be set to true
+//
+//	Example creating a basic auth token with the builder:
+//	v := url.Values{}
+//	v.Add("tls", "tls_profile_name")
+//	v.Add("allowCleartextPasswords", "true")
+//	b := rdsutils.NewConnectionStringBuilder(endpoint, region, user, dbname, creds)
+//	connectStr, err := b.WithTCPFormat().WithParams(v).Build()
+package rdsutils

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -121,6 +121,7 @@ github.com/aws/aws-sdk-go/service/cloudwatchlogs
 github.com/aws/aws-sdk-go/service/kms
 github.com/aws/aws-sdk-go/service/kms/kmsiface
 github.com/aws/aws-sdk-go/service/rds
+github.com/aws/aws-sdk-go/service/rds/rdsutils
 github.com/aws/aws-sdk-go/service/s3
 github.com/aws/aws-sdk-go/service/s3/s3crypto
 github.com/aws/aws-sdk-go/service/s3/s3iface


### PR DESCRIPTION
This adds a new configuration setting, db_use_iam_auth / DB_USE_IAM_AUTH that, if enabled, causes the collector to fetch a short-lived token for logging into the database instance from the AWS API, instead of using a hardcoded password in the collector configuration file.

In order to use this setting IAM authentication needs to be enabled on the database instance / cluster, and the pganalyze IAM policy needs to be extended to cover the "rds-db:connect" privilege for the pganalyze user:

https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.IAMPolicy.html

Note that for now the collector will fetch a new token for each connection it makes (at least one new connection every 10 seconds), which may cause additional AWS API utilization when monitoring a lot of instances.

With thanks to Alexandre Viau for the initial code contribution.