### PR TITLE
Support query tags with SQLCommenter format

### DIFF
--- a/logs/querysample/tags.go
+++ b/logs/querysample/tags.go
@@ -34,19 +34,19 @@ func parseTags(query string) map[string]string {
 				// Parse sqlcommenter format (key='value')
 				keyAndValue := strings.SplitN(part, "=", 2)
 				// Remove surrounding single quotes (if present)
-				value := keyAndValue[1]
+				value := strings.TrimSpace(keyAndValue[1])
 				if match := singleQuotedRegex.FindStringSubmatch(value); match != nil {
 					value = match[1]
 				}
 				// Decode key and value
-				key := decodeString(keyAndValue[0])
+				key := decodeString(strings.TrimSpace(keyAndValue[0]))
 				value = decodeString(value)
 
 				tags[key] = value
 			} else if strings.Contains(part, ":") {
 				// Parse marginalia format (key:value)
 				keyAndValue := strings.SplitN(part, ":", 2)
-				tags[keyAndValue[0]] = keyAndValue[1]
+				tags[strings.TrimSpace(keyAndValue[0])] = strings.TrimSpace(keyAndValue[1])
 			} // TODO: Support other formats
 		}
 	}

--- a/logs/querysample/tags.go
+++ b/logs/querysample/tags.go
@@ -1,10 +1,15 @@
 package querysample
 
 import (
+	"net/url"
+	"regexp"
 	"strings"
 
 	pg_query "github.com/pganalyze/pg_query_go/v4"
 )
+
+var singleQuotedRegex = regexp.MustCompile(`^'(.*)'$`)
+var metaCharacterRegex = regexp.MustCompile(`\\(.)`)
 
 func parseTags(query string) map[string]string {
 	tokens, err := pg_query.Scan(query)
@@ -26,14 +31,41 @@ func parseTags(query string) map[string]string {
 		}
 		for _, part := range strings.Split(strings.TrimSpace(comment), ",") {
 			if strings.Contains(part, "=") {
+				// Parse sqlcommenter format (key='value')
 				keyAndValue := strings.SplitN(part, "=", 2)
-				tags[keyAndValue[0]] = keyAndValue[1]
-				// TODO: Handle sqlcommenter's URL encoding logic, and quoting with single quotes
+				// Remove surrounding single quotes (if present)
+				value := keyAndValue[1]
+				if match := singleQuotedRegex.FindStringSubmatch(value); match != nil {
+					value = match[1]
+				}
+				// Decode key and value
+				key := decodeString(keyAndValue[0])
+				value = decodeString(value)
+
+				tags[key] = value
 			} else if strings.Contains(part, ":") {
+				// Parse marginalia format (key:value)
 				keyAndValue := strings.SplitN(part, ":", 2)
 				tags[keyAndValue[0]] = keyAndValue[1]
 			} // TODO: Support other formats
 		}
 	}
 	return tags
+}
+
+func decodeString(str string) string {
+	// From https://google.github.io/sqlcommenter/spec/#parsing
+	// 1. Unescape the meta characters
+	unescapedStr := metaCharacterRegex.ReplaceAllStringFunc(str, func(matched string) string {
+		// This is simply returning the single char after the backslash "\"
+		// Things like \n or \t are not supported
+		return string(matched[1])
+	})
+	// 2. URL Decode
+	decodedStr, err := url.QueryUnescape(unescapedStr)
+	if err != nil {
+		// Give up decode and use the original str
+		decodedStr = unescapedStr
+	}
+	return decodedStr
 }

