### PR TITLE
Use log_timezone setting to determine log timezone if possible

### DIFF
--- a/input/full.go
+++ b/input/full.go
@@ -133,6 +133,8 @@ func CollectFull(ctx context.Context, server *state.Server, connection *sql.DB, 
 		ps.System = system.GetSystemState(server.Config, logger)
 	}
 
+	server.SetLogTimezone(ts.Settings)
+
 	ps.CollectorStats = getCollectorStats()
 	ts.CollectorConfig = getCollectorConfig(server.Config)
 	ts.CollectorPlatform = getCollectorPlatform(globalCollectionOpts, logger)

--- a/input/system/azure/logs.go
+++ b/input/system/azure/logs.go
@@ -251,7 +251,7 @@ func ParseRecordToLogLines(in AzurePostgresLogRecord) ([]state.LogLine, string, 
 		azureDbServerName = in.LogicalServerName
 	}
 
-	logLine, ok := logs.ParseLogLineWithPrefix("", logLineContent)
+	logLine, ok := logs.ParseLogLineWithPrefix("", logLineContent, nil)
 	if !ok {
 		return []state.LogLine{}, "", fmt.Errorf("Can't parse log line: \"%s\"", logLineContent)
 	}

--- a/input/system/google_cloudsql/logs.go
+++ b/input/system/google_cloudsql/logs.go
@@ -192,7 +192,7 @@ func setupLogTransformer(ctx context.Context, wg *sync.WaitGroup, servers []*sta
 				// Note that we need to restore the original trailing newlines since
 				// AnalyzeStreamInGroups expects them and they are not present in the GCP
 				// log stream.
-				logLine, _ := logs.ParseLogLineWithPrefix("", in.Content+"\n")
+				logLine, _ := logs.ParseLogLineWithPrefix("", in.Content+"\n", nil)
 				logLine.OccurredAt = in.OccurredAt
 
 				// Ignore loglines which are outside our time window

--- a/input/system/heroku/logs.go
+++ b/input/system/heroku/logs.go
@@ -156,7 +156,7 @@ func logStreamItemToLogLine(ctx context.Context, item HttpSyslogMessage, servers
 	logLineNumberChunk, _ := strconv.ParseInt(lineParts[3], 10, 32)
 	prefixedContent := lineParts[4]
 
-	logLine, _ := logs.ParseLogLineWithPrefix("", prefixedContent+"\n")
+	logLine, _ := logs.ParseLogLineWithPrefix("", prefixedContent+"\n", nil)
 
 	sourceToServer = catchIdentifyServerLine(sourceName, logLine.Content, sourceToServer, servers)
 

--- a/input/system/selfhosted/logs.go
+++ b/input/system/selfhosted/logs.go
@@ -374,6 +374,7 @@ func setupDockerTail(ctx context.Context, containerName string, out chan<- SelfH
 
 func setupLogTransformer(ctx context.Context, wg *sync.WaitGroup, server *state.Server, globalCollectionOpts state.CollectionOpts, prefixedLogger *util.Logger, parsedLogStream chan state.ParsedLogStreamItem) chan<- SelfHostedLogStreamItem {
 	logStream := make(chan SelfHostedLogStreamItem)
+	tz := server.GetLogTimezone()
 
 	wg.Add(1)
 	go func() {
@@ -398,7 +399,7 @@ func setupLogTransformer(ctx context.Context, wg *sync.WaitGroup, server *state.
 				// Note that we need to restore the original trailing newlines since
 				// AnalyzeStreamInGroups expects them and they are not present in the tail
 				// log stream.
-				logLine, _ := logs.ParseLogLineWithPrefix("", item.Line+"\n")
+				logLine, _ := logs.ParseLogLineWithPrefix("", item.Line+"\n", tz)
 				logLine.CollectedAt = time.Now()
 				logLine.UUID = uuid.NewV4()
 

--- a/logs/parse_test.go
+++ b/logs/parse_test.go
@@ -13,15 +13,27 @@ import (
 type parseTestpair struct {
 	prefixIn  string
 	lineIn    string
+	lineInTz  *time.Location
 	lineOut   state.LogLine
 	lineOutOk bool
 }
+
+func mustTimeLocation(tzStr string) *time.Location {
+	tz, err := time.LoadLocation(tzStr)
+	if err != nil {
+		panic(err)
+	}
+	return tz
+}
+
+var BSTTimeLocation = mustTimeLocation("Europe/London")
 
 var parseTests = []parseTestpair{
 	// rsyslog format
 	{
 		"",
 		"Feb  1 21:48:31 ip-172-31-14-41 postgres[9076]: [3-1] LOG:  database system is ready to accept connections",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(time.Now().Year(), time.February, 1, 21, 48, 31, 0, time.UTC),
 			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
@@ -33,6 +45,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"Feb  1 21:48:31 ip-172-31-14-41 postgres[9076]: [3-2] #011 something",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(time.Now().Year(), time.February, 1, 21, 48, 31, 0, time.UTC),
 			LogLevel:   pganalyze_collector.LogLineInformation_UNKNOWN,
@@ -44,6 +57,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"Feb  1 21:48:31 ip-172-31-14-41 postgres[123]: [8-1] [user=postgres,db=postgres,app=[unknown]] LOG: connection received: host=[local]",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(time.Now().Year(), time.February, 1, 21, 48, 31, 0, time.UTC),
 			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
@@ -58,6 +72,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-08-22 16:00:04 UTC:ec2-1-1-1-1.compute-1.amazonaws.com(48808):myuser@mydb:[18762]:LOG:  duration: 3668.685 ms  execute <unnamed>: SELECT 1",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2018, time.August, 22, 16, 0, 4, 0, time.UTC),
 			Username:   "myuser",
@@ -71,6 +86,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-08-22 16:00:03 UTC:127.0.0.1(36404):myuser@mydb:[21495]:LOG:  duration: 1630.946 ms  execute 3: SELECT 1",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2018, time.August, 22, 16, 0, 3, 0, time.UTC),
 			Username:   "myuser",
@@ -84,6 +100,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-08-22 16:00:03 UTC:[local]:myuser@mydb:[21495]:LOG:  duration: 1630.946 ms  execute 3: SELECT 1",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2018, time.August, 22, 16, 0, 3, 0, time.UTC),
 			Username:   "myuser",
@@ -98,6 +115,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2020-06-21 22:37:10 UTC-5eefe116.22f4-LOG:  could not receive data from client: An existing connection was forcibly closed by the remote host.",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2020, time.June, 21, 22, 37, 10, 0, time.UTC),
 			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
@@ -109,6 +127,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-09-27 06:57:01.030 EST [20194][] : [1-1] [app=pganalyze_collector] LOG:  connection received: host=[local]",
+		nil,
 		state.LogLine{
 			OccurredAt:    time.Date(2018, time.September, 27, 6, 57, 1, 30*1000*1000, time.FixedZone("EST", -5*3600)),
 			LogLevel:      pganalyze_collector.LogLineInformation_LOG,
@@ -123,6 +142,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-09-27 06:57:01.030 UTC [20194] [user=[unknown],db=[unknown],app=[unknown]] LOG:  connection received: host=[local]",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2018, time.September, 27, 6, 57, 1, 30*1000*1000, time.UTC),
 			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
@@ -134,6 +154,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-09-27 06:57:02.779 UTC [20194] [user=postgres,db=postgres,app=psql] ERROR:  canceling statement due to user request",
+		nil,
 		state.LogLine{
 			OccurredAt:  time.Date(2018, time.September, 27, 6, 57, 2, 779*1000*1000, time.UTC),
 			Username:    "postgres",
@@ -148,6 +169,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-09-27 06:57:02.779 UTC [20194] [user=postgres,db=postgres,app=psql] LOG:  duration: 3000.019 ms  statement: SELECT pg_sleep(3\n);",
+		nil,
 		state.LogLine{
 			OccurredAt:  time.Date(2018, time.September, 27, 6, 57, 2, 779*1000*1000, time.UTC),
 			Username:    "postgres",
@@ -163,6 +185,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-09-27 06:57:01.030 UTC [20194] [user=[unknown],db=[unknown],app=[unknown],host=[local]] LOG:  connection received: host=[local]",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2018, time.September, 27, 6, 57, 1, 30*1000*1000, time.UTC),
 			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
@@ -174,6 +197,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-09-27 06:57:02.779 UTC [20194] [user=postgres,db=postgres,app=psql,host=127.0.0.1] ERROR:  canceling statement due to user request",
+		nil,
 		state.LogLine{
 			OccurredAt:  time.Date(2018, time.September, 27, 6, 57, 2, 779*1000*1000, time.UTC),
 			Username:    "postgres",
@@ -189,6 +213,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-09-28 07:37:59 UTC [331]: [1-1] user=[unknown],db=[unknown] - PG-00000 LOG:  connection received: host=127.0.0.1 port=49738",
+		nil,
 		state.LogLine{
 			OccurredAt:    time.Date(2018, time.September, 28, 7, 37, 59, 0, time.UTC),
 			LogLevel:      pganalyze_collector.LogLineInformation_LOG,
@@ -201,6 +226,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-09-28 07:39:48 UTC [347]: [3-1] user=postgres,db=postgres - PG-57014 ERROR:  canceling statement due to user request",
+		nil,
 		state.LogLine{
 			OccurredAt:    time.Date(2018, time.September, 28, 7, 39, 48, 0, time.UTC),
 			Username:      "postgres",
@@ -216,6 +242,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-10-16 01:25:58 UTC [93897]: [4-1] user=,db=,app=,client= LOG:  database system is ready to accept connections",
+		nil,
 		state.LogLine{
 			OccurredAt:    time.Date(2018, time.October, 16, 1, 25, 58, 0, time.UTC),
 			LogLevel:      pganalyze_collector.LogLineInformation_LOG,
@@ -228,6 +255,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-10-16 01:26:09 UTC [93907]: [1-1] user=[unknown],db=[unknown],app=[unknown],client=::1 LOG:  connection received: host=::1 port=61349",
+		nil,
 		state.LogLine{
 			OccurredAt:    time.Date(2018, time.October, 16, 1, 26, 9, 0, time.UTC),
 			LogLevel:      pganalyze_collector.LogLineInformation_LOG,
@@ -240,6 +268,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-10-16 01:26:33 UTC [93911]: [3-1] user=postgres,db=postgres,app=psql,client=::1 ERROR:  canceling statement due to user request",
+		nil,
 		state.LogLine{
 			OccurredAt:    time.Date(2018, time.October, 16, 1, 26, 33, 0, time.UTC),
 			Username:      "postgres",
@@ -255,6 +284,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2019-01-01 01:59:42 UTC [1]: [4-1] [trx_id=0] user=,db= LOG:  database system is ready to accept connections",
+		nil,
 		state.LogLine{
 			OccurredAt:    time.Date(2019, time.January, 1, 1, 59, 42, 0, time.UTC),
 			LogLevel:      pganalyze_collector.LogLineInformation_LOG,
@@ -267,6 +297,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2019-01-01 02:00:28 UTC [35]: [1-1] [trx_id=0] user=[unknown],db=[unknown] LOG:  connection received: host=::1 port=38842",
+		nil,
 		state.LogLine{
 			OccurredAt:    time.Date(2019, time.January, 1, 2, 0, 28, 0, time.UTC),
 			LogLevel:      pganalyze_collector.LogLineInformation_LOG,
@@ -279,6 +310,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2019-01-01 02:00:28 UTC [34]: [3-1] [trx_id=120950] user=postgres,db=postgres ERROR:  canceling statement due to user request",
+		nil,
 		state.LogLine{
 			OccurredAt:    time.Date(2019, time.January, 1, 2, 0, 28, 0, time.UTC),
 			Username:      "postgres",
@@ -294,6 +326,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"[1127]: [8-1] db=postgres,user=pganalyze LOG:  duration: 2001.842 ms  statement: SELECT pg_sleep(2);",
+		nil,
 		state.LogLine{
 			OccurredAt:    time.Time{},
 			Username:      "pganalyze",
@@ -309,6 +342,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2020-05-21 17:53:05.307 UTC    [5ec6bfff.1] [1] LOG:  database system is ready to accept connections",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2020, time.May, 21, 17, 53, 05, 307*1000*1000, time.UTC),
 			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
@@ -320,6 +354,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2020-05-21 17:54:35.256 UTC 172.18.0.1(56402) pgaweb [unknown] [5ec6c05b.22] [34] LOG:  connection authorized: user=pgaweb database=pgaweb application_name=psql",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2020, time.May, 21, 17, 54, 35, 256*1000*1000, time.UTC),
 			Username:   "pgaweb",
@@ -332,6 +367,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2020-05-21 17:54:43.808 UTC 172.18.0.1(56402) pgaweb psql [5ec6c05b.22] [34] LOG:  disconnection: session time: 0:00:08.574 user=pgaweb database=pgaweb host=172.18.0.1 port=56402",
+		nil,
 		state.LogLine{
 			OccurredAt:  time.Date(2020, time.May, 21, 17, 54, 43, 808*1000*1000, time.UTC),
 			Username:    "pgaweb",
@@ -346,6 +382,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2020-09-04 16:03:11.375 UTC [417880]: [1-1] db=mydb,user=myuser LOG:  pganalyze-collector-identify: myserver",
+		nil,
 		state.LogLine{
 			OccurredAt:    time.Date(2020, time.September, 4, 16, 3, 11, 375*1000*1000, time.UTC),
 			Username:      "myuser",
@@ -361,6 +398,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"pid=8284,user=[unknown],db=[unknown],app=[unknown],client=[local] LOG: connection received: host=[local]",
+		nil,
 		state.LogLine{
 			BackendPid: 8284,
 			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
@@ -371,6 +409,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"pid=8284,user=[unknown],db=[unknown],app=why would you[] name your application this,client=[local] LOG: connection received: host=[local]",
+		nil,
 		state.LogLine{
 			BackendPid: 8284,
 			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
@@ -382,6 +421,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"user=[unknown],db=[unknown],app=[unknown],client=[local] LOG: connection received: host=[local]",
+		nil,
 		state.LogLine{
 			LogLevel: pganalyze_collector.LogLineInformation_LOG,
 			Content:  "connection received: host=[local]",
@@ -392,6 +432,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"27-2021-11-17 19:06:14 UTC-619552a6.1b-1----2021-11-17 19:06:14.946 UTC LOG:  database system was shut down at 2021-11-17 19:01:42 UTC",
+		nil,
 		state.LogLine{
 			OccurredAt:    time.Date(2021, time.November, 17, 19, 6, 14, 946*1000*1000, time.UTC),
 			BackendPid:    27,
@@ -404,6 +445,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"51-2021-11-17 19:11:13 UTC-619553d1.33-2-172.20.0.1-pgaweb-pgaweb-2021-11-17 19:11:13.562 UTC LOG:  connection authorized: user=pgaweb database=pgaweb application_name=puma: cluster worker 2: 18544 [pganalyze]",
+		nil,
 		state.LogLine{
 			OccurredAt:    time.Date(2021, time.November, 17, 19, 11, 13, 562*1000*1000, time.UTC),
 			Username:      "pgaweb",
@@ -419,6 +461,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2021-11-17 19:06:53.897 UTC [34][autovacuum worker][3/5][22996] LOG:  automatic analyze of table \"mydb.pg_catalog.pg_class\" system usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.01 s",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2021, time.November, 17, 19, 6, 53, 897*1000*1000, time.UTC),
 			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
@@ -431,6 +474,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2022-07-22 06:13:13.389 UTC [1] LOG:  database system is ready to accept connections",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2022, time.July, 22, 6, 13, 13, 389*1000*1000, time.UTC),
 			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
@@ -442,6 +486,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2022-07-22 06:13:45.781 UTC [75] myuser@mydb LOG:  connection authorized: user=myuser database=mydb application_name=psql",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2022, time.July, 22, 6, 13, 45, 781*1000*1000, time.UTC),
 			Username:   "myuser",
@@ -456,6 +501,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2022-07-22 06:13:12 UTC [1] LOG:  starting PostgreSQL 14.2 (Debian 14.2-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2022, time.July, 22, 6, 13, 12, 0, time.UTC),
 			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
@@ -467,6 +513,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2022-07-22 06:14:23 UTC [76] my-user@my-db 1.2.3.4 LOG:  disconnection: session time: 0:00:01.667 user=my-user database=my-db host=1.2.3.4 port=5678",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2022, time.July, 22, 6, 14, 23, 0, time.UTC),
 			Username:   "my-user",
@@ -481,6 +528,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-05-04 03:06:18.360 UTC [3184] LOG:  pganalyze-collector-identify: server1",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2018, time.May, 4, 3, 6, 18, 360*1000*1000, time.UTC),
 			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
@@ -492,6 +540,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2018-05-04 03:06:18.360 +0100 [3184] LOG:  pganalyze-collector-identify: server1",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2018, time.May, 4, 3, 6, 18, 360*1000*1000, time.FixedZone("+0100", 3600)),
 			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
@@ -503,6 +552,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		` sql_error_code = 28000 FATAL:  no pg_hba.conf entry for host "127.0.0.1", user "postgres", database "postgres", SSL off`,
+		nil,
 		state.LogLine{
 			LogLevel: pganalyze_collector.LogLineInformation_FATAL,
 			Content:  "no pg_hba.conf entry for host \"127.0.0.1\", user \"postgres\", database \"postgres\", SSL off",
@@ -512,6 +562,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		` sql_error_code = 28000 time_ms = "2022-06-02 22:48:20.807 UTC" pid="11666" proc_start_time="2022-06-02 22:48:20 UTC" session_id="62993e34.2d92" vtid="6/17007" tid="0" log_line="1" database="postgres" connection_source="127.0.0.1(36532)" user="postgres" application_name="[unknown]" FATAL:  no pg_hba.conf entry for host "127.0.0.1", user "postgres", database "postgres", SSL off`,
+		nil,
 		state.LogLine{
 			OccurredAt:    time.Date(2022, time.June, 2, 22, 48, 20, 807*1000*1000, time.UTC),
 			Username:      "postgres",
@@ -526,6 +577,7 @@ var parseTests = []parseTestpair{
 	{
 		"",
 		"2022-12-23 09:53:43.862 -03 [790081] LOG: pganalyze-collector-identify: server1",
+		nil,
 		state.LogLine{
 			OccurredAt: time.Date(2022, time.December, 23, 9, 53, 43, 862*1000*1000, time.FixedZone("-03", -3*3600)),
 			LogLevel:   6,
@@ -534,11 +586,24 @@ var parseTests = []parseTestpair{
 		},
 		true,
 	},
+	// Custom 3 format with explicit time zone
+	{
+		"",
+		"2018-09-27 06:57:01.030 BST [20194] [user=[unknown],db=[unknown],app=[unknown]] LOG:  connection received: host=[local]",
+		BSTTimeLocation,
+		state.LogLine{
+			OccurredAt: time.Date(2018, time.September, 27, 6, 57, 1, 30*1000*1000, BSTTimeLocation),
+			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
+			BackendPid: 20194,
+			Content:    "connection received: host=[local]",
+		},
+		true,
+	},
 }
 
 func TestParseLogLineWithPrefix(t *testing.T) {
 	for _, pair := range parseTests {
-		l, lOk := logs.ParseLogLineWithPrefix(pair.prefixIn, pair.lineIn)
+		l, lOk := logs.ParseLogLineWithPrefix(pair.prefixIn, pair.lineIn, pair.lineInTz)
 
 		cfg := pretty.CompareConfig
 		cfg.SkipZeroFields = true

--- a/logs/replace_test.go
+++ b/logs/replace_test.go
@@ -3,6 +3,7 @@ package logs_test
 import (
 	"bufio"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -63,7 +64,7 @@ var replaceTests = []replaceTestpair{
 func TestReplaceSecrets(t *testing.T) {
 	for _, pair := range replaceTests {
 		reader := bufio.NewReader(strings.NewReader(pair.input))
-		logLines, _ := logs.ParseAndAnalyzeBuffer(reader, time.Time{}, &state.Server{})
+		logLines, _ := logs.ParseAndAnalyzeBuffer(reader, time.Time{}, &state.Server{LogTimezoneMutex: &sync.Mutex{}})
 		output := logs.ReplaceSecrets([]byte(pair.input), logLines, state.ParseFilterLogSecret(pair.filterLogSecret))
 
 		cfg := pretty.CompareConfig

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 		if globalCollectionOpts.TestRun && globalCollectionOpts.TestSection != "" && globalCollectionOpts.TestSection != config.SectionName {
 			continue
 		}
-		servers = append(servers, &state.Server{Config: config, StateMutex: &sync.Mutex{}, LogStateMutex: &sync.Mutex{}, ActivityStateMutex: &sync.Mutex{}, CollectionStatusMutex: &sync.Mutex{}})
+		servers = append(servers, &state.Server{Config: config, StateMutex: &sync.Mutex{}, LogStateMutex: &sync.Mutex{}, ActivityStateMutex: &sync.Mutex{}, CollectionStatusMutex: &sync.Mutex{}, LogTimezoneMutex: &sync.Mutex{}})
 		if config.EnableReports {
 			hasAnyReportsEnabled = true
 		}
@@ -578,6 +578,11 @@ func checkOneInitialCollectionStatus(ctx context.Context, server *state.Server, 
 		logger.PrintInfo("Log duration lines will be ignored for this server: %s", logsDisabledReason)
 	} else if logsIgnoreStatement {
 		logger.PrintInfo("Log statement lines will be ignored for this server: %s", logsDisabledReason)
+	}
+
+	server.SetLogTimezone(settings)
+	if server.LogTimezone == nil {
+		logger.PrintWarning("Could not determine log timezone for this server: %s")
 	}
 
 	server.CollectionStatusMutex.Lock()

--- a/state/util.go
+++ b/state/util.go
@@ -1,5 +1,7 @@
 package state
 
+import "time"
+
 type OidToIdxMap map[Oid](map[Oid]int32)
 
 func MakeOidToIdxMap() OidToIdxMap {
@@ -37,4 +39,23 @@ func XidToXid8(xid Xid, currentXactId Xid8) Xid8 {
 	// By subtracting the xid from the current one, we can get the epoch of the given xid.
 	xidEpoch := int32((currentXactId - Xid8(xid)) >> 32)
 	return Xid8(xidEpoch)<<32 | Xid8(xid)
+}
+
+func getTimeZoneFromSettings(settings []PostgresSetting) *time.Location {
+	for _, setting := range settings {
+		if setting.Name != "log_timezone" {
+			continue
+		}
+		if !setting.ResetValue.Valid {
+			return nil
+		}
+
+		zoneStr := setting.ResetValue.String
+		zone, err := time.LoadLocation(zoneStr)
+		if err != nil {
+			return nil
+		}
+		return zone
+	}
+	return nil
 }


### PR DESCRIPTION
Right now, we infer the log timezone by parsing this out of log lines.
This works in theory, but in practice Go's time.LoadLocation does not
support many timezone abbreviations (and abbreviations can be
ambiguous anyway).

Since we already collect Postgres settings, and these specify the log
timezone in a non-abbreviated form, we can use these. These correspond
to the full name in the IANA Time Zone database, as time.LoadLocation
expects. Sync this on every full snapshot just in case the timezone is
updated.

The current implementation stores this state on the Server, protected
by a new mutex. Since this needs to be written by the full snapshot
and read during log parsing, none of the existing mutexes or state
seemed appropriate. I admit this is not a great solution and I'm open
to other ideas.
