### PR TITLE
Allow pg_stat_statements failures and continue snapshot processing

### DIFF
--- a/input/full.go
+++ b/input/full.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/pganalyze/collector/input/postgres"
 	"github.com/pganalyze/collector/input/system"
+	"github.com/pganalyze/collector/scheduler"
 	"github.com/pganalyze/collector/state"
 	"github.com/pganalyze/collector/util"
 )
@@ -84,9 +85,10 @@ func CollectFull(ctx context.Context, server *state.Server, connection *sql.DB, 
 			logger.PrintError("Error calling pg_stat_statements_reset() as requested: %s", err)
 			err = nil
 		} else {
+			logger.PrintInfo("Successfully called pg_stat_statements_reset() for all queries, next reset in %d hours", server.Grant.Config.Features.StatementResetFrequency/scheduler.FullSnapshotsPerHour)
 			_, _, ts.ResetStatementStats, err = postgres.GetStatements(ctx, server, logger, connection, globalCollectionOpts, ts.Version, false, systemType)
 			if err != nil {
-				logger.PrintError("Error collecting pg_stat_statements: %s", err)
+				logger.PrintError("Error collecting pg_stat_statements after reset: %s", err)
 				err = nil
 			}
 		}

--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -185,15 +185,6 @@ func GetStatements(ctx context.Context, server *state.Server, logger *util.Logge
 
 	rows, err := stmt.QueryContext(ctx)
 	if err != nil {
-		var e *pq.Error
-		if errors.As(err, &e) && e.Code == "55000" { // object_not_in_prerequisite_state
-			if globalCollectionOpts.TestRun {
-				logger.PrintWarning("Could not collect query statistics: pg_stat_statements must be added to shared_preload_libraries")
-			}
-			// We intentionally don't return an error here, as we want the rest of
-			// processing to continue without requiring a reboot
-			return nil, nil, nil, nil
-		}
 		return nil, nil, nil, err
 	}
 	defer rows.Close()

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -73,6 +73,8 @@ func (group Group) ScheduleSecondary(ctx context.Context, runner func(context.Co
 	}()
 }
 
+const FullSnapshotsPerHour = 6
+
 func GetSchedulerGroups() (groups map[string]Group, err error) {
 	tenSecondInterval, err := cronexpr.Parse("*/10 * * * * * *")
 	if err != nil {


### PR DESCRIPTION
Some situations can cause pg_stat_statements data collection to fail, e.g. a timeout when the query text file got too large. Previously we treated the whole snapshot as having failed in such situations, only reporting an error snapshot to pganalyze, without any statistics.

This caused two issues:

(1) Unrelated data, such as schema statistics, got lost in the face of
    temporary pg_stat_statements issues

(2) The early return from the collection logic caused us to skip over
    the optional pg_stat_statements_reset() facility in the collector,
    which otherwise would have allowed the collector to recover from
    an overly large file (by resetting it, allowing the next collection
    to succeed)

Fix by treating pg_stat_statements errors as a collector error in the snapshot, but continuing afterwards instead of returning early.