### PR TITLE
AWS: Avoid DescribeDBInstances calls for log downloads for RDS instances

### DIFF
--- a/util/awsutil/rds.go
+++ b/util/awsutil/rds.go
@@ -1,7 +1,6 @@
 package awsutil
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -12,31 +11,6 @@ import (
 	"github.com/pganalyze/collector/config"
 	"github.com/pganalyze/collector/util"
 )
-
-var IdentifierMap *util.TTLMap = util.NewTTLMap(5 * 60)
-var ErrorCache *util.TTLMap = util.NewTTLMap(10 * 60)
-
-func FindRdsIdentifier(config config.ServerConfig, sess *session.Session) (identifier string, err error) {
-	identifier = IdentifierMap.Get(config.AwsDbInstanceID)
-	if identifier != "" {
-		return
-	}
-
-	cachedError := ErrorCache.Get(config.AwsDbInstanceID)
-	if cachedError != "" {
-		err = errors.New(cachedError)
-		return
-	}
-
-	instance, err := FindRdsInstance(config, sess)
-	if err == nil {
-		identifier = *instance.DBInstanceIdentifier
-		IdentifierMap.Put(config.AwsDbInstanceID, identifier)
-	} else {
-		ErrorCache.Put(config.AwsDbInstanceID, err.Error())
-	}
-	return
-}
 
 func findRdsClusterByIdentifier(clusterIdentifier string, svc *rds.RDS) (*rds.DBCluster, error) {
 	params := &rds.DescribeDBClustersInput{


### PR DESCRIPTION
Previously the log download for RDS would issue a DescribeDBInstances call for confirming whether the instance ID is indeed valid.

Whilst this was made less problematic by addition of a cache in f2ab72f45bd, it missed the fact that we don't actually need to do this lookup at all in the case of log downloads for Amazon RDS instances.

Instead, we can just rely on the later DescribeDBLogFiles API call to complain if an instance ID does not exist. Thus, this change removes that API call completely for log downloads when the instance ID is specified.

In the case of Aurora we do need the API call to DescribeDBClusters to find the specific instance ID, e.g. that of the current writer. In terms of caching we can't cache the cluster ID => instance ID mapping for risk of missing a failover event (i.e. where the cluster ID should start pointing to a new instance ID right away), but we can cache errors, e.g. when someone specified an incorrect cluster ID.

With thanks to Jesse Liston for pointing out the unnecessary DescribeDBInstances call. Supersedes #349.