### PR TITLE
Extend the deadline for activity snapshots

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -30,7 +30,7 @@ func (group Group) Schedule(ctx context.Context, runner func(context.Context), l
 					deadline := nextExecutions[1].Add(-1 * time.Second)
 					// Extend the deadline of very short runs to avoid pointless cancellations.
 					if nextExecutions[1].Sub(nextExecutions[0]) <= 15*time.Second {
-						deadline = deadline.Add(15 * time.Second)
+						deadline = nextExecutions[0].Add(19 * time.Second)
 					}
 					ctx, cancel := context.WithDeadline(ctx, deadline)
 					defer cancel()

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -27,10 +27,10 @@ func (group Group) Schedule(ctx context.Context, runner func(context.Context), l
 				func() {
 					// Cancel runner at latest right before next scheduled execution should
 					// occur, to prevent skipping over runner executions by accident.
-					deadline := nextExecutions[1].Add(-1*time.Second)
+					deadline := nextExecutions[1].Add(-1 * time.Second)
 					// Extend the deadline of very short runs to avoid pointless cancellations.
 					if nextExecutions[1].Sub(nextExecutions[0]) <= 15*time.Second {
-						deadline = deadline.Add(15*time.Second)
+						deadline = deadline.Add(15 * time.Second)
 					}
 					ctx, cancel := context.WithDeadline(ctx, deadline)
 					defer cancel()


### PR DESCRIPTION
#384 added a deadline / timeout for each snapshot, but this is leading to data loss for a customer with a collector process that monitors 20+ servers. When monitoring so many servers it's possible that network requests, for example, could cause activity snapshots to not reliably finish within 10 seconds. A future refactor may move snapshot uploads to a separate deadline, but this PR should mitigate the issue for now.