### PR TITLE
Amazon RDS/Aurora: Improve handling of excessively large log file portions

### DIFF
--- a/input/postgres/log_pg_read_file.go
+++ b/input/postgres/log_pg_read_file.go
@@ -104,7 +104,7 @@ func LogPgReadFile(server *state.Server, globalCollectionOpts state.CollectionOp
 		_, err := logFile.TmpFile.WriteString(logData)
 		if err != nil {
 			err = fmt.Errorf("Error writing to tempfile: %s", err)
-			logFile.Cleanup()
+			logFile.Cleanup(logger)
 			goto ErrorCleanup
 		}
 
@@ -122,7 +122,7 @@ func LogPgReadFile(server *state.Server, globalCollectionOpts state.CollectionOp
 
 ErrorCleanup:
 	for _, logFile := range logFiles {
-		logFile.Cleanup()
+		logFile.Cleanup(logger)
 	}
 
 	return server.LogPrevState, nil, nil, err

--- a/input/system/rds/logs.go
+++ b/input/system/rds/logs.go
@@ -5,21 +5,18 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/pganalyze/collector/config"
 	"github.com/pganalyze/collector/logs"
 	"github.com/pganalyze/collector/state"
 	"github.com/pganalyze/collector/util"
 	"github.com/pganalyze/collector/util/awsutil"
 	uuid "github.com/satori/go.uuid"
 )
-
-// Read at most the trailing 10 megabytes of the temp file, to avoid OOMs on initial start of the collector
-// (where the full RDS log file gets downloaded before the marker gets initialized)
-const maxLogParsingSize = 10 * 1024 * 1024
-
-var DescribeDBClustersErrorCache *util.TTLMap = util.NewTTLMap(10 * 60)
 
 // DownloadLogFiles - Gets log files for an Amazon RDS instance
 func DownloadLogFiles(server *state.Server, logger *util.Logger) (state.PersistedLogState, []state.LogFile, []state.PostgresQuerySample, error) {
@@ -34,29 +31,9 @@ func DownloadLogFiles(server *state.Server, logger *util.Logger) (state.Persiste
 		return server.LogPrevState, nil, nil, err
 	}
 
-	identifier := server.Config.AwsDbInstanceID
-	// If this is an Aurora cluster endpoint, we need to find the actual instance ID in order to get the logs
-	if identifier == "" {
-		if server.Config.AwsDbClusterID == "" {
-			return server.LogPrevState, nil, nil, fmt.Errorf("Neither AWS instance ID or cluster ID are specified - skipping log download")
-		}
-
-		// Remember when an Aurora instance find failed previously to avoid failing on the same
-		// DescribeDBClusters call again and again. Note that we don't cache successes because
-		// we want to react quickly to failover events.
-		cachedError := DescribeDBClustersErrorCache.Get(server.Config.AwsDbClusterID)
-		if cachedError != "" {
-			return server.LogPrevState, nil, nil, errors.New(cachedError)
-		}
-
-		instance, err := awsutil.FindRdsInstance(server.Config, sess)
-		if err != nil {
-			err = fmt.Errorf("Error finding instance for cluster ID \"%s\": %s", server.Config.AwsDbClusterID, err)
-			DescribeDBClustersErrorCache.Put(server.Config.AwsDbClusterID, err.Error())
-			return server.LogPrevState, nil, nil, err
-		}
-
-		identifier = *instance.DBInstanceIdentifier
+	identifier, err := getAwsDbInstanceID(server.Config, sess)
+	if err != nil {
+		return server.LogPrevState, nil, nil, err
 	}
 
 	// Retrieve all possibly matching logfiles in the last two minutes, assuming
@@ -88,75 +65,43 @@ func DownloadLogFiles(server *state.Server, logger *util.Logger) (state.Persiste
 			lastMarker = &prevMarker
 		}
 
-		var logFile state.LogFile
-		logFile.UUID = uuid.NewV4()
-		logFile.TmpFile, err = ioutil.TempFile("", "")
+		tmpFile, err := ioutil.TempFile("", "")
 		if err != nil {
 			err = fmt.Errorf("Error allocating tempfile for logs: %s", err)
 			goto ErrorCleanup
 		}
-		logFile.OriginalName = *rdsLogFile.LogFileName
 
 		for {
-			var resp *rds.DownloadDBLogFilePortionOutput
-			resp, err = rdsSvc.DownloadDBLogFilePortion(&rds.DownloadDBLogFilePortionInput{
-				DBInstanceIdentifier: &identifier,
-				LogFileName:          rdsLogFile.LogFileName,
-				Marker:               lastMarker, // This is not set for the initial call, so we only get the most recent lines
-			})
-
+			newBytesWritten, newMarker, additionalDataPending, err := downloadRdsLogFilePortion(rdsSvc, tmpFile, logger, &identifier, rdsLogFile.LogFileName, lastMarker)
 			if err != nil {
-				err = fmt.Errorf("Error downloading logs: %s", err)
-				logFile.Cleanup()
+				tmpFile.Close()
+				os.Remove(tmpFile.Name())
 				goto ErrorCleanup
 			}
 
-			if resp.LogFileData == nil {
-				logger.PrintVerbose("Rds/Logs: No log data in response, skipping")
-				break
+			bytesWritten += newBytesWritten
+			if newMarker != nil {
+				lastMarker = newMarker
 			}
 
-			if len(*resp.LogFileData) > 0 {
-				_, err = logFile.TmpFile.WriteString(*resp.LogFileData)
-				if err != nil {
-					err = fmt.Errorf("Error writing to tempfile: %s", err)
-					logFile.Cleanup()
-					goto ErrorCleanup
-				}
-				bytesWritten += len(*resp.LogFileData)
-			}
-
-			lastMarker = resp.Marker
-
-			if !*resp.AdditionalDataPending {
+			if !additionalDataPending {
 				break
 			}
 		}
 
-		var newLogLines []state.LogLine
-		var newSamples []state.PostgresQuerySample
-
-		readStart := bytesWritten - maxLogParsingSize
-		if readStart < 0 {
-			readStart = 0
-		}
-		_, err = logFile.TmpFile.Seek(int64(readStart), io.SeekStart)
+		buf, tmpFile, err := readLogFilePortion(tmpFile, bytesWritten, logger)
 		if err != nil {
-			err = fmt.Errorf("Error seeking tempfile: %s", err)
-			logFile.Cleanup()
+			tmpFile.Close()
+			os.Remove(tmpFile.Name())
 			goto ErrorCleanup
 		}
 
-		buf := make([]byte, bytesWritten-readStart)
+		newLogLines, newSamples, _ := logs.ParseAndAnalyzeBuffer(string(buf), 0, linesNewerThan, server)
 
-		_, err = io.ReadFull(logFile.TmpFile, buf)
-		if err != nil {
-			err = fmt.Errorf("Error reading %d bytes from tempfile: %s", len(buf), err)
-			logFile.Cleanup()
-			goto ErrorCleanup
-		}
-
-		newLogLines, newSamples, _ = logs.ParseAndAnalyzeBuffer(string(buf), int64(readStart), linesNewerThan, server)
+		var logFile state.LogFile
+		logFile.UUID = uuid.NewV4()
+		logFile.TmpFile = tmpFile // Pass responsibility to LogFile for cleaning up the temp file
+		logFile.OriginalName = *rdsLogFile.LogFileName
 		logFile.LogLines = append(logFile.LogLines, newLogLines...)
 		samples = append(samples, newSamples...)
 
@@ -176,4 +121,120 @@ ErrorCleanup:
 	}
 
 	return server.LogPrevState, nil, nil, err
+}
+
+var DescribeDBClustersErrorCache *util.TTLMap = util.NewTTLMap(10 * 60)
+
+func getAwsDbInstanceID(config config.ServerConfig, sess *session.Session) (string, error) {
+	identifier := config.AwsDbInstanceID
+	// If this is an Aurora cluster endpoint, we need to find the actual instance ID in order to get the logs
+	if identifier == "" {
+		if config.AwsDbClusterID == "" {
+			return "", fmt.Errorf("Neither AWS instance ID or cluster ID are specified - skipping log download")
+		}
+
+		// Remember when an Aurora instance find failed previously to avoid failing on the same
+		// DescribeDBClusters call again and again. Note that we don't cache successes because
+		// we want to react quickly to failover events.
+		cachedError := DescribeDBClustersErrorCache.Get(config.AwsDbClusterID)
+		if cachedError != "" {
+			return "", errors.New(cachedError)
+		}
+
+		instance, err := awsutil.FindRdsInstance(config, sess)
+		if err != nil {
+			err = fmt.Errorf("Error finding instance for cluster ID \"%s\": %s", config.AwsDbClusterID, err)
+			DescribeDBClustersErrorCache.Put(config.AwsDbClusterID, err.Error())
+			return "", err
+		}
+
+		identifier = *instance.DBInstanceIdentifier
+	}
+
+	return identifier, nil
+}
+
+func downloadRdsLogFilePortion(rdsSvc *rds.RDS, tmpFile *os.File, logger *util.Logger, identifier *string, logFileName *string, lastMarker *string) (newBytesWritten int, newMarker *string, additionalDataPending bool, err error) {
+	var resp *rds.DownloadDBLogFilePortionOutput
+	resp, err = rdsSvc.DownloadDBLogFilePortion(&rds.DownloadDBLogFilePortionInput{
+		DBInstanceIdentifier: identifier,
+		LogFileName:          logFileName,
+		Marker:               lastMarker, // This is not set for the initial call, so we only get the most recent lines
+	})
+
+	if err != nil {
+		err = fmt.Errorf("Error downloading logs: %s", err)
+		return
+	}
+
+	if resp.LogFileData == nil {
+		logger.PrintVerbose("Rds/Logs: No log data in response, skipping")
+		return
+	}
+
+	if len(*resp.LogFileData) > 0 {
+		_, err = tmpFile.WriteString(*resp.LogFileData)
+		if err != nil {
+			err = fmt.Errorf("Error writing to tempfile: %s", err)
+			return
+		}
+		newBytesWritten += len(*resp.LogFileData)
+	}
+
+	newMarker = resp.Marker
+	additionalDataPending = *resp.AdditionalDataPending
+
+	return
+}
+
+// Analyze and submit at most the trailing 10 megabytes of the retrieved RDS log file portions
+//
+// This avoids an OOM in two edge cases:
+// 1) When starting the collector, as we always load the last 10,000 lines (which may be very long)
+// 2) When extremely large values are output in a single log event (e.g. query parameters in a DETAIL line)
+//
+// We intentionally throw away data here (and warn the user about it), since the alternative
+// is often a collector crash (due to OOM), which would be less desirable.
+const maxLogParsingSize = 10 * 1024 * 1024
+
+func readLogFilePortion(tmpFile *os.File, bytesWritten int, logger *util.Logger) ([]byte, *os.File, error) {
+	exceededMaxParsingSize := bytesWritten > maxLogParsingSize
+	if exceededMaxParsingSize {
+		logger.PrintWarning("RDS log file portion exceeded more than 10 MB of data in 30 second interval, collecting most recent data only (skipping %d bytes)", bytesWritten-maxLogParsingSize)
+
+		_, err := tmpFile.Seek(int64(bytesWritten-maxLogParsingSize), io.SeekStart)
+		if err != nil {
+			return nil, tmpFile, fmt.Errorf("Error seeking tempfile: %s", err)
+		}
+	}
+
+	// Read the data into memory for analysis
+	buf := make([]byte, bytesWritten)
+	_, err := io.ReadFull(tmpFile, buf)
+	if err != nil {
+		return nil, tmpFile, fmt.Errorf("Error reading %d bytes from tempfile: %s", len(buf), err)
+	}
+
+	// If necessary, recreate tempfile with just the data we're analyzing
+	// (this supports the later read of the temp file during the log upload)
+	if exceededMaxParsingSize {
+		truncatedTmpFile, err := ioutil.TempFile("", "")
+		if err != nil {
+			return nil, tmpFile, fmt.Errorf("Error allocating tempfile for logs: %s", err)
+		}
+
+		_, err = truncatedTmpFile.Write(buf)
+		if err != nil {
+			truncatedTmpFile.Close()
+			os.Remove(truncatedTmpFile.Name())
+			return nil, tmpFile, fmt.Errorf("Error writing to tempfile: %s", err)
+		}
+
+		// We succeeded, so remove the previous file and use the new one going forward
+		tmpFile.Close()
+		os.Remove(tmpFile.Name())
+		tmpFile = truncatedTmpFile
+	}
+
+	return buf, tmpFile, nil
 }

--- a/logs/stream/stream_test.go
+++ b/logs/stream/stream_test.go
@@ -2,6 +2,8 @@ package stream_test
 
 import (
 	"io/ioutil"
+	"log"
+	"os"
 	"sort"
 	"testing"
 	"time"
@@ -10,6 +12,7 @@ import (
 	"github.com/pganalyze/collector/logs/stream"
 	"github.com/pganalyze/collector/output/pganalyze_collector"
 	"github.com/pganalyze/collector/state"
+	"github.com/pganalyze/collector/util"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -357,7 +360,7 @@ var streamTests = []streamTestpair{
 
 func TestAnalyzeStreamInGroups(t *testing.T) {
 	for _, pair := range streamTests {
-		TransientLogState, logFile, tooFreshLogLines, err := stream.AnalyzeStreamInGroups(pair.logLines, now, &state.Server{})
+		TransientLogState, logFile, tooFreshLogLines, err := stream.AnalyzeStreamInGroups(pair.logLines, now, &state.Server{}, &util.Logger{Destination: log.New(os.Stderr, "", log.LstdFlags)})
 		logFileContent := ""
 		if logFile.TmpFile != nil {
 			dat, err := ioutil.ReadFile(logFile.TmpFile.Name())

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -147,7 +147,7 @@ func downloadLogsForServer(server *state.Server, globalCollectionOpts state.Coll
 	}
 
 	transientLogState := state.TransientLogState{CollectedAt: time.Now()}
-	defer transientLogState.Cleanup()
+	defer transientLogState.Cleanup(logger)
 
 	var newLogState state.PersistedLogState
 	newLogState, transientLogState.LogFiles, transientLogState.QuerySamples, err = system.DownloadLogFiles(server, globalCollectionOpts, logger)
@@ -228,12 +228,12 @@ func processLogStream(server *state.Server, logLines []state.LogLine, now time.T
 	}
 	server.CollectionStatusMutex.Unlock()
 
-	transientLogState, logFile, tooFreshLogLines, err := stream.AnalyzeStreamInGroups(logLines, now, server)
+	transientLogState, logFile, tooFreshLogLines, err := stream.AnalyzeStreamInGroups(logLines, now, server, logger)
 	if err != nil {
 		logger.PrintError("%s", err)
 		return tooFreshLogLines
 	}
-	defer transientLogState.Cleanup()
+	defer transientLogState.Cleanup(logger)
 
 	transientLogState.LogFiles = []state.LogFile{logFile}
 

--- a/state/logs.go
+++ b/state/logs.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pganalyze/collector/config"
 	"github.com/pganalyze/collector/output/pganalyze_collector"
+	"github.com/pganalyze/collector/util"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -179,15 +180,14 @@ type LogLine struct {
 	SecretMarkers      []LogSecretMarker
 }
 
-func (logFile *LogFile) Cleanup() {
+func (logFile *LogFile) Cleanup(logger *util.Logger) {
 	if logFile.TmpFile != nil {
-		logFile.TmpFile.Close()
-		os.Remove(logFile.TmpFile.Name())
+		util.CleanupTmpFileAndLogErrors(logFile.TmpFile, logger)
 	}
 }
 
-func (ls *TransientLogState) Cleanup() {
+func (ls *TransientLogState) Cleanup(logger *util.Logger) {
 	for _, logFile := range ls.LogFiles {
-		logFile.Cleanup()
+		logFile.Cleanup(logger)
 	}
 }

--- a/state/logs.go
+++ b/state/logs.go
@@ -182,7 +182,7 @@ type LogLine struct {
 
 func (logFile *LogFile) Cleanup(logger *util.Logger) {
 	if logFile.TmpFile != nil {
-		util.CleanupTmpFileAndLogErrors(logFile.TmpFile, logger)
+		util.CleanUpTmpFile(logFile.TmpFile, logger)
 	}
 }
 

--- a/util/tmp_file.go
+++ b/util/tmp_file.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Clean up a created temporary file, reporting any errors to the log
-func CleanupTmpFileAndLogErrors(tmpFile *os.File, logger *Logger) {
+func CleanUpTmpFile(tmpFile *os.File, logger *Logger) {
 	err := tmpFile.Close()
 	if err != nil {
 		logger.PrintError("Failed to close temporary file \"%s\": %s", tmpFile.Name(), err)

--- a/util/tmp_file.go
+++ b/util/tmp_file.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"os"
+)
+
+// Clean up a created temporary file, reporting any errors to the log
+func CleanupTmpFileAndLogErrors(tmpFile *os.File, logger *Logger) {
+	err := tmpFile.Close()
+	if err != nil {
+		logger.PrintError("Failed to close temporary file \"%s\": %s", tmpFile.Name(), err)
+	}
+
+	err = os.Remove(tmpFile.Name())
+	if err != nil {
+		logger.PrintError("Failed to delete temporary file \"%s\": %s", tmpFile.Name(), err)
+	}
+}


### PR DESCRIPTION
We've previously introduced a limit of 10 MB of log data per file tracked in a log snapshot, to avoid causing log analysis to time out in cases of very large log events, or other issues that caused a lot of data to be written since the last log marker.

However, the prior logic was still keeping the full original log data around *and* unnecessarily encrypted and submitted that data, even though it was not actually usable. Additionally, the prior logic was hard to reason about, and had subtle bugs, such as the one fixed in 90db3291ec.

Instead, in cases of the downloaded log data exceeding 10 MB, write out a new temporary file that contains just that data. In addition, add a warning in the collector logs to highlight when this happens, so that a user may take action (e.g. reduce occurrence of problematic log events).

In passing this refactors the RDS log handling code into more targeted functions for clarity, as well as potentially helping Go enforce scoping rules better for the individual downloaded log file portion (to ensure the downloaded log text is not kept in memory after its been written to the temp file).