### PR TITLE
Avoid partial data and bogus statistics when locks are encountered in parts of the snapshot

### DIFF
--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -54,7 +54,8 @@ SELECT c.oid,
 			 CASE WHEN c.relminmxid <> '0' THEN pg_catalog.mxid_age(c.relminmxid) ELSE 0 END AS relation_mxid_age,
 			 c.relpages,
 			 c.reltuples,
-			 c.relallvisible
+			 c.relallvisible,
+			 false AS exclusively_locked
 	FROM pg_catalog.pg_class c
 	LEFT JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
 	LEFT JOIN pg_catalog.pg_stat_user_tables s ON (s.relid = c.oid)
@@ -65,6 +66,44 @@ SELECT c.oid,
 			 AND c.oid NOT IN (SELECT pd.objid FROM pg_catalog.pg_depend pd WHERE pd.deptype = 'e' AND pd.classid = 'pg_catalog.pg_class'::regclass)
 			 AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
 			 AND ($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)
+ UNION ALL
+SELECT relid,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   NULL,
+	   NULL,
+	   NULL,
+	   NULL,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   true AS exclusively_locked
+  FROM locked_relids_with_parents
 `
 
 const indexStatsSQL = `
@@ -75,11 +114,22 @@ SELECT s.indexrelid,
 			 COALESCE(s.idx_tup_read, 0),
 			 COALESCE(s.idx_tup_fetch, 0),
 			 COALESCE(sio.idx_blks_read, 0),
-			 COALESCE(sio.idx_blks_hit, 0)
+			 COALESCE(sio.idx_blks_hit, 0),
+			 false AS exclusively_locked
 	FROM pg_catalog.pg_stat_user_indexes s
 			 LEFT JOIN pg_catalog.pg_statio_user_indexes sio USING (indexrelid)
  WHERE s.indexrelid NOT IN (SELECT relid FROM locked_relids)
 			 AND ($1 = '' OR (s.schemaname || '.' || s.relname) !~* $1)
+UNION ALL
+SELECT relid,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   0,
+	   true AS exclusively_locked
+  FROM locked_relids
 `
 
 const columnStatsSQL = `
