### PR TITLE
Add a special error message during test run when Postgres 14+ is using the older pgss

### DIFF
--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -142,11 +142,9 @@ func GetStatements(ctx context.Context, server *state.Server, logger *util.Logge
 	if globalCollectionOpts.TestRun && foundExtMinorVersion < extMinorVersion {
 		logger.PrintInfo("pg_stat_statements extension outdated (1.%d installed, 1.%d available). To update run `ALTER EXTENSION pg_stat_statements UPDATE`", foundExtMinorVersion, extMinorVersion)
 		if extMinorVersion >= 9 {
-			// Prior to pgss 1.9, there was no distinction between toplevel queries and others.
-			// This was known to cause issues in stats collection, as the collector might
-			// inconsistently pick up stats from or not, which was known to cause the stats from
-			// toplevel queries at one time and non-toplevel queries at another.
-			// Warn when an upgrade is available to avoid this problem.
+			// Using the older version pgss with Postgres 14+ can cause the incorrect query stats
+			// when track = all is used + there are toplevel queries and nested queries
+			// https://github.com/pganalyze/collector/pull/472#discussion_r1399976152
 			logger.PrintError("Outdated pg_stat_statements may cause incorrect query statistics")
 		}
 	}

--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -142,8 +142,12 @@ func GetStatements(ctx context.Context, server *state.Server, logger *util.Logge
 	if globalCollectionOpts.TestRun && foundExtMinorVersion < extMinorVersion {
 		logger.PrintInfo("pg_stat_statements extension outdated (1.%d installed, 1.%d available). To update run `ALTER EXTENSION pg_stat_statements UPDATE`", foundExtMinorVersion, extMinorVersion)
 		if extMinorVersion >= 9 {
-			// with Postgres 14+, there is a known data issue if pgss is using the older version
-			logger.PrintError("Outdated pg_stat_statements extension is known to cause the incorrect data with query statistics")
+			// Prior to pgss 1.9, there was no distinction between toplevel queries and others.
+			// This was known to cause issues in stats collection, as the collector might
+			// inconsistently pick up stats from or not, which was known to cause the stats from
+			// toplevel queries at one time and non-toplevel queries at another.
+			// Warn when an upgrade is available to avoid this problem.
+			logger.PrintError("Outdated pg_stat_statements may cause incorrect query statistics")
 		}
 	}
 

--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -141,6 +141,10 @@ func GetStatements(ctx context.Context, server *state.Server, logger *util.Logge
 
 	if globalCollectionOpts.TestRun && foundExtMinorVersion < extMinorVersion {
 		logger.PrintInfo("pg_stat_statements extension outdated (1.%d installed, 1.%d available). To update run `ALTER EXTENSION pg_stat_statements UPDATE`", foundExtMinorVersion, extMinorVersion)
+		if extMinorVersion >= 9 {
+			// with Postgres 14+, there is a known data issue if pgss is using the older version
+			logger.PrintError("Outdated pg_stat_statements extension is known to cause the incorrect data with query statistics")
+		}
 	}
 
 	usingStatsHelper := false


### PR DESCRIPTION
Starting from Postgres 14, there is a concept called `toplevel` but if you're using the older version of pg_stat_statements extension, this `toplevel` not appearing during the stats collection, therefore it can still cause the bug that was fixed in https://github.com/pganalyze/collector/pull/463

With this PR, we detect such case during the test run and warn folks to upgrade pgss.