### PR TITLE
README: Add missing GRANT USAGE for helper functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ to run as a superuser, you can setup a separate monitoring user like this:
 
 ```sql
 CREATE SCHEMA pganalyze;
+GRANT USAGE ON SCHEMA pganalyze TO pganalyze;
 
 CREATE EXTENSION IF NOT EXISTS pg_stat_statements WITH SCHEMA public;
 


### PR DESCRIPTION
Whilst we're planning to overhaul this section of the README soon, there is a very common problem that one can run into if you forget to grant the pganalyze user usage on the schema for the restricted monitoring user - fix that since its straightforward to do.

This matches documentation pages such as https://pganalyze.com/docs/install/amazon_rds/02_create_monitoring_user