### PR TITLE
Return zero as FullFrozenXID for replicas

### DIFF
--- a/state/postgres_relations.go
+++ b/state/postgres_relations.go
@@ -100,7 +100,7 @@ func (i PostgresIndex) Fillfactor() int32 {
 
 // FullFrozenXID - Returns frozenXid in 64-bit FullTransactionId, by calculating and adding an epoch from current transaction ID
 func (r PostgresRelation) FullFrozenXID(currentXactId int64) int64 {
-	if r.FrozenXID == 0 {
+	if r.FrozenXID == 0 || currentXactId == 0 {
 		return 0
 	}
 	// If we simply shift the currentXactId, it'll give the epoch of the current transaction ID, which may be different

--- a/state/postgres_relations.go
+++ b/state/postgres_relations.go
@@ -100,6 +100,7 @@ func (i PostgresIndex) Fillfactor() int32 {
 
 // FullFrozenXID - Returns frozenXid in 64-bit FullTransactionId, by calculating and adding an epoch from current transaction ID
 func (r PostgresRelation) FullFrozenXID(currentXactId int64) int64 {
+	// FrozenXID can be 0 if the relation is not a table, currentXactId can be 0 on replicas
 	if r.FrozenXID == 0 || currentXactId == 0 {
 		return 0
 	}

--- a/state/postgres_relations_test.go
+++ b/state/postgres_relations_test.go
@@ -35,6 +35,11 @@ var fullFrozenXIDTests = []struct {
 		0,
 		0,
 	},
+	{
+		0,
+		12345,
+		0,
+	},
 }
 
 func TestFullFrozenXID(t *testing.T) {


### PR DESCRIPTION
We currently set `currentXactId` to 0 when it's in recovery mode (aka replicas). This PR fixes the issue of the `FullFrozenXID` becomes negative when 0 is passed as `currentXactId`. Instead, `FullFrozenXID` will become zero.

This will introduce a slight inconsistency for what we return as the data. Let's think about the following case:

* current xact id is epoch 1 + 300, multixact id is 30
* database/table
  * frozen_xid 100, age 200
  * min_mxid 10, age 20

For non-replica, it'll return:
* current xact id: (1 << 32) + 300, multixact id: 30
* database
  * frozen_xid 100, age 200
  * min_mxid 10, age 20
* table
  * frozen_xid (1 << 32) + 100, age 200
  * min_mxid 10, age 20

For replica, with this PR, it'll return:
* current xact id: 0, multixact id: 0
* database
  * frozen_xid 100, age 200
  * min_mxid 10, age 20
* table
  * frozen_xid 0 (previously returning -100 here), age 200
  * min_mxid 10, age 20

I think 0 is better than -100, but still not sure if it's the best. The alternative we _could_ do is: return 100 there (and forget about epoch).