### PR TITLE
Pin protoc-gen-go to specific version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ docker_release:
 output/pganalyze_collector/snapshot.pb.go: $(PROTOBUF_FILES)
 ifdef PROTOC_VERSION
 	mkdir -p $(PWD)/bin
-	GOBIN=$(PWD)/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+	GOBIN=$(PWD)/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0
 	protoc --go_out=. --go_opt=module=github.com/pganalyze/collector -I protobuf $(PROTOBUF_FILES)
 else
 	@echo '👷 Warning: protoc not found, skipping protocol buffer regeneration (to install protoc check Makefile instructions in install_protoc step)'


### PR DESCRIPTION
This avoids automatically regenerating compiled protoc files with a
new version whenever protoc-gen-go has a release. The current behavior
makes it easy to include changes from a new tool version alongside
with other unrelated changes, which could make it harder to track
down problems.

Pin protoc-gen-go like we pin our other dependencies. We can update it
manually as necessary.
