### PR TITLE
Add logs for test run when system state collection is skipped

### DIFF
--- a/input/full.go
+++ b/input/full.go
@@ -130,7 +130,7 @@ func CollectFull(ctx context.Context, server *state.Server, connection *sql.DB, 
 	}
 
 	if globalCollectionOpts.CollectSystemInformation {
-		ps.System = system.GetSystemState(server.Config, logger)
+		ps.System = system.GetSystemState(server.Config, logger, globalCollectionOpts)
 	}
 
 	server.SetLogTimezone(ts.Settings)

--- a/input/system/system.go
+++ b/input/system/system.go
@@ -56,7 +56,7 @@ func GetSystemState(config config.ServerConfig, logger *util.Logger, globalColle
 			// didn't detect the collector is running on the same instance as
 			// the database server.
 			// Leave logs for if this is a test run.
-			logger.PrintInfo("Remote host (%s) was specified for the database address, skip collecting system state. Consider enabling always_collect_system_data if it's a local database with a non-local IP address", dbHost)
+			logger.PrintInfo("Skipping collection of system state: remote host (%s) was specified for the database address. Consider enabling always_collect_system_data if the database is running on the same system as the collector", dbHost)
 		}
 	}
 


### PR DESCRIPTION
We try to collect system data (e.g. CPU, memory usage, etc., shown in "System" page) when it's a self hosted database server and the database server is in the same instance as the collector's.
However, sometimes people would set the db host different from localhost or 127.0.0.1 even though the database is running locally. In that case, setting `always_collect_system_data` will help the situation, but it's not so obvious.
https://pganalyze.com/docs/collector/settings#self-managed-servers

In this PR, add a log during the test run if we detect 1) the server is self hosted 2) but it's detected as a remote host.