### PR TITLE
Scheduler: Use 19 seconds to check for very short deadlines

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -29,7 +29,7 @@ func (group Group) Schedule(ctx context.Context, runner func(context.Context), l
 					// occur, to prevent skipping over runner executions by accident.
 					deadline := nextExecutions[1].Add(-1 * time.Second)
 					// Extend the deadline of very short runs to avoid pointless cancellations.
-					if nextExecutions[1].Sub(nextExecutions[0]) <= 15*time.Second {
+					if nextExecutions[1].Sub(nextExecutions[0]) < 19*time.Second {
 						deadline = nextExecutions[0].Add(19 * time.Second)
 					}
 					ctx, cancel := context.WithDeadline(ctx, deadline)


### PR DESCRIPTION
This makes it easier for a future reader to understand, since it matches the if condition with the override we're setting.

In practice this doesn't actually matter with the current scheduler config since we either have 10 seconds or 1 minute apart, and thus the 10 seconds interval would already have matched as a very short deadline.

See https://github.com/pganalyze/collector/pull/406#discussion_r1156552159