### PR TITLE
Look for truncation messages in the middle of log lines

### DIFF
--- a/logs/analyze.go
+++ b/logs/analyze.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/pganalyze/collector/logs/querysample"
+	"github.com/pganalyze/collector/logs/util"
 	"github.com/pganalyze/collector/output/pganalyze_collector"
 	"github.com/pganalyze/collector/state"
 )
@@ -1491,7 +1492,7 @@ func classifyAndSetDetails(logLine state.LogLine, statementLine state.LogLine, d
 	if matchesPrefix(logLine, duration.primary.prefixes) {
 		logLine.Classification = duration.classification
 		logLine, parts = matchLogLine(logLine, duration.primary)
-		if strings.HasSuffix(strings.TrimSpace(logLine.Content), "[Your log message was truncated]") {
+		if util.WasTruncated(logLine.Content) {
 			logLine.Details = map[string]interface{}{"truncated": true}
 		} else if len(parts) == 5 {
 			var parameterParts [][]string
@@ -2106,7 +2107,7 @@ func AnalyzeBackendLogLines(logLines []state.LogLine) (logLinesOut []state.LogLi
 			if futureLine.LogLevel == pganalyze_collector.LogLineInformation_STATEMENT || futureLine.LogLevel == pganalyze_collector.LogLineInformation_DETAIL ||
 				futureLine.LogLevel == pganalyze_collector.LogLineInformation_HINT || futureLine.LogLevel == pganalyze_collector.LogLineInformation_CONTEXT ||
 				futureLine.LogLevel == pganalyze_collector.LogLineInformation_QUERY {
-				if futureLine.LogLevel == pganalyze_collector.LogLineInformation_STATEMENT && !strings.HasSuffix(futureLine.Content, "[Your log message was truncated]") {
+				if futureLine.LogLevel == pganalyze_collector.LogLineInformation_STATEMENT && !util.WasTruncated(futureLine.Content) {
 					logLine.Query = futureLine.Content
 					statementLine = futureLine
 					statementLine.ParentUUID = logLine.UUID

--- a/logs/analyze_test.go
+++ b/logs/analyze_test.go
@@ -3745,6 +3745,24 @@ var tests = []testpair{
 	},
 	{
 		[]state.LogLine{{
+			Content: "duration: 2334.085 ms  plan:\n" +
+				"	{\n" +
+				"	  \"Query Text\": \"SELECT abalance FROM pgbench_accounts WHERE aid = \n [Your log message was truncated]\n some other log content",
+		}},
+		[]state.LogLine{{
+			Classification:     pganalyze_collector.LogLineInformation_STATEMENT_AUTO_EXPLAIN,
+			Details:            map[string]interface{}{"query_sample_error": "auto_explain output was truncated and can't be parsed as JSON"},
+			ReviewedForSecrets: true,
+			SecretMarkers: []state.LogSecretMarker{{
+				ByteStart: 30,
+				ByteEnd:   158,
+				Kind:      state.StatementTextLogSecret,
+			}},
+		}},
+		nil,
+	},
+	{
+		[]state.LogLine{{
 			Content: "duration: 1681.452 ms  plan:\n" +
 				"  Query Text: UPDATE pgbench_branches SET bbalance = bbalance + 2656 WHERE bid = 59;\n" +
 				"  Update on public.pgbench_branches  (cost=0.27..8.29 rows=1 width=370) (actual rows=0 loops=1)\n" +

--- a/logs/querysample/querysample.go
+++ b/logs/querysample/querysample.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/guregu/null"
+	"github.com/pganalyze/collector/logs/util"
 	"github.com/pganalyze/collector/output/pganalyze_collector"
 	"github.com/pganalyze/collector/state"
 )
@@ -15,7 +16,7 @@ import (
 func TransformAutoExplainToQuerySample(logLine state.LogLine, explainText string, queryRuntime string) (state.PostgresQuerySample, error) {
 	queryRuntimeMs, _ := strconv.ParseFloat(queryRuntime, 64)
 	if strings.HasPrefix(explainText, "{") { // json format
-		if strings.HasSuffix(explainText, "[Your log message was truncated]") {
+		if util.WasTruncated(explainText) {
 			return state.PostgresQuerySample{}, fmt.Errorf("auto_explain output was truncated and can't be parsed as JSON")
 		} else {
 			return transformExplainJSONToQuerySample(logLine, explainText, queryRuntimeMs)

--- a/logs/util/parse.go
+++ b/logs/util/parse.go
@@ -1,0 +1,10 @@
+package util
+
+import "strings"
+
+func WasTruncated(line string) bool {
+	// RDS limits log lines to 1MB, and inserts a message if the line overflows. We may
+	// stitch the line together with the truncation message, so we need to look for it
+	// anywhere in the line.
+	return strings.Contains(line, "[Your log message was truncated]")
+}


### PR DESCRIPTION
This can happen because of stitching; we can't just look for them at
the end.
