### PR TITLE
Docker log tail: Re-order args to also support podman aliased as docker

### DIFF
--- a/input/system/selfhosted/logs.go
+++ b/input/system/selfhosted/logs.go
@@ -340,7 +340,7 @@ func setupLogLocationTail(ctx context.Context, logLocation string, out chan<- Se
 func setupDockerTail(ctx context.Context, containerName string, out chan<- SelfHostedLogStreamItem, prefixedLogger *util.Logger) error {
 	var err error
 
-	cmd := exec.Command("docker", "logs", containerName, "-f", "--tail", "0")
+	cmd := exec.Command("docker", "logs", "-f", "--tail", "0", containerName)
 	stderr, _ := cmd.StderrPipe()
 
 	scanner := bufio.NewScanner(stderr)


### PR DESCRIPTION
Whilst we currently explicitly call out to "docker" for this experimental way of reading local logs during development, we technically also support podman when its available with the "docker" alias. However, podman requires arguments to be set before the container name. Fix support for this type of setup. This keeps compatibility with docker, which accepts arguments in either order.