### PR TITLE
Summarize compact snapshot logs to reduce noise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,13 @@ jobs:
       with:
         submodules: true
 
-    - name: Runs tests
+    - name: Lint
+      run: |
+        test $(go fmt ./... | wc -l) -eq 0
+
+    - name: Run tests
       run: |
         make build OUTFILE=pganalyze-collector-linux-amd64
         make test
         DOCKER_BUILDKIT=1 make integration_test
         shellcheck contrib/install.sh
-
-    - name: Lint
-      run: |
-        test $(go fmt ./... | wc -l) -eq 0

--- a/output/compact.go
+++ b/output/compact.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -48,7 +49,7 @@ func uploadAndSubmitCompactSnapshot(ctx context.Context, s pganalyze_collector.C
 		if collectionOpts.OutputAsJson {
 			debugCompactOutputAsJSON(logger, compressedData)
 		} else if !quiet {
-			logger.PrintVerbose("Collected compact %s snapshot successfully", kind)
+			logger.PrintInfo("Collected compact %s snapshot successfully", kind)
 		}
 		return nil
 	}
@@ -138,7 +139,29 @@ func submitCompactSnapshot(ctx context.Context, server *state.Server, collection
 		logger.PrintInfo("  %s", msg)
 	} else if !quiet {
 		logger.PrintVerbose("Submitted compact %s snapshot successfully", kind)
+		if time.Now().Sub(lastLog) > time.Minute {
+			lastLog = time.Now()
+			details := ""
+			var keys []string
+			for k := range callCounts {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for i, kind := range keys {
+				details += fmt.Sprintf("%d %s", callCounts[kind], kind)
+				if i < len(keys)-1 {
+					details += ", "
+				}
+			}
+			logger.PrintInfo("Compact snapshots submitted over the past minute: " + details)
+			callCounts = make(map[string]uint8)
+		} else {
+			callCounts[kind] = callCounts[kind] + 1
+		}
 	}
 
 	return nil
 }
+
+var callCounts = make(map[string]uint8)
+var lastLog = time.Now()

--- a/output/compact.go
+++ b/output/compact.go
@@ -48,7 +48,7 @@ func uploadAndSubmitCompactSnapshot(ctx context.Context, s pganalyze_collector.C
 		if collectionOpts.OutputAsJson {
 			debugCompactOutputAsJSON(logger, compressedData)
 		} else if !quiet {
-			logger.PrintInfo("Collected compact %s snapshot successfully", kind)
+			logger.PrintVerbose("Collected compact %s snapshot successfully", kind)
 		}
 		return nil
 	}
@@ -137,7 +137,7 @@ func submitCompactSnapshot(ctx context.Context, server *state.Server, collection
 	if len(msg) > 0 && collectionOpts.TestRun {
 		logger.PrintInfo("  %s", msg)
 	} else if !quiet {
-		logger.PrintInfo("Submitted compact %s snapshot successfully", kind)
+		logger.PrintVerbose("Submitted compact %s snapshot successfully", kind)
 	}
 
 	return nil

--- a/output/compact.go
+++ b/output/compact.go
@@ -140,7 +140,7 @@ func submitCompactSnapshot(ctx context.Context, server *state.Server, collection
 	} else if !quiet {
 		logger.PrintVerbose("Submitted compact %s snapshot successfully", kind)
 		if server.CompactLogTime.IsZero() {
-			server.CompactLogTime = time.Now()
+			server.CompactLogTime = time.Now().Truncate(time.Minute)
 			server.CompactLogStats = make(map[string]uint8)
 		} else if time.Now().Sub(server.CompactLogTime) > time.Minute {
 			var keys []string
@@ -158,7 +158,7 @@ func submitCompactSnapshot(ctx context.Context, server *state.Server, collection
 			if len(details) > 0 {
 				logger.PrintInfo("Compact snapshots submitted: " + details)
 			}
-			server.CompactLogTime = time.Now()
+			server.CompactLogTime = time.Now().Truncate(time.Minute)
 			server.CompactLogStats = make(map[string]uint8)
 		} else {
 			server.CompactLogStats[kind] = server.CompactLogStats[kind] + 1

--- a/output/compact.go
+++ b/output/compact.go
@@ -143,7 +143,6 @@ func submitCompactSnapshot(ctx context.Context, server *state.Server, collection
 			server.CompactLogTime = time.Now()
 			server.CompactLogStats = make(map[string]uint8)
 		} else if time.Now().Sub(server.CompactLogTime) > time.Minute {
-			server.CompactLogTime = time.Now()
 			var keys []string
 			for k := range server.CompactLogStats {
 				keys = append(keys, k)
@@ -156,7 +155,10 @@ func submitCompactSnapshot(ctx context.Context, server *state.Server, collection
 					details += ", "
 				}
 			}
-			logger.PrintInfo("Compact snapshots submitted: " + details)
+			if len(details) > 0 {
+				logger.PrintInfo("Compact snapshots submitted: " + details)
+			}
+			server.CompactLogTime = time.Now()
 			server.CompactLogStats = make(map[string]uint8)
 		} else {
 			server.CompactLogStats[kind] = server.CompactLogStats[kind] + 1

--- a/state/state.go
+++ b/state/state.go
@@ -286,6 +286,10 @@ type Server struct {
 	// differences (see https://groups.google.com/g/golang-nuts/c/eIqkhXh9PLg),
 	// as we access this in high frequency log-related code paths.
 	LogIgnoreFlags uint32
+
+	// State to track compact snapshot submissions, and log them routinely
+	CompactLogStats map[string]uint8
+	CompactLogTime time.Time
 }
 
 func MakeServer(config config.ServerConfig) *Server {

--- a/state/state.go
+++ b/state/state.go
@@ -289,7 +289,7 @@ type Server struct {
 
 	// State to track compact snapshot submissions, and log them routinely
 	CompactLogStats map[string]uint8
-	CompactLogTime time.Time
+	CompactLogTime  time.Time
 }
 
 func MakeServer(config config.ServerConfig) *Server {


### PR DESCRIPTION
The high frequency of compact snapshots causes them to create the vast majority of log lines in the default (info) log level. That makes it difficult to find logs related to errors when debugging an issue.

This PR summarizes the 6+ compact snapshots sent per minute into a single log line:
```
Compact snapshots submitted: 6 activity, 2 logs
