### PR TITLE
Improve data directory detection

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -190,6 +190,9 @@ type ServerConfig struct {
 	// HTTP clients to be used for API connections
 	HTTPClient          *http.Client
 	HTTPClientWithRetry *http.Client
+
+	// Data directory used for system stats
+	DataDirectory string
 }
 
 // SupportsLogDownload - Determines whether the specified config can download logs

--- a/config/config.go
+++ b/config/config.go
@@ -60,7 +60,7 @@ type ServerConfig struct {
 	DbUseIamAuth          bool   `ini:"db_use_iam_auth"`
 
 	// Postgres data directory, as used for system stats (autodetected if unset)
-	DataDirectory string `ini:"db_data_directory"`
+	DbDataDirectory string `ini:"db_data_directory"`
 
 	// We have to do some tricks to support sslmode=prefer, namely we have to
 	// first try an SSL connection (= require), and if that fails change the

--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,9 @@ type ServerConfig struct {
 	DbExtraNames []string // Additional databases that should be fetched (determined by additional databases in db_name)
 	DbAllNames   bool     // All databases except template databases should be fetched (determined by * in the db_name list)
 
+	// Postgres data directory, as used for system stats (autodetected if unset)
+	DataDirectory string `ini:"data_directory"`
+
 	AwsRegion               string `ini:"aws_region"`
 	AwsAccountID            string `ini:"aws_account_id"`
 	AwsDbInstanceID         string `ini:"aws_db_instance_id"`
@@ -190,9 +193,6 @@ type ServerConfig struct {
 	// HTTP clients to be used for API connections
 	HTTPClient          *http.Client
 	HTTPClientWithRetry *http.Client
-
-	// Data directory used for system stats
-	DataDirectory string
 }
 
 // SupportsLogDownload - Determines whether the specified config can download logs

--- a/config/config.go
+++ b/config/config.go
@@ -59,6 +59,9 @@ type ServerConfig struct {
 	DbSslKeyContents      string `ini:"db_sslkey_contents"`
 	DbUseIamAuth          bool   `ini:"db_use_iam_auth"`
 
+	// Postgres data directory, as used for system stats (autodetected if unset)
+	DataDirectory string `ini:"db_data_directory"`
+
 	// We have to do some tricks to support sslmode=prefer, namely we have to
 	// first try an SSL connection (= require), and if that fails change the
 	// sslmode to none
@@ -66,9 +69,6 @@ type ServerConfig struct {
 
 	DbExtraNames []string // Additional databases that should be fetched (determined by additional databases in db_name)
 	DbAllNames   bool     // All databases except template databases should be fetched (determined by * in the db_name list)
-
-	// Postgres data directory, as used for system stats (autodetected if unset)
-	DataDirectory string `ini:"data_directory"`
 
 	AwsRegion               string `ini:"aws_region"`
 	AwsAccountID            string `ini:"aws_account_id"`

--- a/config/read.go
+++ b/config/read.go
@@ -119,6 +119,9 @@ func getDefaultConfig() *ServerConfig {
 	if dbSslKeyContents := os.Getenv("DB_SSLKEY_CONTENTS"); dbSslKeyContents != "" {
 		config.DbSslKeyContents = dbSslKeyContents
 	}
+	if dataDirectory := os.Getenv(("DATA_DIRECTORY")); dataDirectory != "" {
+		config.DataDirectory = dataDirectory
+	}
 	if awsRegion := os.Getenv("AWS_REGION"); awsRegion != "" {
 		config.AwsRegion = awsRegion
 	}

--- a/config/read.go
+++ b/config/read.go
@@ -119,7 +119,7 @@ func getDefaultConfig() *ServerConfig {
 	if dbSslKeyContents := os.Getenv("DB_SSLKEY_CONTENTS"); dbSslKeyContents != "" {
 		config.DbSslKeyContents = dbSslKeyContents
 	}
-	if dataDirectory := os.Getenv(("DATA_DIRECTORY")); dataDirectory != "" {
+	if dataDirectory := os.Getenv(("DB_DATA_DIRECTORY")); dataDirectory != "" {
 		config.DataDirectory = dataDirectory
 	}
 	if awsRegion := os.Getenv("AWS_REGION"); awsRegion != "" {

--- a/config/read.go
+++ b/config/read.go
@@ -119,8 +119,8 @@ func getDefaultConfig() *ServerConfig {
 	if dbSslKeyContents := os.Getenv("DB_SSLKEY_CONTENTS"); dbSslKeyContents != "" {
 		config.DbSslKeyContents = dbSslKeyContents
 	}
-	if dataDirectory := os.Getenv(("DB_DATA_DIRECTORY")); dataDirectory != "" {
-		config.DataDirectory = dataDirectory
+	if dataDirectory := os.Getenv("DB_DATA_DIRECTORY"); dataDirectory != "" {
+		config.DbDataDirectory = dataDirectory
 	}
 	if awsRegion := os.Getenv("AWS_REGION"); awsRegion != "" {
 		config.AwsRegion = awsRegion

--- a/helper/main.go
+++ b/helper/main.go
@@ -38,7 +38,7 @@ func getPostmasterPid() (int, error) {
 	return pgPid, nil
 }
 
-func getStatus() {
+func getStatus(dataDirectory string) {
 	var pgControldataOut, xlogUsageBytesStr []byte
 	var pgControldataBinary string
 	var status helperStatus
@@ -48,7 +48,12 @@ func getStatus() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 	} else {
-		status.DataDirectory = os.Getenv("PGDATA")
+		if dataDirectory != "" {
+			status.DataDirectory = dataDirectory
+		} else {
+			status.DataDirectory = os.Getenv("PGDATA")
+		}
+
 		if status.DataDirectory == "" {
 			status.DataDirectory, err = filepath.EvalSymlinks("/proc/" + strconv.Itoa(status.PostmasterPid) + "/cwd")
 			if err != nil {
@@ -115,7 +120,11 @@ func main() {
 
 	switch os.Args[1] {
 	case "status":
-		getStatus()
+		var dataDir string
+		if len(os.Args) == 3 {
+			dataDir = os.Args[2]
+		}
+		getStatus(dataDir)
 	default:
 		fmt.Fprintf(os.Stderr, "Unknown command: %s\n", os.Args[1])
 	}

--- a/input/postgres/data_directory.go
+++ b/input/postgres/data_directory.go
@@ -4,16 +4,16 @@ import (
 	"github.com/pganalyze/collector/state"
 )
 
-// SetDataDirectory - Finds the data_directory in the list of settings and sets
-// the Server.Config.DataDirectory field to its value. Does nothing if the
-// setting is not found (e.g., due to permission issues).
-func SetDataDirectory(server *state.Server, settings []state.PostgresSetting) {
-	// N.B.: we're not taking a mutex here, because the data directory will not change location,
-	// so we only run this once at collector startup
+// GetDataDirectory - Finds the data_directory in the list of settings and returns
+// its current value. Returns an empty string if not found (e.g., the setting is
+// not present due to permissions issues)
+func GetDataDirectory(server *state.Server, settings []state.PostgresSetting) string {
+	// N.B.: we're not taking a mutex here, because the data directory will not
+	// change location, so we only run this once at collector startup
 	for _, setting := range settings {
 		if setting.Name == "data_directory" && setting.CurrentValue.Valid {
-			server.Config.DataDirectory = setting.CurrentValue.String
-			return
+			return setting.CurrentValue.String
 		}
 	}
+	return ""
 }

--- a/input/postgres/data_directory.go
+++ b/input/postgres/data_directory.go
@@ -1,0 +1,19 @@
+package postgres
+
+import (
+	"github.com/pganalyze/collector/state"
+)
+
+// SetDataDirectory - Finds the data_directory in the list of settings and sets
+// the Server.Config.DataDirectory field to its value. Does nothing if the
+// setting is not found (e.g., due to permission issues).
+func SetDataDirectory(server *state.Server, settings []state.PostgresSetting) {
+	// N.B.: we're not taking a mutex here, because the data directory will not change location,
+	// so we only run this once at collector startup
+	for _, setting := range settings {
+		if setting.Name == "data_directory" && setting.CurrentValue.Valid {
+			server.Config.DataDirectory = setting.CurrentValue.String
+			return
+		}
+	}
+}

--- a/input/postgres/data_directory.go
+++ b/input/postgres/data_directory.go
@@ -8,8 +8,6 @@ import (
 // its current value. Returns an empty string if not found (e.g., the setting is
 // not present due to permissions issues)
 func GetDataDirectory(server *state.Server, settings []state.PostgresSetting) string {
-	// N.B.: we're not taking a mutex here, because the data directory will not
-	// change location, so we only run this once at collector startup
 	for _, setting := range settings {
 		if setting.Name == "data_directory" && setting.CurrentValue.Valid {
 			return setting.CurrentValue.String

--- a/input/system/selfhosted/system.go
+++ b/input/system/selfhosted/system.go
@@ -36,7 +36,7 @@ func GetSystemState(config config.ServerConfig, logger *util.Logger) (system sta
 		Architecture: runtime.GOARCH,
 	}
 
-	statusBytes, err := exec.Command("/usr/bin/pganalyze-collector-helper", "status").Output()
+	statusBytes, err := exec.Command("/usr/bin/pganalyze-collector-helper", "status", config.DataDirectory).Output()
 	if err != nil {
 		logger.PrintVerbose("Selfhosted/System: Could not run helper process: %s", err)
 	} else {

--- a/input/system/selfhosted/system.go
+++ b/input/system/selfhosted/system.go
@@ -36,7 +36,7 @@ func GetSystemState(config config.ServerConfig, logger *util.Logger) (system sta
 		Architecture: runtime.GOARCH,
 	}
 
-	statusBytes, err := exec.Command("/usr/bin/pganalyze-collector-helper", "status", config.DataDirectory).Output()
+	statusBytes, err := exec.Command("/usr/bin/pganalyze-collector-helper", "status", config.DbDataDirectory).Output()
 	if err != nil {
 		logger.PrintVerbose("Selfhosted/System: Could not run helper process: %s", err)
 	} else {

--- a/main.go
+++ b/main.go
@@ -558,10 +558,9 @@ func checkOneInitialCollectionStatus(ctx context.Context, server *state.Server, 
 		return err
 	}
 
-	// We don't need a mutex here, because we only check once at startup
-	dataDirectorySetting := postgres.GetDataDirectory(server, settings)
-	if dataDirectorySetting != "" && server.Config.DataDirectory == "" {
-		server.Config.DataDirectory = dataDirectorySetting
+	if server.Config.DbDataDirectory == "" {
+		// We don't need a mutex here, because we only do this once at startup
+		server.Config.DbDataDirectory = postgres.GetDataDirectory(server, settings)
 	}
 
 	logsDisabled, logsIgnoreStatement, logsIgnoreDuration, logsDisabledReason := logs.ValidateLogCollectionConfig(server, settings)

--- a/main.go
+++ b/main.go
@@ -557,7 +557,11 @@ func checkOneInitialCollectionStatus(ctx context.Context, server *state.Server, 
 	if err != nil {
 		return err
 	}
-	postgres.SetDataDirectory(server, settings)
+	autodetectedDataDir := postgres.GetDataDirectory(server, settings)
+	if autodetectedDataDir != "" {
+		server.Config.DataDirectory = autodetectedDataDir
+	}
+
 	logsDisabled, logsIgnoreStatement, logsIgnoreDuration, logsDisabledReason := logs.ValidateLogCollectionConfig(server, settings)
 
 	var isIgnoredReplica bool

--- a/main.go
+++ b/main.go
@@ -557,9 +557,11 @@ func checkOneInitialCollectionStatus(ctx context.Context, server *state.Server, 
 	if err != nil {
 		return err
 	}
-	autodetectedDataDir := postgres.GetDataDirectory(server, settings)
-	if autodetectedDataDir != "" {
-		server.Config.DataDirectory = autodetectedDataDir
+
+	// We don't need a mutex here, because we only check once at startup
+	dataDirectorySetting := postgres.GetDataDirectory(server, settings)
+	if dataDirectorySetting != "" {
+		server.Config.DataDirectory = dataDirectorySetting
 	}
 
 	logsDisabled, logsIgnoreStatement, logsIgnoreDuration, logsDisabledReason := logs.ValidateLogCollectionConfig(server, settings)

--- a/main.go
+++ b/main.go
@@ -557,6 +557,7 @@ func checkOneInitialCollectionStatus(ctx context.Context, server *state.Server, 
 	if err != nil {
 		return err
 	}
+	postgres.SetDataDirectory(server, settings)
 	logsDisabled, logsIgnoreStatement, logsIgnoreDuration, logsDisabledReason := logs.ValidateLogCollectionConfig(server, settings)
 
 	var isIgnoredReplica bool

--- a/main.go
+++ b/main.go
@@ -560,7 +560,7 @@ func checkOneInitialCollectionStatus(ctx context.Context, server *state.Server, 
 
 	// We don't need a mutex here, because we only check once at startup
 	dataDirectorySetting := postgres.GetDataDirectory(server, settings)
-	if dataDirectorySetting != "" {
+	if dataDirectorySetting != "" && server.Config.DataDirectory == "" {
 		server.Config.DataDirectory = dataDirectorySetting
 	}
 


### PR DESCRIPTION
Currently, for gathering system stats on self-hosted systems, we look
up the current working directory of the postmaster process. This
usually works, but if customers have an unusual configuration, it can
find the wrong directory.

Instead, use the current method only as a fallback, and look at the
data_directory setting instead. This is readable with
pg_read_all_settings (part of pg_monitor), so it should be accessible
to us in most configurations.
