### PR TITLE
Snapshot submission: Streamling wording for success message

### DIFF
--- a/output/compact.go
+++ b/output/compact.go
@@ -158,7 +158,7 @@ func submitCompactSnapshot(ctx context.Context, server *state.Server, collection
 					}
 				}
 				if len(details) > 0 {
-					logger.PrintInfo("Compact snapshots submitted: " + details)
+					logger.PrintInfo("Submitted compact snapshots successfully: " + details)
 				}
 				server.CompactLogTime = time.Now().Truncate(time.Minute)
 				server.CompactLogStats = make(map[string]uint8)

--- a/output/full.go
+++ b/output/full.go
@@ -188,7 +188,7 @@ func submitSnapshot(ctx context.Context, server *state.Server, collectionOpts st
 	if len(msg) > 0 && collectionOpts.TestRun {
 		logger.PrintInfo("  %s", msg)
 	} else if !quiet {
-		logger.PrintInfo("Submitted snapshot successfully")
+		logger.PrintInfo("Submitted full snapshot successfully")
 	}
 
 	return nil


### PR DESCRIPTION
This adjusts the recently changed compact snapshot information to be closer to what it was before, and adds "full" to the full snapshot message for clarity:

```
 I [default] Submitted compact snapshots successfully: 5 activity, 2 logs
 I [default] Submitted full snapshot successfully
```

Note that the compact snapshot message continues to emitted once per minute, not continuously as in past releases.