### PR TITLE
Do not forget submodules when fetching the project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,11 @@
 ## Contributing Instructions
 
+Pull the project with submodules.
+
+```sh
+git clone --recursive https://github.com/pganalyze/collector
+```
+
 ### Setup
 
 The dependencies are stored in the `vendor` folder, so no installation is needed.


### PR DESCRIPTION
This is pretty basic. But I didn't see that `protobub/` was a submodule. On a basic git clone, folder was empty leading to:

```
~/code/collector main ❯ make build 

mkdir -p /Users/benoit.tigeot/code/collector/bin
GOBIN=/Users/benoit.tigeot/code/collector/bin go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.31.0
protoc --go_out=. --go_opt=module=github.com/pganalyze/collector -I protobuf
Missing input file.
make: *** [output/pganalyze_collector/snapshot.pb.go] Error 1
```