### PR TITLE
Update Go version to 1.21, update Dockerfile alpine base image to 3.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version: 1.21
       id: go
 
     - name: Set up protoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version: 1.21
       id: go
 
     - name: Set up protoc

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY contrib/sslrootcert/rds-ca-global.pem /usr/share/pganalyze-collector/sslroo
 COPY contrib/docker-entrypoint.sh $HOME_DIR
 RUN chmod +x $HOME_DIR/docker-entrypoint.sh
 
-FROM alpine:3.15 as slim
+FROM alpine:3.18 as slim
 
 RUN apk add --no-cache ca-certificates tzdata
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine as base
+FROM golang:1.21-alpine as base
 MAINTAINER team@pganalyze.com
 
 ENV GOPATH /go

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-// +heroku goVersion go1.19
+// +heroku goVersion go1.20
 
 module github.com/pganalyze/collector
 
@@ -81,4 +81,4 @@ require (
 	google.golang.org/grpc v1.32.0 // indirect
 )
 
-go 1.19
+go 1.20

--- a/integration_test/Dockerfile.test-citus
+++ b/integration_test/Dockerfile.test-citus
@@ -2,7 +2,7 @@ FROM citusdata/citus:11.1
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.19
+ENV GOVERSION 1.21.0
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-citus
+++ b/integration_test/Dockerfile.test-citus
@@ -10,7 +10,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://go.dev/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-guided-setup
+++ b/integration_test/Dockerfile.test-guided-setup
@@ -19,7 +19,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://go.dev/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-guided-setup
+++ b/integration_test/Dockerfile.test-guided-setup
@@ -11,7 +11,7 @@ STOPSIGNAL SIGRTMIN+3
 ENTRYPOINT ["/lib/systemd/systemd"]
 CMD ["--log-level=info"]
 
-ENV GOVERSION 1.19
+ENV GOVERSION 1.21.0
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg10
+++ b/integration_test/Dockerfile.test-pg10
@@ -2,7 +2,7 @@ FROM postgres:10-bullseye
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.19
+ENV GOVERSION 1.21.0
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg10
+++ b/integration_test/Dockerfile.test-pg10
@@ -10,7 +10,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://go.dev/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-pg11
+++ b/integration_test/Dockerfile.test-pg11
@@ -2,7 +2,7 @@ FROM postgres:11-bullseye
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.19
+ENV GOVERSION 1.21.0
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg11
+++ b/integration_test/Dockerfile.test-pg11
@@ -10,7 +10,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://go.dev/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-pg12
+++ b/integration_test/Dockerfile.test-pg12
@@ -2,7 +2,7 @@ FROM postgres:12
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.19
+ENV GOVERSION 1.21.0
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg12
+++ b/integration_test/Dockerfile.test-pg12
@@ -10,7 +10,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://go.dev/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-pg13
+++ b/integration_test/Dockerfile.test-pg13
@@ -10,7 +10,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://go.dev/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-pg13
+++ b/integration_test/Dockerfile.test-pg13
@@ -2,7 +2,7 @@ FROM postgres:13
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.19
+ENV GOVERSION 1.21.0
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg14
+++ b/integration_test/Dockerfile.test-pg14
@@ -2,7 +2,7 @@ FROM postgres:14
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.19
+ENV GOVERSION 1.21.0
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg14
+++ b/integration_test/Dockerfile.test-pg14
@@ -10,7 +10,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://go.dev/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-pg15
+++ b/integration_test/Dockerfile.test-pg15
@@ -10,7 +10,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://go.dev/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-pg15
+++ b/integration_test/Dockerfile.test-pg15
@@ -2,7 +2,7 @@ FROM postgres:15
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.19
+ENV GOVERSION 1.21.0
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-reload
+++ b/integration_test/Dockerfile.test-reload
@@ -19,7 +19,7 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN apt-get update -qq && apt-get install -y -q build-essential git curl
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://go.dev/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build the collector

--- a/integration_test/Dockerfile.test-reload
+++ b/integration_test/Dockerfile.test-reload
@@ -11,7 +11,7 @@ STOPSIGNAL SIGRTMIN+3
 ENTRYPOINT ["/lib/systemd/systemd"]
 CMD ["--log-level=info"]
 
-ENV GOVERSION 1.19
+ENV GOVERSION 1.21.0
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/packages/src/Dockerfile.build.deb-systemd
+++ b/packages/src/Dockerfile.build.deb-systemd
@@ -16,7 +16,7 @@ RUN apt-get update -qq \
 RUN gem install public_suffix -v 4.0.7 && gem install fpm -v 1.14.1
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://go.dev/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build arguments

--- a/packages/src/Dockerfile.build.deb-systemd
+++ b/packages/src/Dockerfile.build.deb-systemd
@@ -2,7 +2,7 @@ FROM debian:bullseye
 
 ARG TARGETARCH
 ENV GOPATH /go
-ENV GOVERSION 1.19
+ENV GOVERSION 1.21.0
 ENV CODE_DIR $GOPATH/src/github.com/pganalyze/collector
 ENV PATH $PATH:/usr/local/go/bin
 ENV ROOT_DIR /root

--- a/packages/src/Dockerfile.build.rpm-systemd
+++ b/packages/src/Dockerfile.build.rpm-systemd
@@ -15,7 +15,7 @@ RUN yum install -y centos-release-scl scl-utils tar make git rpmdevtools gcc && 
 RUN source scl_source enable rh-ruby27 && gem install fpm -v 1.14.1
 
 # Golang
-RUN curl -o go.tar.gz -sSL "https://golang.org/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
+RUN curl -o go.tar.gz -sSL "https://go.dev/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"
 RUN tar -C /usr/local -xzf go.tar.gz
 
 # Build arguments

--- a/packages/src/Dockerfile.build.rpm-systemd
+++ b/packages/src/Dockerfile.build.rpm-systemd
@@ -2,7 +2,7 @@ FROM centos:7
 
 ARG TARGETARCH
 ENV GOPATH /go
-ENV GOVERSION 1.19
+ENV GOVERSION 1.21.0
 ENV CODE_DIR $GOPATH/src/github.com/pganalyze/collector
 ENV PATH $PATH:/usr/local/go/bin
 ENV ROOT_DIR /root


### PR DESCRIPTION
```
Update Go version in use for packages and tests to 1.21

Additionally, this bumps up the minimum Go version to 1.20, and uses
that on Heroku, as Heroku's Go buildpack does not yet support 1.21.
```

```
Dockerfile: Update alpine base image from 3.15 to 3.18
```

```
Update Go download location from "golang.org" to "go.dev" domain

This has been changed upstream, and it seems reasonable to match.
```