--- a/logs/querysample/tags_test.go
+++ b/logs/querysample/tags_test.go
@@ -1,6 +1,7 @@
 package querysample
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/kylelemons/godebug/pretty"
@@ -16,32 +17,79 @@ var parseTagsTests = []parseTagsTestpair{
 	{
 		"No query tags",
 		"SELECT 1",
-		nil,
+		map[string]string{},
 	},
 	{
-		"Query tag with key:value shape",
-		"/*key1:value1,key2:value2*/ SELECT 1",
-		map[string]string{"key1": "value1", "key2": "value2"},
+		"Query tag with key:value (marginalia) shape",
+		"SELECT 1 /* abc:123, def:456 */",
+		map[string]string{"abc": "123", "def": "456"},
+	},
+	{
+		"Query tag with complex key:value (marginalia) shape",
+		"SELECT 1 /*controller_with_namespace:Api::V1::SubmittedInspectionFormsController,action:index,line:/config/initializers/kaminari_total_count.rb:60:in `total_count'*/",
+		map[string]string{
+			"controller_with_namespace": "Api::V1::SubmittedInspectionFormsController",
+			"action":                    "index",
+			"line":                      "/config/initializers/kaminari_total_count.rb:60:in `total_count'",
+		},
 	},
 	{
 		"Query tag with key=value shape",
-		"/*key1=value1,key2=value2*/ SELECT 1",
-		map[string]string{"key1": "value1", "key2": "value2"},
+		"SELECT 1 /* abc=123,def=456 */",
+		map[string]string{"abc": "123", "def": "456"},
 	},
 	{
-		"Query tag with key='value' shape",
-		"/*key1='value1',key2='value2'*/ SELECT 1",
-		map[string]string{"key1": "value1", "key2": "value2"},
+		"Query tag with key=value shape with valueless key (ignore)",
+		"SELECT 1 /* hello=world,foo */",
+		map[string]string{"hello": "world"},
 	},
 	{
-		"Query tag with key='value' shape with meta characters and URL encoded",
-		"/*key1='value1',key2='%2Fparam%20\\'first\\''*/ SELECT 1",
-		map[string]string{"key1": "value1", "key2": "/param 'first'"},
+		"Query tag with key=value shape with valueless key in the middle (ignore)",
+		"SELECT 1 /* hello: world, foo, bar: 123 */",
+		map[string]string{"hello": "world", "bar": "123"},
 	},
 	{
-		"Bad query",
-		"SELECT BAD QUERY",
-		nil,
+		"Comment inside string",
+		"SELECT '/* not a comment */' /* a:42 */",
+		map[string]string{"a": "42"},
+	},
+	{
+		"Multiple comments",
+		"/* a:1,b:2 */ SELECT 1 /* c:3,d:4 */",
+		map[string]string{
+			"a": "1",
+			"b": "2",
+			"c": "3",
+			"d": "4",
+		},
+	},
+	{
+		"Multiple comments with conflicting keys",
+		"/* a:1,b:2 */ SELECT 1 /* c:3,a:4 */",
+		map[string]string{
+			"a": "4",
+			"b": "2",
+			"c": "3",
+		},
+	},
+	{
+		"Comment inside string",
+		"SELECT '/* not a comment */' /* a:42 */",
+		map[string]string{"a": "42"},
+	},
+	{
+		"Query tag with key='value' (sqlcommenter) shape",
+		"SELECT 1 /* foo='bar%20quux' */",
+		map[string]string{"foo": "bar quux"},
+	},
+	{
+		"Query tag with complex key='value' (sqlcommenter) shape",
+		"SELECT 1, 'string', '/* ignore */' /* foo='bar%20quux',fred='http://example.org/a%20b%20c\\'',thud%20thud%25thud\\'='\\'%25%20%25 %20' */",
+		map[string]string{
+			"foo":             "bar quux",
+			"fred":            "http://example.org/a b c'",
+			"thud thud%thud'": "'% %  ",
+		},
 	},
 }
 
@@ -50,8 +98,8 @@ func TestParseTags(t *testing.T) {
 
 	for _, pair := range parseTagsTests {
 		tags := parseTags(pair.query)
-		if diff := cfg.Compare(pair.tags, tags); diff != "" {
-			t.Errorf("For %s: (-want +got)\n%s", pair.testName, diff)
+		if !reflect.DeepEqual(pair.tags, tags) {
+			t.Errorf("For %s: (-want +got)\n%s", pair.testName, cfg.Compare(pair.tags, tags))
 		}
 	}
 

--- a/logs/querysample/tags_test.go
+++ b/logs/querysample/tags_test.go
@@ -1,0 +1,58 @@
+package querysample
+
+import (
+	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
+)
+
+type parseTagsTestpair struct {
+	testName string
+	query    string
+	tags     map[string]string
+}
+
+var parseTagsTests = []parseTagsTestpair{
+	{
+		"No query tags",
+		"SELECT 1",
+		nil,
+	},
+	{
+		"Query tag with key:value shape",
+		"/*key1:value1,key2:value2*/ SELECT 1",
+		map[string]string{"key1": "value1", "key2": "value2"},
+	},
+	{
+		"Query tag with key=value shape",
+		"/*key1=value1,key2=value2*/ SELECT 1",
+		map[string]string{"key1": "value1", "key2": "value2"},
+	},
+	{
+		"Query tag with key='value' shape",
+		"/*key1='value1',key2='value2'*/ SELECT 1",
+		map[string]string{"key1": "value1", "key2": "value2"},
+	},
+	{
+		"Query tag with key='value' shape with meta characters and URL encoded",
+		"/*key1='value1',key2='%2Fparam%20\\'first\\''*/ SELECT 1",
+		map[string]string{"key1": "value1", "key2": "/param 'first'"},
+	},
+	{
+		"Bad query",
+		"SELECT BAD QUERY",
+		nil,
+	},
+}
+
+func TestParseTags(t *testing.T) {
+	cfg := pretty.CompareConfig
+
+	for _, pair := range parseTagsTests {
+		tags := parseTags(pair.query)
+		if diff := cfg.Compare(pair.tags, tags); diff != "" {
+			t.Errorf("For %s: (-want +got)\n%s", pair.testName, diff)
+		}
+	}
+
+}


### PR DESCRIPTION
See the spec, especially for the parsing in https://google.github.io/sqlcommenter/spec/#parsing

This PR will support query tags with SQLCommenter format, like `key='value'` (value is surrounded by single quotes). I think it's quite essential to support this as I believe Active Record Query Logs uses SQLCommenter format by default.
I confirmed that the current code doesn't support picking up `traceparent` when the format is SQLCommenter, and this should fix it.

https://api.rubyonrails.org/classes/ActiveRecord/QueryLogs.html