### PR TITLE
CONTRIBUTING: Update docker installation steps to use official repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,22 @@ Note the integration tests require Docker, and will take a while to run through.
 To run step 5 from an Ubuntu 22.04 VM, do the following:
 
 ```
-sudo snap install docker
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get install ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin
+
+# Add support for ARM emulation
 sudo apt update
 sudo apt install qemu-user-static binfmt-support make
 


### PR DESCRIPTION
It appears Ubuntu's "docker" snap package has broken buildx support, so use upstream's official packages instead.