### PR TITLE
Azure: Add troubleshooting link for Azure AD provider error

### DIFF
--- a/runner/logs.go
+++ b/runner/logs.go
@@ -456,7 +456,7 @@ func testAzureLogStream(ctx context.Context, wg *sync.WaitGroup, server *state.S
 	if err != nil {
 		logger.PrintError("ERROR - Could not get logs through Azure Event Hub: %s", err)
 		if strings.HasPrefix(err.Error(), "failed to configure Azure AD JWT provider: failed") {
-			logger.PrintInfo("HINT - This may occur when you have multiple user-assigned managed identities set for your virtual machine. Try removing any unrelated managed identities, or explicitly set the azure_ad_client_id setting to the managed identity's Client ID.")
+			logger.PrintInfo("HINT - This error occurs when there are no Azure AD credentials configured. Please review the pganalyze documentation: https://pganalyze.com/docs/log-insights/setup/azure-database/troubleshooting#error-failed-to-configure-azure-ad-jwt-provider")
 		}
 		return false
 	}


### PR DESCRIPTION
Contrary to the existing hint, this can also occur when one simply forgets to assign a managed identity to the VM. Its easier for us to explain this on a web page, so link to the troubleshooting page instead.

Note that I have some pending docs improvements (https://github.com/pganalyze/pganalyze-docs/pull/145/commits/a4275f413b6ca5ec0a9fef104bc40dbaa0f57b6b) that carry over the existing hint messaging to the docs.