@@ -126,7 +176,8 @@ func GetRelationStats(ctx context.Context, db *sql.DB, postgresVersion state.Pos
 			&stats.HeapBlksHit, &stats.IdxBlksRead, &stats.IdxBlksHit,
 			&stats.ToastBlksRead, &stats.ToastBlksHit, &stats.TidxBlksRead,
 			&stats.TidxBlksHit, &stats.FrozenXIDAge, &stats.MinMXIDAge,
-			&stats.Relpages, &stats.Reltuples, &stats.Relallvisible)
+			&stats.Relpages, &stats.Reltuples, &stats.Relallvisible,
+			&stats.ExclusivelyLocked)
 		if err != nil {
 			err = fmt.Errorf("RelationStats/Scan: %s", err)
 			return
@@ -166,7 +217,8 @@ func GetIndexStats(ctx context.Context, db *sql.DB, postgresVersion state.Postgr
 		var stats state.PostgresIndexStats
 
 		err = rows.Scan(&oid, &stats.SizeBytes, &stats.IdxScan, &stats.IdxTupRead,
-			&stats.IdxTupFetch, &stats.IdxBlksRead, &stats.IdxBlksHit)
+			&stats.IdxTupFetch, &stats.IdxBlksRead, &stats.IdxBlksHit,
+			&stats.ExclusivelyLocked)
 		if err != nil {
 			err = fmt.Errorf("IndexStats/Scan: %s", err)
 			return

--- a/output/transform/postgres_relations.go
+++ b/output/transform/postgres_relations.go
@@ -65,6 +65,13 @@ func transformPostgresRelations(s snapshot.FullSnapshot, newState state.Persiste
 
 		schemaStats, schemaStatsExist := newState.SchemaStats[relation.DatabaseOid]
 
+		// In case of exclusively locked relations that are encountered by a later input query
+		// (e.g. to get column or index information), it can happen that we get partial data
+		// - make sure we don't send that unnecessarily (the server would just ignore it)
+		if relation.ExclusivelyLocked {
+			continue
+		}
+
 		if relation.ViewDefinition != "" {
 			info.ViewDefinition = &snapshot.NullString{Valid: true, Value: relation.ViewDefinition}
 		}

--- a/runner/diff.go
+++ b/runner/diff.go
@@ -63,9 +63,11 @@ func diffRelationStats(new state.PostgresRelationStatsMap, prev state.PostgresRe
 	diff = make(state.DiffedPostgresRelationStatsMap)
 	for key, stats := range new {
 		prevStats, exists := prev[key]
-		if exists {
+		if stats.ExclusivelyLocked {
+			// Skip, we don't have any usable data for this relation
+		} else if exists && !prevStats.ExclusivelyLocked {
 			diff[key] = stats.DiffSince(prevStats)
-		} else if followUpRun { // New since the last run
+		} else if followUpRun && !prevStats.ExclusivelyLocked { // New relation since the last run
 			diff[key] = stats.DiffSince(state.PostgresRelationStats{})
 		} else {
 			diff[key] = state.DiffedPostgresRelationStats{
@@ -96,9 +98,11 @@ func diffIndexStats(new state.PostgresIndexStatsMap, prev state.PostgresIndexSta
 	diff = make(state.DiffedPostgresIndexStatsMap)
 	for key, stats := range new {
 		prevStats, exists := prev[key]
-		if exists {
+		if stats.ExclusivelyLocked {
+			// Skip, we don't have any usable data for this index
+		} else if exists && !prevStats.ExclusivelyLocked {
 			diff[key] = stats.DiffSince(prevStats)
-		} else if followUpRun { // New since the last run
+		} else if followUpRun && !prevStats.ExclusivelyLocked { // New index since the last run
 			diff[key] = stats.DiffSince(state.PostgresIndexStats{})
 		} else {
 			diff[key] = state.DiffedPostgresIndexStats{

--- a/state/postgres_relation_stats.go
+++ b/state/postgres_relation_stats.go
@@ -3,49 +3,51 @@ package state
 import "github.com/guregu/null"
 
 type PostgresRelationStats struct {
-	SizeBytes        int64     // On-disk size including FSM and VM, plus TOAST table if any, excluding indices
-	ToastSizeBytes   int64     // TOAST table and TOAST index size (included in SizeBytes as well)
-	SeqScan          int64     // Number of sequential scans initiated on this table
-	SeqTupRead       int64     // Number of live rows fetched by sequential scans
-	IdxScan          int64     // Number of index scans initiated on this table
-	IdxTupFetch      int64     // Number of live rows fetched by index scans
-	NTupIns          int64     // Number of rows inserted
-	NTupUpd          int64     // Number of rows updated
-	NTupDel          int64     // Number of rows deleted
-	NTupHotUpd       int64     // Number of rows HOT updated (i.e., with no separate index update required)
-	NLiveTup         int64     // Estimated number of live rows
-	NDeadTup         int64     // Estimated number of dead rows
-	NModSinceAnalyze null.Int  // Estimated number of rows modified since this table was last analyzed
-	LastVacuum       null.Time // Last time at which this table was manually vacuumed (not counting VACUUM FULL)
-	LastAutovacuum   null.Time // Last time at which this table was vacuumed by the autovacuum daemon
-	LastAnalyze      null.Time // Last time at which this table was manually analyzed
-	LastAutoanalyze  null.Time // Last time at which this table was analyzed by the autovacuum daemon
-	VacuumCount      int64     // Number of times this table has been manually vacuumed (not counting VACUUM FULL)
-	AutovacuumCount  int64     // Number of times this table has been vacuumed by the autovacuum daemon
-	AnalyzeCount     int64     // Number of times this table has been manually analyzed
-	AutoanalyzeCount int64     // Number of times this table has been analyzed by the autovacuum daemon
-	HeapBlksRead     int64     // Number of disk blocks read from this table
-	HeapBlksHit      int64     // Number of buffer hits in this table
-	IdxBlksRead      int64     // Number of disk blocks read from all indexes on this table
-	IdxBlksHit       int64     // Number of buffer hits in all indexes on this table
-	ToastBlksRead    int64     // Number of disk blocks read from this table's TOAST table (if any)
-	ToastBlksHit     int64     // Number of buffer hits in this table's TOAST table (if any)
-	TidxBlksRead     int64     // Number of disk blocks read from this table's TOAST table indexes (if any)
-	TidxBlksHit      int64     // Number of buffer hits in this table's TOAST table indexes (if any)
-	FrozenXIDAge     int32     // Age of frozen XID for this table
-	MinMXIDAge       int32     // Age of minimum multixact ID for this table
-	Relpages         int32     // Size of the on-disk representation of this table in pages (of size BLCKSZ)
-	Reltuples        float32   // Number of live rows in the table. -1 indicating that the row count is unknown
-	Relallvisible    int32     // Number of pages that are marked all-visible in the table's visibility map
+	SizeBytes         int64     // On-disk size including FSM and VM, plus TOAST table if any, excluding indices
+	ToastSizeBytes    int64     // TOAST table and TOAST index size (included in SizeBytes as well)
+	SeqScan           int64     // Number of sequential scans initiated on this table
+	SeqTupRead        int64     // Number of live rows fetched by sequential scans
+	IdxScan           int64     // Number of index scans initiated on this table
+	IdxTupFetch       int64     // Number of live rows fetched by index scans
+	NTupIns           int64     // Number of rows inserted
+	NTupUpd           int64     // Number of rows updated
+	NTupDel           int64     // Number of rows deleted
+	NTupHotUpd        int64     // Number of rows HOT updated (i.e., with no separate index update required)
+	NLiveTup          int64     // Estimated number of live rows
+	NDeadTup          int64     // Estimated number of dead rows
+	NModSinceAnalyze  null.Int  // Estimated number of rows modified since this table was last analyzed
+	LastVacuum        null.Time // Last time at which this table was manually vacuumed (not counting VACUUM FULL)
+	LastAutovacuum    null.Time // Last time at which this table was vacuumed by the autovacuum daemon
+	LastAnalyze       null.Time // Last time at which this table was manually analyzed
+	LastAutoanalyze   null.Time // Last time at which this table was analyzed by the autovacuum daemon
+	VacuumCount       int64     // Number of times this table has been manually vacuumed (not counting VACUUM FULL)
+	AutovacuumCount   int64     // Number of times this table has been vacuumed by the autovacuum daemon
+	AnalyzeCount      int64     // Number of times this table has been manually analyzed
+	AutoanalyzeCount  int64     // Number of times this table has been analyzed by the autovacuum daemon
+	HeapBlksRead      int64     // Number of disk blocks read from this table
+	HeapBlksHit       int64     // Number of buffer hits in this table
+	IdxBlksRead       int64     // Number of disk blocks read from all indexes on this table
+	IdxBlksHit        int64     // Number of buffer hits in all indexes on this table
+	ToastBlksRead     int64     // Number of disk blocks read from this table's TOAST table (if any)
+	ToastBlksHit      int64     // Number of buffer hits in this table's TOAST table (if any)
+	TidxBlksRead      int64     // Number of disk blocks read from this table's TOAST table indexes (if any)
+	TidxBlksHit       int64     // Number of buffer hits in this table's TOAST table indexes (if any)
+	FrozenXIDAge      int32     // Age of frozen XID for this table
+	MinMXIDAge        int32     // Age of minimum multixact ID for this table
+	Relpages          int32     // Size of the on-disk representation of this table in pages (of size BLCKSZ)
+	Reltuples         float32   // Number of live rows in the table. -1 indicating that the row count is unknown
+	Relallvisible     int32     // Number of pages that are marked all-visible in the table's visibility map
+	ExclusivelyLocked bool      // Whether these statistics are zeroed out because the table was locked at collection time
 }
 
 type PostgresIndexStats struct {
-	SizeBytes   int64
-	IdxScan     int64 // Number of index scans initiated on this index
-	IdxTupRead  int64 // Number of index entries returned by scans on this index
-	IdxTupFetch int64 // Number of live table rows fetched by simple index scans using this index
-	IdxBlksRead int64 // Number of disk blocks read from this index
-	IdxBlksHit  int64 // Number of buffer hits in this index
+	SizeBytes         int64
+	IdxScan           int64 // Number of index scans initiated on this index
+	IdxTupRead        int64 // Number of index entries returned by scans on this index
+	IdxTupFetch       int64 // Number of live table rows fetched by simple index scans using this index
+	IdxBlksRead       int64 // Number of disk blocks read from this index
+	IdxBlksHit        int64 // Number of buffer hits in this index
+	ExclusivelyLocked bool  // Whether these statistics are zeroed out because the index was locked at collection time
 }
 
 type PostgresColumnStats struct {


### PR DESCRIPTION
```
Relation queries: Correctly handle later queries encountering a lock

The existing coding assumed that we can rely on the fact that a relation
is exclusively locked to stay the same across each query that works with
relation data to get columns, indexes, constraints, etc.

But that is not true (locks can change between the queries) and that
causes a race condition where the first query does not see a relation
being locked, but later queries do. This then causes downstream problems
since only part of the information was sent, and e.g. an index might
show in one snapshot, and then disappear in the next, if locking
conditions are unlucky.

To fix, return which exclusive locks each relation query encountered, and
take that to consider the relation having been exclusively locked for the
whole current snapshot, and set the flag accordingly.

In passing, add explicit checks on subsequent relation queries to
ensure the relation actually was captured in the first query. This is
to protect against locks being held on relations that we ignored earlier
(e.g. because of them being a catalog table, or matching the schema filter)
suddenly showing up with empty data through a later query returning them
as a locked relation.

Note that the relation statistics logic suffers from a different but
related problem which is to be fixed in a subsequent commit.
```

```
Relation statistics: Avoid bogus data due to diffs against locked objects

Previously we would skip locked relations when getting the statistics for
either the table or an index. Compared to the locking race condition
in the relation info queries, this is actually not directly a problem in
the same way.

However, the problem with the stats queries is that they assume they
can diff against the prior record, and if that doesn't exist, that the
table (or index) was recently added, and thus we can diff against zero.

That is not correct when relations were ignored due to locks, leading
to a subsequent stats collection suddenly seeing the full counter value
as the diff (since the prior data point was skipped due to the lock).

Fix by explicitly tracking locked relations that the stats queries
skipped, and applying that knowledge in the diff handling.
```