### PR TITLE
Activity snapshots: Normalize queries for "filter_query_sample = normalize"

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,6 +40,7 @@ func run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 
 	keepRunning = false
 	writeStateFile = func() {}
+	shutdown = func() {}
 
 	schedulerGroups, err := scheduler.GetSchedulerGroups()
 	if err != nil {

--- a/output/compact_activity.go
+++ b/output/compact_activity.go
@@ -12,7 +12,7 @@ import (
 func SubmitCompactActivitySnapshot(ctx context.Context, server *state.Server, grant state.Grant, collectionOpts state.CollectionOpts, logger *util.Logger, activityState state.TransientActivityState) error {
 	as, r := transform.ActivityStateToCompactActivitySnapshot(server, activityState)
 
-	if server.Config.FilterQuerySample != "none" {
+	if server.Config.FilterQuerySample != "" && server.Config.FilterQuerySample != "none" {
 		for idx, backend := range as.Backends {
 			// Normalize can be slow, protect against edge cases here by checking for cancellations
 			select {

--- a/output/compact_activity.go
+++ b/output/compact_activity.go
@@ -20,6 +20,9 @@ func SubmitCompactActivitySnapshot(ctx context.Context, server *state.Server, gr
 				return ctx.Err()
 			default:
 				if backend.QueryText != "" {
+					// We pass "unparseable" here as the implied value of the filter_query_text setting, since for historic
+					// reasons this conditional here is based on filter_query_sample. The intent is that if the query is
+					// unparseable, it turns into "<truncated query>" or "<unparseable query>", not the original text.
 					as.Backends[idx].QueryText = util.NormalizeQuery(backend.QueryText, "unparseable", activityState.TrackActivityQuerySize)
 				}
 			}


### PR DESCRIPTION
For historic reasons, we were only normalizing pg_stat_activity query texts when `filter_query_sample` was set to `all`, not `normalize`, which has a similar intent.

Whilst we could also control the filtering of pg_stat_activity query texts with the `filter_query_text` setting (which today controls whether pg_stat_statements query texts are re-normalized, and is enabled by default), this is intentionally
not done here. The main motivation to not do this for now are performance implications of running normalize every 10 seconds for many active queries, and we may adjust this in a future commit based on more benchmarks.