### PR TITLE
packages Makefile: Fix variable default logic to not assume bash

### DIFF
--- a/packages/Makefile
+++ b/packages/Makefile
@@ -1,9 +1,6 @@
-export NAME=pganalyze-collector
-export VERSION="${VERSION:-0.49.1}"
-export GIT_VERSION="${GIT_VERSION:-v0.49.1}"
-#export GIT_VERSION=HEAD
-#export GIT_VERSION=618e85ce5ed5365bc7d9d9da866fdeb73bac5a55
-#export VERSION=$(shell git show -s --format=%ct.%h HEAD)
+export NAME ?= pganalyze-collector
+export VERSION ?= 0.49.1
+export GIT_VERSION ?= v$(VERSION)
 
 export RPM_PACKAGE_X86_64=$(NAME)-$(VERSION)-1.x86_64.rpm
 export RPM_PACKAGE_ARM64=$(NAME)-$(VERSION)-1.aarch64.rpm


### PR DESCRIPTION
The syntax added in the previous commit does not work within Makefiles, only in bash. Instead use "?=" which is the correct way to allow overriding Makefile variables from the environment.

In passing, default the GIT_VERSION to be the version prefixed by "v", to have one less variable to change when releasing a new version.