### PR TITLE
Add option to turn off collection of Citus schema statistics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -119,6 +119,7 @@ type ServerConfig struct {
 	SystemScopeFallback string `ini:"api_system_scope_fallback"`
 
 	AlwaysCollectSystemData bool `ini:"always_collect_system_data"`
+	DisableCitusSchemaStats bool `ini:"disable_citus_schema_stats"`
 
 	// Configures the location where logfiles are - this can either be a directory,
 	// or a file - needs to readable by the regular pganalyze user

--- a/config/read.go
+++ b/config/read.go
@@ -219,6 +219,9 @@ func getDefaultConfig() *ServerConfig {
 	if alwaysCollectSystemData := os.Getenv("PGA_ALWAYS_COLLECT_SYSTEM_DATA"); alwaysCollectSystemData != "" {
 		config.AlwaysCollectSystemData = parseConfigBool(alwaysCollectSystemData)
 	}
+	if disableCitusSchemaStats := os.Getenv("DISABLE_CITUS_SCHEMA_STATS"); disableCitusSchemaStats != "" {
+		config.DisableCitusSchemaStats = parseConfigBool(disableCitusSchemaStats)
+	}
 	if logPgReadFile := os.Getenv("LOG_PG_READ_FILE"); logPgReadFile != "" {
 		config.LogPgReadFile = parseConfigBool(logPgReadFile)
 	}

--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -95,7 +95,7 @@ SELECT 1 AS enabled
  WHERE n.nspname = 'pganalyze' AND p.proname = 'get_column_stats'
 `
 
-func GetRelationStats(ctx context.Context, db *sql.DB, postgresVersion state.PostgresVersion, ignoreRegexp string) (relStats state.PostgresRelationStatsMap, err error) {
+func GetRelationStats(ctx context.Context, db *sql.DB, postgresVersion state.PostgresVersion, server *state.Server) (relStats state.PostgresRelationStatsMap, err error) {
 	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+relationStatsSQL)
 	if err != nil {
 		err = fmt.Errorf("RelationStats/Prepare: %s", err)
@@ -103,7 +103,7 @@ func GetRelationStats(ctx context.Context, db *sql.DB, postgresVersion state.Pos
 	}
 	defer stmt.Close()
 
-	rows, err := stmt.QueryContext(ctx, ignoreRegexp)
+	rows, err := stmt.QueryContext(ctx, server.Config.IgnoreSchemaRegexp)
 	if err != nil {
 		err = fmt.Errorf("RelationStats/Query: %s", err)
 		return
@@ -140,12 +140,12 @@ func GetRelationStats(ctx context.Context, db *sql.DB, postgresVersion state.Pos
 		return
 	}
 
-	relStats, err = handleRelationStatsExt(ctx, db, relStats, postgresVersion, ignoreRegexp)
+	relStats, err = handleRelationStatsExt(ctx, db, relStats, postgresVersion, server)
 
 	return
 }
 
-func GetIndexStats(ctx context.Context, db *sql.DB, postgresVersion state.PostgresVersion, ignoreRegexp string) (indexStats state.PostgresIndexStatsMap, err error) {
+func GetIndexStats(ctx context.Context, db *sql.DB, postgresVersion state.PostgresVersion, server *state.Server) (indexStats state.PostgresIndexStatsMap, err error) {
 	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+indexStatsSQL)
 	if err != nil {
 		err = fmt.Errorf("IndexStats/Prepare: %s", err)
@@ -153,7 +153,7 @@ func GetIndexStats(ctx context.Context, db *sql.DB, postgresVersion state.Postgr
 	}
 	defer stmt.Close()
 
-	rows, err := stmt.QueryContext(ctx, ignoreRegexp)
+	rows, err := stmt.QueryContext(ctx, server.Config.IgnoreSchemaRegexp)
 	if err != nil {
 		err = fmt.Errorf("IndexStats/Query: %s", err)
 		return
@@ -180,7 +180,7 @@ func GetIndexStats(ctx context.Context, db *sql.DB, postgresVersion state.Postgr
 		return
 	}
 
-	indexStats, err = handleIndexStatsExt(ctx, db, indexStats, postgresVersion, ignoreRegexp)
+	indexStats, err = handleIndexStatsExt(ctx, db, indexStats, postgresVersion, server)
 
 	return
 }

--- a/input/postgres/relation_stats_ext.go
+++ b/input/postgres/relation_stats_ext.go
@@ -21,15 +21,15 @@ SELECT logicalrelid::oid,
  WHERE ($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)
 `
 
-func handleRelationStatsExt(ctx context.Context, db *sql.DB, relStats state.PostgresRelationStatsMap, postgresVersion state.PostgresVersion, ignoreRegexp string) (state.PostgresRelationStatsMap, error) {
-	if postgresVersion.IsCitus {
+func handleRelationStatsExt(ctx context.Context, db *sql.DB, relStats state.PostgresRelationStatsMap, postgresVersion state.PostgresVersion, server *state.Server) (state.PostgresRelationStatsMap, error) {
+	if postgresVersion.IsCitus && !server.Config.DisableCitusSchemaStats {
 		stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+citusRelationSizeSQL)
 		if err != nil {
 			return relStats, fmt.Errorf("RelationStatsExt/Prepare: %s", err)
 		}
 		defer stmt.Close()
 
-		rows, err := stmt.QueryContext(ctx, ignoreRegexp)
+		rows, err := stmt.QueryContext(ctx, server.Config.IgnoreSchemaRegexp)
 		if err != nil {
 			return relStats, fmt.Errorf("RelationStatsExt/Query: %s", err)
 		}
@@ -103,15 +103,15 @@ GROUP BY
   oid;
 `
 
-func handleIndexStatsExt(ctx context.Context, db *sql.DB, idxStats state.PostgresIndexStatsMap, postgresVersion state.PostgresVersion, ignoreRegexp string) (state.PostgresIndexStatsMap, error) {
-	if postgresVersion.IsCitus {
+func handleIndexStatsExt(ctx context.Context, db *sql.DB, idxStats state.PostgresIndexStatsMap, postgresVersion state.PostgresVersion, server *state.Server) (state.PostgresIndexStatsMap, error) {
+	if postgresVersion.IsCitus && !server.Config.DisableCitusSchemaStats {
 		stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+citusIndexSizeSQL)
 		if err != nil {
 			return idxStats, fmt.Errorf("IndexStatsExt/Prepare: %s", err)
 		}
 		defer stmt.Close()
 
-		rows, err := stmt.QueryContext(ctx, ignoreRegexp)
+		rows, err := stmt.QueryContext(ctx, server.Config.IgnoreSchemaRegexp)
 		if err != nil {
 			return idxStats, fmt.Errorf("IndexStatsExt/Query: %s", err)
 		}


### PR DESCRIPTION
For certain Citus deployments, running the relation or index size functions can fail or time out due to a very high number of distributed tables.

Add the new option "disable_citus_schema_stats" / "DISABLE_CITUS_SCHEMA_STATS" to turn off the collection of these statistics. When using this option its recommended to instead monitor the workers directly for table and index sizes.