### PR TITLE
Log analysis: Remember unqualified name for "skipping vacuum" events

### DIFF
--- a/logs/analyze.go
+++ b/logs/analyze.go
@@ -1547,7 +1547,9 @@ func classifyAndSetDetails(logLine state.LogLine, statementLine state.LogLine, d
 		logLine.Classification = skippingVacuum.classification
 		logLine, parts = matchLogLine(logLine, skippingVacuum.primary)
 		if len(parts) == 2 {
-			logLine.RelationName = parts[1]
+			// Unfortunately Postgres doesn't log a schema here, so we need to store this
+			// outside of the usual relation reference (which requires a schema)
+			logLine.Details = map[string]interface{}{"relation_name": parts[1]}
 		}
 		contextLine = matchOtherContextLogLine(contextLine)
 		return logLine, statementLine, detailLine, contextLine, hintLine, samples
@@ -1556,7 +1558,9 @@ func classifyAndSetDetails(logLine state.LogLine, statementLine state.LogLine, d
 		logLine.Classification = skippingAnalyze.classification
 		logLine, parts = matchLogLine(logLine, skippingAnalyze.primary)
 		if len(parts) == 2 {
-			logLine.RelationName = parts[1]
+			// Unfortunately Postgres doesn't log a schema here, so we need to store this
+			// outside of the usual relation reference (which requires a schema)
+			logLine.Details = map[string]interface{}{"relation_name": parts[1]}
 		}
 		contextLine = matchOtherContextLogLine(contextLine)
 		return logLine, statementLine, detailLine, contextLine, hintLine, samples

--- a/logs/analyze_test.go
+++ b/logs/analyze_test.go
@@ -1680,10 +1680,12 @@ var tests = []testpair{
 			UUID:     uuid.UUID{1},
 		}},
 		[]state.LogLine{{
-			LogLevel:           pganalyze_collector.LogLineInformation_LOG,
-			Classification:     pganalyze_collector.LogLineInformation_SKIPPING_VACUUM_LOCK_NOT_AVAILABLE,
-			UUID:               uuid.UUID{1},
-			RelationName:       "mytable",
+			LogLevel:       pganalyze_collector.LogLineInformation_LOG,
+			Classification: pganalyze_collector.LogLineInformation_SKIPPING_VACUUM_LOCK_NOT_AVAILABLE,
+			UUID:           uuid.UUID{1},
+			Details: map[string]interface{}{
+				"relation_name": "mytable",
+			},
 			ReviewedForSecrets: true,
 		}},
 		nil,
@@ -1694,10 +1696,12 @@ var tests = []testpair{
 			UUID:     uuid.UUID{1},
 		}},
 		[]state.LogLine{{
-			LogLevel:           pganalyze_collector.LogLineInformation_LOG,
-			Classification:     pganalyze_collector.LogLineInformation_SKIPPING_ANALYZE_LOCK_NOT_AVAILABLE,
-			UUID:               uuid.UUID{1},
-			RelationName:       "pgbench_tellers",
+			LogLevel:       pganalyze_collector.LogLineInformation_LOG,
+			Classification: pganalyze_collector.LogLineInformation_SKIPPING_ANALYZE_LOCK_NOT_AVAILABLE,
+			UUID:           uuid.UUID{1},
+			Details: map[string]interface{}{
+				"relation_name": "pgbench_tellers",
+			},
 			ReviewedForSecrets: true,
 		}},
 		nil,


### PR DESCRIPTION
Due to the way we associate log lines to relation references, we need to have a fully qualified name that has both a schema and relation name.

Unfortunately Postgres currently never outputs a schema name for the "skipping vacuum" and "skipping analyze" events, only the table name itself - which caused us to not associate the line to a relation.

To allow filtering on the application side through special logic that can look at tables in all schemas matching the name, remember the relation name in the unstructured details field of the log line, and stop storing it in the RelationName field (which was never sent to the server anyways).