### PR TITLE
Log Parsing: Fix crash in --analyze-logfile option

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 		if globalCollectionOpts.TestRun && globalCollectionOpts.TestSection != "" && globalCollectionOpts.TestSection != config.SectionName {
 			continue
 		}
-		servers = append(servers, &state.Server{Config: config, StateMutex: &sync.Mutex{}, LogStateMutex: &sync.Mutex{}, ActivityStateMutex: &sync.Mutex{}, CollectionStatusMutex: &sync.Mutex{}, LogTimezoneMutex: &sync.Mutex{}})
+		servers = append(servers, state.MakeServer(config))
 		if config.EnableReports {
 			hasAnyReportsEnabled = true
 		}
@@ -397,7 +397,7 @@ func main() {
 		content := string(contentBytes)
 		reader := strings.NewReader(content)
 		logReader := logs.NewMaybeHerokuLogReader(reader)
-		logLines, samples := logs.ParseAndAnalyzeBuffer(logReader, time.Time{}, &state.Server{})
+		logLines, samples := logs.ParseAndAnalyzeBuffer(logReader, time.Time{}, state.MakeServer(config.ServerConfig{}))
 		logs.PrintDebugInfo(content, logLines, samples)
 		if analyzeDebugClassifications != "" {
 			classifications := strings.Split(analyzeDebugClassifications, ",")

--- a/state/state.go
+++ b/state/state.go
@@ -286,6 +286,17 @@ type Server struct {
 	LogIgnoreFlags uint32
 }
 
+func MakeServer(config config.ServerConfig) *Server {
+	return &Server{
+		Config:                config,
+		StateMutex:            &sync.Mutex{},
+		LogStateMutex:         &sync.Mutex{},
+		ActivityStateMutex:    &sync.Mutex{},
+		CollectionStatusMutex: &sync.Mutex{},
+		LogTimezoneMutex:      &sync.Mutex{},
+	}
+}
+
 const (
 	LOG_IGNORE_STATEMENT uint32 = 1 << iota
 	LOG_IGNORE_DURATION


### PR DESCRIPTION
Due to the changes in 7b67039fd9a22e5b5e34cb934b73a18f42115ea7 we need to always initialize the server mutex for the log parsing functions.