### PR TITLE
Log parsing: Only consider first 1000 characters for log_line_prefix

### DIFF
--- a/logs/parse.go
+++ b/logs/parse.go
@@ -125,6 +125,16 @@ func ParseLogLineWithPrefix(prefix string, line string) (logLine state.LogLine, 
 
 	rsyslog := false
 
+	// Only read the first 1000 characters of a log line to parse the log_line_prefix
+	//
+	// This reduces the overhead for very long loglines, because we don't pass in the
+	// whole line to the regexp engine (twice).
+	lineExtra := ""
+	if len(line) > 1000 {
+		lineExtra = line[1000:]
+		line = line[0:1000]
+	}
+
 	if prefix == "" {
 		if LogPrefixAmazonRdsRegexp.MatchString(line) {
 			prefix = LogPrefixAmazonRds
@@ -462,7 +472,7 @@ func ParseLogLineWithPrefix(prefix string, line string) (logLine state.LogLine, 
 			contentPart = parts[14]
 		default:
 			// Some callers use the content of unparsed lines to stitch multi-line logs together
-			logLine.Content = line
+			logLine.Content = line + lineExtra
 			return
 		}
 	}
@@ -521,7 +531,7 @@ func ParseLogLineWithPrefix(prefix string, line string) (logLine state.LogLine, 
 
 	backendPid, _ := strconv.ParseInt(pidPart, 10, 32)
 	logLine.BackendPid = int32(backendPid)
-	logLine.Content = contentPart
+	logLine.Content = contentPart + lineExtra
 
 	// This is actually a continuation of a previous line
 	if levelPart == "" {


### PR DESCRIPTION
Sometimes log lines can be excessively long, but the log_line_prefix is almost always a tiny portion of such log lines. Since we are currently doing Regexp-based parsing for log lines (before analysis), it can be expensive to pass such large log lines in full to the Go regexp engine.

Instead, only pass the first 1000 characters to the Regexp engine when reading out the log_line_prefix fields. In a real world test case this improves the parsing performance for a 2.1GB log file from 17 minutes to 14 minutes (tested with "time pganalyze-collector --analyze-logfile"), and its hard to imagine a case where the prefix is longer than 1000 characters.