### PR TITLE
README: Don't list individual authors, adjust copyright to match common style

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,14 +308,9 @@ The script will also have the following environment variables set:
 * PGA_ERROR_MESSAGE (error message, in the case of the error callback)
 
 
-Authors
--------
-
- * [Lukas Fittl](https://github.com/lfittl)
- * [Michael Renner](https://github.com/terrorobe)
-
-
 License
 -------
 
 pganalyze-collector is licensed under the 3-clause BSD license, see LICENSE file for details.
+
+Copyright (c) 2012-2023, Duboce Labs, Inc. (pganalyze)


### PR DESCRIPTION
The pganalyze collector is maintained by pganalyze as a team, and so it doesn't make sense to reflect individual authorship in the README (a list which by now was also clearly outdated).

In passing, adjust the copyright to match the style we use in other repositories.