### PR TITLE
Fix bug where xmin horizon ReplicationSlot was wrongly set to ReplicationSlotCatalog

### DIFF
--- a/output/transform/postgres.go
+++ b/output/transform/postgres.go
@@ -158,7 +158,7 @@ func transformPostgresServerStats(s snapshot.FullSnapshot, transientState state.
 		NextMultiXactId:                   int64(transientState.ServerStats.NextMultiXactId),
 		XminHorizonBackend:                transientState.ServerStats.FullXminHorizonBackend(),
 		XminHorizonReplicationSlot:        transientState.ServerStats.FullXminHorizonReplicationSlot(),
-		XminHorizonReplicationSlotCatalog: transientState.ServerStats.FullXminHorizonReplicationSlot(),
+		XminHorizonReplicationSlotCatalog: transientState.ServerStats.FullXminHorizonReplicationSlotCatalog(),
 		XminHorizonPreparedXact:           transientState.ServerStats.FullXminHorizonPreparedXact(),
 		XminHorizonStandby:                transientState.ServerStats.FullXminHorizonStandby(),
 	}


### PR DESCRIPTION
Bugfix. With xmin horizon stats, ReplicationSlot was used for XminHorizonReplicationSlotCatalog, wrongly. This PR fixes it.