### PR TITLE
Relax locking requirements for collecting table stats

### DIFF
--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -14,7 +14,7 @@ const relationStatsSQLInsertsSinceVacuumFieldDefault string = "0"
 
 const relationStatsSQL = `
 WITH locked_relids AS (
-	SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL
+	SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype <> 'tuple'
 ),
 locked_relids_with_parents AS (
 	SELECT DISTINCT inhparent relid FROM pg_catalog.pg_inherits WHERE inhrelid IN (SELECT relid FROM locked_relids)
@@ -117,7 +117,7 @@ SELECT relid,
 `
 
 const indexStatsSQL = `
-WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL)
+WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype <> 'tuple')
 SELECT s.indexrelid,
 			 COALESCE(pg_catalog.pg_relation_size(s.indexrelid), 0) AS size_bytes,
 			 COALESCE(s.idx_scan, 0),

--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -14,7 +14,7 @@ const relationStatsSQLInsertsSinceVacuumFieldDefault string = "0"
 
 const relationStatsSQL = `
 WITH locked_relids AS (
-	SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype <> 'tuple'
+	SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype = 'relation'
 ),
 locked_relids_with_parents AS (
 	SELECT DISTINCT inhparent relid FROM pg_catalog.pg_inherits WHERE inhrelid IN (SELECT relid FROM locked_relids)
@@ -117,7 +117,7 @@ SELECT relid,
 `
 
 const indexStatsSQL = `
-WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype <> 'tuple')
+WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype = 'relation')
 SELECT s.indexrelid,
 			 COALESCE(pg_catalog.pg_relation_size(s.indexrelid), 0) AS size_bytes,
 			 COALESCE(s.idx_scan, 0),

--- a/input/postgres/relations.go
+++ b/input/postgres/relations.go
@@ -15,7 +15,7 @@ const relationsSQLOidField = "c.relhasoids AS relation_has_oids"
 const relationsSQLpg12OidField = "false AS relation_has_oids"
 
 const relationsSQL string = `
-	 WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL)
+	 WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype <> 'tuple')
  SELECT c.oid,
 				n.nspname AS schema_name,
 				c.relname AS table_name,
@@ -45,7 +45,7 @@ const relationsSQL string = `
 				AND ($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)`
 
 const columnsSQL string = `
-	 WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL)
+	 WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype <> 'tuple')
  SELECT c.oid,
 				a.attname AS name,
 				pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,
@@ -81,7 +81,7 @@ const columnsSQL string = `
    FROM locked_relids`
 
 const indicesSQL string = `
-	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL)
+	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype <> 'tuple')
 SELECT c.oid,
 			 c2.oid,
 			 i.indkey::text,
@@ -125,7 +125,7 @@ SELECT c.oid,
 `
 
 const constraintsSQL string = `
-	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL)
+	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype <> 'tuple')
 SELECT c.oid,
 			 conname,
 			 contype,
@@ -162,7 +162,7 @@ SELECT relid,
 `
 
 const viewDefinitionSQL string = `
-	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL)
+	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype <> 'tuple')
 SELECT c.oid,
 			 pg_catalog.pg_get_viewdef(c.oid) AS view_definition,
 			 false AS exclusively_locked

--- a/input/postgres/relations.go
+++ b/input/postgres/relations.go
@@ -15,7 +15,7 @@ const relationsSQLOidField = "c.relhasoids AS relation_has_oids"
 const relationsSQLpg12OidField = "false AS relation_has_oids"
 
 const relationsSQL string = `
-	 WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype <> 'tuple')
+	 WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype = 'relation')
  SELECT c.oid,
 				n.nspname AS schema_name,
 				c.relname AS table_name,
@@ -45,7 +45,7 @@ const relationsSQL string = `
 				AND ($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)`
 
 const columnsSQL string = `
-	 WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype <> 'tuple')
+	 WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype = 'relation')
  SELECT c.oid,
 				a.attname AS name,
 				pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,
@@ -81,7 +81,7 @@ const columnsSQL string = `
    FROM locked_relids`
 
 const indicesSQL string = `
-	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype <> 'tuple')
+	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype = 'relation')
 SELECT c.oid,
 			 c2.oid,
 			 i.indkey::text,
@@ -125,7 +125,7 @@ SELECT c.oid,
 `
 
 const constraintsSQL string = `
-	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype <> 'tuple')
+	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype = 'relation')
 SELECT c.oid,
 			 conname,
 			 contype,
@@ -162,7 +162,7 @@ SELECT relid,
 `
 
 const viewDefinitionSQL string = `
-	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype <> 'tuple')
+	WITH locked_relids AS (SELECT DISTINCT relation relid FROM pg_catalog.pg_locks WHERE mode = 'AccessExclusiveLock' AND relation IS NOT NULL AND locktype = 'relation')
 SELECT c.oid,
 			 pg_catalog.pg_get_viewdef(c.oid) AS view_definition,
 			 false AS exclusively_locked


### PR DESCRIPTION
Currently, if tables are locked in AccessExclusiveMode, we skip
collecting most table structure information and table and column
stats. We do this since the lock would conflict with the lock the
collector needs and potentially cause cascading locking problems and
impact the application. However, we're not checking the locktype, so
the collector also avoids collecting stats for tables with
AccessExclusiveMode locktype = 'tuple' locks, which do not actually
block collection. These can be fairly common, e.g., if a transaction
issues a `SELECT FOR UPDATE` query while another transaction has
already obtained a `SELECT FOR UPDATE` lock.

Relax the locking requirements by ignoring AccessExclusiveMode
locktype = 'tuple' locks when collecting schema structure and stats.
