### PR TITLE
Send out exclusively locked relation info

### DIFF
--- a/output/transform/postgres_relations.go
+++ b/output/transform/postgres_relations.go
@@ -63,6 +63,16 @@ func transformPostgresRelations(s snapshot.FullSnapshot, newState state.Persiste
 			Options:                relation.Options,
 		}
 
+		// In case of exclusively locked relations that are encountered by a later input query
+		// (e.g. to get column or index information), it can happen that we get partial data
+		// - make sure we don't send that unnecessarily (the server would just ignore it)
+		if relation.ExclusivelyLocked {
+			// Still add to RelationInformations as some basic information like RelationType
+			// will be used with RelationReferences
+			s.RelationInformations = append(s.RelationInformations, &info)
+			continue
+		}
+
 		schemaStats, schemaStatsExist := newState.SchemaStats[relation.DatabaseOid]
 
 		if relation.ViewDefinition != "" {

--- a/output/transform/postgres_relations.go
+++ b/output/transform/postgres_relations.go
@@ -65,13 +65,6 @@ func transformPostgresRelations(s snapshot.FullSnapshot, newState state.Persiste
 
 		schemaStats, schemaStatsExist := newState.SchemaStats[relation.DatabaseOid]
 
-		// In case of exclusively locked relations that are encountered by a later input query
-		// (e.g. to get column or index information), it can happen that we get partial data
-		// - make sure we don't send that unnecessarily (the server would just ignore it)
-		if relation.ExclusivelyLocked {
-			continue
-		}
-
 		if relation.ViewDefinition != "" {
 			info.ViewDefinition = &snapshot.NullString{Valid: true, Value: relation.ViewDefinition}
 		}


### PR DESCRIPTION
In https://github.com/pganalyze/collector/pull/391, we stopped sending out the data like `RelationInformations` and `RelationStatistics` when the relation is exclusively locked.
However, this caused the issue on the pganalyze app side, because we're still sending out `RelationReferences` yet we weren't able to find the corresponding `RelationInformations` with it. When storing the `RelationReferences`  data, we use the information of `RelationInformations`, especially `RelationType` data.

With this change, revert stop sending out the `RelationInformations` data. This should be the only info that we need but dropped (we are okay not having `RelationStatistics` or other things), and we also shouldn't have the "bad data" with `RelationInformations` because we can still get this basic relation info without worrying about the locks.

https://github.com/pganalyze/collector/pull/391/files#r1139988321