### PR TITLE
Postgres 14+: Include toplevel attribute in statement statistics key

### DIFF
--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -14,12 +14,15 @@ import (
 )
 
 // pg_stat_statements 1.3+ (Postgres 9.5+)
-const statementSQLOptionalFieldsMinorVersion3 = "queryid, min_time, max_time, mean_time, stddev_time"
+const statementSQLOptionalFieldsMinorVersion3 = "queryid, min_time, max_time, mean_time, stddev_time, NULL"
 const statementSQLTotalTimeFieldDefault = "total_time"
 
 // pg_stat_statements 1.8+ (Postgres 13+)
-const statementSQLOptionalFieldsMinorVersion8 = "queryid, min_exec_time, max_exec_time, mean_exec_time, stddev_exec_time"
+const statementSQLOptionalFieldsMinorVersion8 = "queryid, min_exec_time, max_exec_time, mean_exec_time, stddev_exec_time, NULL"
 const statementSQLTotalTimeFieldMinorVersion8 = "total_exec_time"
+
+// pg_stat_statements 1.9+ (Postgres 14+)
+const statementSQLOptionalFieldsMinorVersion9 = "queryid, min_exec_time, max_exec_time, mean_exec_time, stddev_exec_time, toplevel"
 
 const statementSQL string = `
 SELECT dbid, userid, query, calls, %s, rows, shared_blks_hit, shared_blks_read,
@@ -118,7 +121,9 @@ func GetStatements(ctx context.Context, server *state.Server, logger *util.Logge
 		foundExtMinorVersion = extMinorVersion
 	}
 
-	if foundExtMinorVersion >= 8 {
+	if foundExtMinorVersion >= 9 {
+		optionalFields = statementSQLOptionalFieldsMinorVersion9
+	} else if foundExtMinorVersion >= 8 {
 		optionalFields = statementSQLOptionalFieldsMinorVersion8
 	} else if foundExtMinorVersion >= 3 {
 		optionalFields = statementSQLOptionalFieldsMinorVersion3
@@ -204,7 +209,7 @@ func GetStatements(ctx context.Context, server *state.Server, logger *util.Logge
 			&stats.SharedBlksHit, &stats.SharedBlksRead, &stats.SharedBlksDirtied, &stats.SharedBlksWritten,
 			&stats.LocalBlksHit, &stats.LocalBlksRead, &stats.LocalBlksDirtied, &stats.LocalBlksWritten,
 			&stats.TempBlksRead, &stats.TempBlksWritten, &stats.BlkReadTime, &stats.BlkWriteTime,
-			&queryID, &stats.MinTime, &stats.MaxTime, &stats.MeanTime, &stats.StddevTime)
+			&queryID, &stats.MinTime, &stats.MaxTime, &stats.MeanTime, &stats.StddevTime, &key.TopLevel)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -99,7 +99,9 @@ func GetStatements(ctx context.Context, server *state.Server, logger *util.Logge
 	var extMinorVersion int16
 	var foundExtMinorVersion int16
 
-	if postgresVersion.Numeric >= state.PostgresVersion13 {
+	if postgresVersion.Numeric >= state.PostgresVersion14 {
+		extMinorVersion = 9
+	} else if postgresVersion.Numeric >= state.PostgresVersion13 {
 		extMinorVersion = 8
 	} else {
 		extMinorVersion = 3

--- a/output/transform/postgres_statements.go
+++ b/output/transform/postgres_statements.go
@@ -18,6 +18,8 @@ func groupStatements(statements state.PostgresStatementMap, statsMap state.Diffe
 			statement = state.PostgresStatement{QueryTextUnavailable: true, Fingerprint: util.FingerprintText(util.QueryTextUnavailable)}
 		}
 
+		// Note we intentionally don't include sKey.TopLevel here, since we don't (yet)
+		// separate statistics based on that attribute in the pganalyze app
 		key := statementKey{
 			databaseOid: sKey.DatabaseOid,
 			userOid:     sKey.UserOid,

--- a/state/postgres_statement.go
+++ b/state/postgres_statement.go
@@ -2,6 +2,8 @@ package state
 
 import (
 	"time"
+
+	"github.com/guregu/null"
 )
 
 // PostgresStatement - Specific kind of statement that has run one or multiple times
@@ -39,11 +41,12 @@ type PostgresStatementStats struct {
 	StddevTime        float64 // Population standard deviation of time spent in the statement, in milliseconds
 }
 
-// PostgresStatementKey - Information that uniquely identifies a query
+// PostgresStatementKey - Information that uniquely identifies a query (this needs to match pgssHashKey in pg_stat_statements.c)
 type PostgresStatementKey struct {
-	DatabaseOid Oid   // OID of database in which the statement was executed
-	UserOid     Oid   // OID of user who executed the statement
-	QueryID     int64 // Internal hash code, computed from the statement's parse tree
+	DatabaseOid Oid       // OID of database in which the statement was executed
+	UserOid     Oid       // OID of user who executed the statement
+	QueryID     int64     // Internal hash code, computed from the statement's parse tree (note pg_stat_statements stores this as a uint64, but returns it as a int64 in the user-facing API)
+	TopLevel    null.Bool // Whether this statement was executed directly (at the top level), or from within a function / stored procedure (on older Postgres versions this is not tracked, so we set it to NULL)
 }
 
 type PostgresStatementStatsTimeKey struct {


### PR DESCRIPTION
This could have caused statistics to be incorrect in Postgres 14+ when the same query was called both from within a function (toplevel=false) and directly (toplevel=true), with pg_stat_statements track set to "all".

If affected, the issue may have shown by bogus statistics being recorded, for example very high call counts, since the statement stats diff would not have used the correct reference.

Fix by including toplevel attribute for internal tracking, matching the [pgssHashKey struct](https://github.com/postgres/postgres/blob/master/contrib/pg_stat_statements/pg_stat_statements.c#L148) in pg_stat_statements.c where this data originates.