### PR TITLE
Query stats reset: Make pg_stat_statements_reset() failure a soft error

### DIFF
--- a/input/full.go
+++ b/input/full.go
@@ -64,8 +64,9 @@ func CollectFull(ctx context.Context, server *state.Server, connection *sql.DB, 
 		ps.StatementResetCounter = 0
 		err = postgres.ResetStatements(ctx, logger, connection, systemType)
 		if err != nil {
-			// This is a non-fatal error, so continue snapshot collection but report it
-			logger.PrintWarning("Failed to call pg_stat_statements_reset() as requested: %s", err)
+			// This is a non-fatal error, so continue snapshot collection but do log it as an error
+			// (this gets automatically added to the snapshot's CollectorErrors information)
+			logger.PrintError("Error calling pg_stat_statements_reset() as requested: %s", err)
 			err = nil
 		} else {
 			_, _, ts.ResetStatementStats, err = postgres.GetStatements(ctx, server, logger, connection, globalCollectionOpts, ts.Version, false, systemType)


### PR DESCRIPTION
Previously this was a hard error, which failed the snapshot - this is not desirable because hard errors mean the snapshot state does not get persisted. In practice this meant that the error would very likely occur again on the next full snapshot run, in the typical case of a permission problem. This meant that full snapshots kept failing, which indirectly led to a memory leak because the UnidentifiedStatementStats list would keep growing (as the query runner was working just fine, once a minute).

To fix, emit only a warning instead, and process the rest of the snapshot as usual, thus persisting the state and not calling the reset function again until the next scheduled interval.

Fixes #398

---

Separately, as a defense against this class of bugs causing memory leaks, we should review in a follow-up PR how we can prune UnidentifiedStatementStats in face of constantly failing full snapshots (possibly by having the query stats runner do a sanity check and drop old unsubmitted data if needed).