### PR TITLE
RPM Packages: Switch to SHA256 signatures to fix RHEL9 install errors

### DIFF
--- a/packages/repo/Dockerfile.repo-rpm
+++ b/packages/repo/Dockerfile.repo-rpm
@@ -15,6 +15,15 @@ RUN yum install -y -q rpm-sign createrepo
 
 RUN echo "%_gpg_name team@pganalyze.com" > /root/.rpmmacros
 
+# Switch signature algorithm from SHA1 to SHA256 to support RHEL9 and newer
+# See https://www.redhat.com/en/blog/rhel-security-sha-1-package-signatures-distrusted-rhel-9
+RUN echo "%__gpg_sign_cmd                 %{__gpg} \
+        gpg --batch --no-verbose --no-armor --passphrase-fd 3 \
+        %{?_gpg_digest_algo:--digest-algo %{_gpg_digest_algo}} \
+        --no-secmem-warning \
+        --digest-algo sha256 \
+        -u \"%{_gpg_name}\" -sbo %{__signature_filename} %{__plaintext_filename}" >> /root/.rpmmacros
+
 COPY sync_rpm.sh /root
 COPY $NAME-$VERSION-1.x86_64.rpm $RPM_DIR/systemd/$NAME-$VERSION-1.x86_64.rpm
 COPY $NAME-$VERSION-1.aarch64.rpm $RPM_DIR/systemd/$NAME-$VERSION-1.aarch64.rpm

--- a/packages/repo/sync_rpm.sh
+++ b/packages/repo/sync_rpm.sh
@@ -10,8 +10,8 @@ rpm --addsign /rpm/systemd/$RPM_PACKAGE_ARM64
 
 # Verify that we've actually correctly signed the packages
 rpm --import https://packages.pganalyze.com/pganalyze_signing_key.asc
-rpm --checksig /rpm/systemd/$RPM_PACKAGE_X86_64
-rpm --checksig /rpm/systemd/$RPM_PACKAGE_ARM64
+rpm --checksig -v /rpm/systemd/$RPM_PACKAGE_X86_64
+rpm --checksig -v /rpm/systemd/$RPM_PACKAGE_ARM64
 
 mkdir -p /repo/el/7/RPMS
 cp /rpm/systemd/$RPM_PACKAGE_X86_64 /repo/el/7/RPMS/


### PR DESCRIPTION
In passing, add the "-v" switch to the "rpm --checksig" command so we can easily see which signature was used.

---

Before:

```
/rpm/systemd/pganalyze-collector-0.50.1-1.x86_64.rpm:
    Header V4 RSA/SHA1 Signature, key ID a2b5f2f9: OK
    Header SHA1 digest: OK (7461f9f24bcd3cb5d52bac85de3541a0b5f48f2a)
    V4 RSA/SHA1 Signature, key ID a2b5f2f9: OK
    MD5 digest: OK (b7b80dd6da1fae32d76e86d6673cfc00)
/rpm/systemd/pganalyze-collector-0.50.1-1.aarch64.rpm:
    Header V4 RSA/SHA1 Signature, key ID a2b5f2f9: OK
    Header SHA1 digest: OK (455543595f47e9402383c85f1a8540044d6b5e5c)
    V4 RSA/SHA1 Signature, key ID a2b5f2f9: OK
    MD5 digest: OK (4e57b10b5de21dcec17ca459117ad1b7)
```

After:

```
/rpm/systemd/pganalyze-collector-0.50.1-1.x86_64.rpm:
    Header V4 RSA/SHA256 Signature, key ID a2b5f2f9: OK
    Header SHA1 digest: OK (7461f9f24bcd3cb5d52bac85de3541a0b5f48f2a)
    V4 RSA/SHA256 Signature, key ID a2b5f2f9: OK
    MD5 digest: OK (b7b80dd6da1fae32d76e86d6673cfc00)
/rpm/systemd/pganalyze-collector-0.50.1-1.aarch64.rpm:
    Header V4 RSA/SHA256 Signature, key ID a2b5f2f9: OK
    Header SHA1 digest: OK (455543595f47e9402383c85f1a8540044d6b5e5c)
    V4 RSA/SHA256 Signature, key ID a2b5f2f9: OK
    MD5 digest: OK (4e57b10b5de21dcec17ca459117ad1b7)
```

Note that the "Header SHA1 digest" is expected even after this change, per https://www.starlab.io/blog/adding-sha256-digests-to-rpms using a SHA256 signature for the digest is not well supported yet.