### PR TITLE
Release task: Use Ubuntu 20.04 release to release binary with older glibc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Use older Ubuntu release to avoid building with a too new glibc, which will cause
+    # errors on older distributions, if anyone uses the generated binary directly.
+    runs-on: ubuntu-20.04
     permissions: {}
     # ensure we don't release on create events for branches (only tags)
     if: ${{ startsWith( github.ref, 'refs/tags' ) }}


### PR DESCRIPTION
GitHub actions automatically updated the "ubuntu-latest" release to 22.04, which uses a fairly new glibc that breaks use of the release binary on older operating systems.

Since we're not in a rush to build on 22.04 for the release task, pin to 20.04 to ensure an older minimum required glibc version.