### PR TITLE
Collector test: Always return correct exit code, even with --no-reload

### DIFF
--- a/main.go
+++ b/main.go
@@ -509,6 +509,8 @@ ReadConfigAndRun:
 						logger.PrintError("Error: Reload requested, but ignoring since configuration errors are present")
 						exitCode = 1
 					}
+				} else if !success {
+					exitCode = 1
 				}
 				break DoneOrSignal
 			case s := <-sigs:


### PR DESCRIPTION
Due to a coding oversight that dates a while back, the exit code is only set when doing test+reload, but not when doing just test.

Whilst a recent change has flipped the default of test to also execute reload automatically, it doesn't hurt to return a failue exit code (1) in case of failure when "--no-reload" is specified.