### PR TITLE
RPM packages: Ensure collector gets started after reboot

### DIFF
--- a/packages/src/rpm-systemd/post.sh
+++ b/packages/src/rpm-systemd/post.sh
@@ -30,3 +30,6 @@ elif [ "$1" -eq "2" ]; then
   systemctl stop pganalyze-collector.service
   systemctl start pganalyze-collector.service
 fi
+
+# Enable the service to ensure it gets started after reboot
+systemctl enable pganalyze-collector.service

--- a/packages/src/rpm-systemd/preun.sh
+++ b/packages/src/rpm-systemd/preun.sh
@@ -4,5 +4,6 @@ set -e
 
 if [ "$1" -eq "0" ]; then
   # Last version of the package is being erased
+  systemctl disable pganalyze-collector.service
   systemctl stop pganalyze-collector.service
 fi


### PR DESCRIPTION
This was an oversight in the packaging logic, since we utilize fpm's "--deb-systemd-auto-start" setting for the Debian-based packages, but we don't have the equivalent for the RPM packages.

Fix by adding an explicit "systemctl enable" on installation, and a corresponding "systemctl disable" on removal, matching what was already done for the Debian packages.