### PR TITLE
Allow collector to run in verbose log mode with Docker

### DIFF
--- a/contrib/docker-entrypoint.sh
+++ b/contrib/docker-entrypoint.sh
@@ -24,7 +24,7 @@ if [ "$1" = 'collector' ]; then
 fi
 
 if [ "$1" = 'collector-verbose' ]; then
-  eval $CMD_PREFIX /home/pganalyze/collector --verbose --statefile=/state/pganalyze-collector.state --no-log-timestamps
+  eval $CMD_PREFIX /home/pganalyze/collector --statefile=/state/pganalyze-collector.state --no-log-timestamps --verbose
 fi
 
 eval $CMD_PREFIX "$@"

--- a/contrib/docker-entrypoint.sh
+++ b/contrib/docker-entrypoint.sh
@@ -23,4 +23,8 @@ if [ "$1" = 'collector' ]; then
   eval $CMD_PREFIX /home/pganalyze/collector --statefile=/state/pganalyze-collector.state --no-log-timestamps
 fi
 
+if [ "$1" = 'collector-verbose' ]; then
+  eval $CMD_PREFIX /home/pganalyze/collector --verbose --statefile=/state/pganalyze-collector.state --no-log-timestamps
+fi
+
 eval $CMD_PREFIX "$@"

--- a/contrib/docker-entrypoint.sh
+++ b/contrib/docker-entrypoint.sh
@@ -12,19 +12,14 @@ if [ $(id -u) = 0 ]; then
 fi
 
 if [ "$1" = 'test' ]; then
-  eval $CMD_PREFIX /home/pganalyze/collector --test --no-log-timestamps --no-reload
+  shift
+  eval $CMD_PREFIX /home/pganalyze/collector --test --no-log-timestamps --no-reload "$@"
+elif [ "$1" = 'test-explain' ]; then
+  shift
+  eval $CMD_PREFIX /home/pganalyze/collector --test-explain --no-log-timestamps "$@"
+elif  [ "$1" = 'collector' ]; then
+  shift
+  eval $CMD_PREFIX /home/pganalyze/collector --statefile=/state/pganalyze-collector.state --no-log-timestamps "$@"
+else
+  eval $CMD_PREFIX "$@"
 fi
-
-if [ "$1" = 'test-explain' ]; then
-  eval $CMD_PREFIX /home/pganalyze/collector --test-explain --no-log-timestamps
-fi
-
-if [ "$1" = 'collector' ]; then
-  eval $CMD_PREFIX /home/pganalyze/collector --statefile=/state/pganalyze-collector.state --no-log-timestamps
-fi
-
-if [ "$1" = 'collector-verbose' ]; then
-  eval $CMD_PREFIX /home/pganalyze/collector --statefile=/state/pganalyze-collector.state --no-log-timestamps --verbose
-fi
-
-eval $CMD_PREFIX "$@"

--- a/main.go
+++ b/main.go
@@ -286,7 +286,7 @@ func main() {
 	flag.StringVar(&testSection, "test-section", "", "Tests a particular section of the config file, i.e. a specific server, and ignores all other config sections")
 	flag.BoolVar(&reloadRun, "reload", false, "Reloads the collector daemon thats running on the host")
 	flag.BoolVar(&noReload, "no-reload", false, "Disables automatic config reloading during a test run")
-	flag.BoolVarP(&logger.Verbose, "verbose", "v", false, "Outputs additional debugging information, use this if you're encoutering errors or other problems")
+	flag.BoolVarP(&logger.Verbose, "verbose", "v", false, "Outputs additional debugging information, use this if you're encountering errors or other problems")
 	flag.BoolVarP(&logger.Quiet, "quiet", "q", false, "Only outputs error messages to the logs and hides informational and warning messages")
 	flag.BoolVar(&logToSyslog, "syslog", false, "Write all log output to syslog instead of stderr (disabled by default)")
 	flag.BoolVar(&logToJSON, "json-logs", false, "Write all log output to stderr as newline delimited json (disabled by default, ignored if --syslog is set)")


### PR DESCRIPTION
With this change, `docker run` will take more args than just `test`, `test-explain`, or `collector`. This allows users to run things like `docker run --env-file pganalyze_collector.env quay.io/pganalyze/collector:stable test -v` to run the test with verbose mode.

----
(previous comment)

Please correct me if I'm doing something useless, though I always find it difficult to run with the debug log mode with a Docker setup. Maybe I can run `docker run .... quay.io/pganalyze/collector:stable /home/pganalyze/collector --statefile=/state/pganalyze-collector.state --no-log-timestamps --verbose`?
Not sure, but I thought it won't hurt to add some new command, so that we can do `docker run .... quay.io/pganalyze/collector:stable /home/pganalyze/collector collector-verbose` to launch the collector with the verbose log mode.