### PR TITLE
Support tracestate query tag with marginalia shape

### DIFF
--- a/logs/querysample/tags.go
+++ b/logs/querysample/tags.go
@@ -55,8 +55,8 @@ func parseTags(query string) map[string]string {
 
 func sqlcommenterFormat(str string) bool {
 	keyAndValue := strings.SplitN(str, "=", 2)
-        // With sqlcommenter format (key='value'), key shouldn't include ":"
-        return len(keyAndValue) == 2 && !strings.Contains(keyAndValue[0], ":")
+	// With sqlcommenter format (key='value'), key shouldn't include ":"
+	return len(keyAndValue) == 2 && !strings.Contains(keyAndValue[0], ":")
 }
 
 func decodeString(str string) string {

--- a/logs/querysample/tags.go
+++ b/logs/querysample/tags.go
@@ -55,13 +55,8 @@ func parseTags(query string) map[string]string {
 
 func sqlcommenterFormat(str string) bool {
 	keyAndValue := strings.SplitN(str, "=", 2)
-	if len(keyAndValue) == 2 {
-		// With sqlcommenter format (key='value'), key shouldn't include ":"
-		if !strings.Contains(keyAndValue[0], ":") {
-			return true
-		}
-	}
-	return false
+        // With sqlcommenter format (key='value'), key shouldn't include ":"
+        return len(keyAndValue) == 2 && !strings.Contains(keyAndValue[0], ":")
 }
 
 func decodeString(str string) string {

--- a/logs/querysample/tags.go
+++ b/logs/querysample/tags.go
@@ -30,7 +30,7 @@ func parseTags(query string) map[string]string {
 			continue
 		}
 		for _, part := range strings.Split(strings.TrimSpace(comment), ",") {
-			if strings.Contains(part, "=") {
+			if sqlcommenterFormat(part) {
 				// Parse sqlcommenter format (key='value')
 				keyAndValue := strings.SplitN(part, "=", 2)
 				// Remove surrounding single quotes (if present)
@@ -51,6 +51,17 @@ func parseTags(query string) map[string]string {
 		}
 	}
 	return tags
+}
+
+func sqlcommenterFormat(str string) bool {
+	keyAndValue := strings.SplitN(str, "=", 2)
+	if len(keyAndValue) == 2 {
+		// With sqlcommenter format (key='value'), key shouldn't include ":"
+		if !strings.Contains(keyAndValue[0], ":") {
+			return true
+		}
+	}
+	return false
 }
 
 func decodeString(str string) string {

--- a/logs/querysample/tags_test.go
+++ b/logs/querysample/tags_test.go
@@ -91,6 +91,16 @@ var parseTagsTests = []parseTagsTestpair{
 			"thud thud%thud'": "'% %  ",
 		},
 	},
+	{
+		"Query tag with key:value (marginalia) shape, with traceparent and tracestate",
+		"SELECT 1 /* traceparent:00-7dd3a87ae5bdacc0c56f3ba452a22fed-b39c2eabd3993833-01,tracestate:pganalyze=t:1701420562.550783 */",
+		map[string]string{"traceparent": "00-7dd3a87ae5bdacc0c56f3ba452a22fed-b39c2eabd3993833-01", "tracestate": "pganalyze=t:1701420562.550783"},
+	},
+	{
+		"Query tag with key='value' (sqlcommenter) shape, with traceparent and tracestate",
+		"SELECT 1 /* traceparent='00-7dd3a87ae5bdacc0c56f3ba452a22fed-b39c2eabd3993833-01',tracestate='pganalyze=t:1701420562.550783' */",
+		map[string]string{"traceparent": "00-7dd3a87ae5bdacc0c56f3ba452a22fed-b39c2eabd3993833-01", "tracestate": "pganalyze=t:1701420562.550783"},
+	},
 }
 
 func TestParseTags(t *testing.T) {

--- a/logs/querysample/tags_test.go
+++ b/logs/querysample/tags_test.go
@@ -101,6 +101,11 @@ var parseTagsTests = []parseTagsTestpair{
 		"SELECT 1 /* traceparent='00-7dd3a87ae5bdacc0c56f3ba452a22fed-b39c2eabd3993833-01',tracestate='pganalyze=t:1701420562.550783' */",
 		map[string]string{"traceparent": "00-7dd3a87ae5bdacc0c56f3ba452a22fed-b39c2eabd3993833-01", "tracestate": "pganalyze=t:1701420562.550783"},
 	},
+	{
+		"Query tag with key='value' (sqlcommenter) shape, with traceparent and tracestate (URL escaped)",
+		"SELECT 1 /* traceparent='00-7dd3a87ae5bdacc0c56f3ba452a22fed-b39c2eabd3993833-01',tracestate='pganalyze%3Dt%3A1701420562.550783' */",
+		map[string]string{"traceparent": "00-7dd3a87ae5bdacc0c56f3ba452a22fed-b39c2eabd3993833-01", "tracestate": "pganalyze=t:1701420562.550783"},
+	},
 }
 
 func TestParseTags(t *testing.T) {


### PR DESCRIPTION
While I was testing, I realized that tracestate is not propagating well when it's passed with marginalia shape.
This PR should fix it.
Honestly, I'm not 100% sure if "With sqlcommenter format (key='value'), key shouldn't include ":"" is accurate, but I think it's a safe assumption to make.

With sqlcommenter, the tracestate might be URL escaped, but let's assume that it's not for marginalia here.