### PR TITLE
Reload collector config after successful test run

### DIFF
--- a/main.go
+++ b/main.go
@@ -307,7 +307,7 @@ func main() {
 
 	// Automatically reload the configuration after a successful test run.
 	if testRun && !noReload {
-		reloadRun = true;
+		reloadRun = true
 	}
 
 	if showVersion {

--- a/main.go
+++ b/main.go
@@ -267,7 +267,7 @@ func main() {
 	logger := &util.Logger{}
 
 	flag.BoolVarP(&showVersion, "version", "", false, "Shows current version of the collector and exits")
-	flag.BoolVarP(&testRun, "test", "t", false, "Tests whether we can successfully collect statistics (including log data if configured), submits it to the server, and exits afterwards")
+	flag.BoolVarP(&testRun, "test", "t", false, "Tests data collection (including logs), submits it to the server, and reloads the collector daemon (disable with --no-reload)")
 	flag.StringVar(&testReport, "test-report", "", "Tests a particular report and returns its output as JSON")
 	flag.BoolVar(&testRunLogs, "test-logs", false, "Tests whether log collection works (does not test privilege dropping for local log collection, use --test for that)")
 	flag.BoolVar(&testExplain, "test-explain", false, "Tests whether EXPLAIN collection works by issuing a dummy query (ensure log collection works first)")

--- a/main.go
+++ b/main.go
@@ -226,12 +226,6 @@ func run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 		wg.Done()
 	}, logger, "high frequency query statistics of all servers", schedulerGroups["stats"])
 
-	schedulerGroups["reload"].Schedule(ctx, func(ctx context.Context) {
-		wg.Add(1)
-		Reload(logger)
-		wg.Done()
-	}, logger, "")
-
 	keepRunning = true
 	return
 }

--- a/main.go
+++ b/main.go
@@ -260,6 +260,7 @@ func main() {
 	var logToJSON bool
 	var logNoTimestamps bool
 	var reloadRun bool
+	var noReload bool
 	var benchmark bool
 
 	logFlags := log.LstdFlags
@@ -272,6 +273,7 @@ func main() {
 	flag.BoolVar(&testExplain, "test-explain", false, "Tests whether EXPLAIN collection works by issuing a dummy query (ensure log collection works first)")
 	flag.StringVar(&testSection, "test-section", "", "Tests a particular section of the config file, i.e. a specific server, and ignores all other config sections")
 	flag.BoolVar(&reloadRun, "reload", false, "Reloads the collector daemon thats running on the host")
+	flag.BoolVar(&noReload, "no-reload", false, "Disables automatic config reloading during a test run")
 	flag.BoolVarP(&logger.Verbose, "verbose", "v", false, "Outputs additional debugging information, use this if you're encoutering errors or other problems")
 	flag.BoolVarP(&logger.Quiet, "quiet", "q", false, "Only outputs error messages to the logs and hides informational and warning messages")
 	flag.BoolVar(&logToSyslog, "syslog", false, "Write all log output to syslog instead of stderr (disabled by default)")
@@ -302,6 +304,11 @@ func main() {
 	flag.StringVar(&pidFilename, "pidfile", "", "Specifies a path that a pidfile should be written to (default is no pidfile being written)")
 	flag.BoolVar(&benchmark, "benchmark", false, "Runs collector in benchmark mode (skip submitting the statistics to the server)")
 	flag.Parse()
+
+	// Automatically reload the configuration after a successful test run.
+	if testRun && !noReload {
+		reloadRun = true;
+	}
 
 	if showVersion {
 		fmt.Printf("%s\n", util.CollectorVersion)

--- a/main.go
+++ b/main.go
@@ -226,6 +226,12 @@ func run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 		wg.Done()
 	}, logger, "high frequency query statistics of all servers", schedulerGroups["stats"])
 
+	schedulerGroups["reload"].Schedule(ctx, func(ctx context.Context) {
+		wg.Add(1)
+		Reload(logger)
+		wg.Done()
+	}, logger, "")
+
 	keepRunning = true
 	return
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -89,18 +89,12 @@ func GetSchedulerGroups() (groups map[string]Group, err error) {
 		return
 	}
 
-	hourInterval, err := cronexpr.Parse("0 * * * *")
-	if err != nil {
-		return
-	}
-
 	groups = make(map[string]Group)
 
 	groups["stats"] = Group{interval: tenMinuteInterval}
 	groups["reports"] = Group{interval: oneMinuteInterval}
 	groups["activity"] = Group{interval: tenSecondInterval}
 	groups["query_stats"] = Group{interval: oneMinuteInterval}
-	groups["reload"] = Group{interval: hourInterval}
 
 	return
 }

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -89,12 +89,18 @@ func GetSchedulerGroups() (groups map[string]Group, err error) {
 		return
 	}
 
+	hourInterval, err := cronexpr.Parse("0 * * * *")
+	if err != nil {
+		return
+	}
+
 	groups = make(map[string]Group)
 
 	groups["stats"] = Group{interval: tenMinuteInterval}
 	groups["reports"] = Group{interval: oneMinuteInterval}
 	groups["activity"] = Group{interval: tenSecondInterval}
 	groups["query_stats"] = Group{interval: oneMinuteInterval}
+	groups["reload"] = Group{interval: hourInterval}
 
 	return
 }


### PR DESCRIPTION
It's fairly common for users to make a config change and verify it with `--test`, but forget to include `--reload` so the background collector continues running with the old configuration. ~~This PR attempts to reduce our support burden by automatically reloading the configuration every hour.~~

Another option might be to always reload the configuration after a successful test run, removing the `--reload` flag.