### PR TITLE
Release task: Correctly use version without "v" prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,9 +99,11 @@ jobs:
       with:
         name: packages
 
-    - name: Get version from tag
+    - name: Get version and git version from tag
       id: get_version
-      run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      run: |
+        echo "git_version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
 
     - name: Create release
       id: create_release
@@ -109,8 +111,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ steps.get_version.outputs.version }}
-        release_name: ${{ steps.get_version.outputs.version }}
+        tag_name: ${{ steps.get_version.outputs.git_version }}
+        release_name: ${{ steps.get_version.outputs.git_version }}
         draft: false
         prerelease: false
 


### PR DESCRIPTION
This accidentally led to the package upload to the release entry not working as intended, since the package names use the raw version number without the "v" prefix used in the git tag.