### PR TITLE
Fall back to managed identity with workload identity credential error

### DIFF
--- a/input/system/azure/logs.go
+++ b/input/system/azure/logs.go
@@ -77,24 +77,7 @@ func getEventHubConsumerClient(config config.ServerConfig) (*azeventhubs.Consume
 			return nil, fmt.Errorf("failed to set up client secret Azure credentials: %s", err)
 		}
 	} else {
-		workloadIdentityCredential, err := azidentity.NewWorkloadIdentityCredential(nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to set up workload identity Azure credentials: %s", err)
-		}
-		var managedIdentityOptions *azidentity.ManagedIdentityCredentialOptions
-		if config.AzureADClientID != "" {
-			managedIdentityOptions = &azidentity.ManagedIdentityCredentialOptions{
-				ID: azidentity.ClientID(config.AzureADClientID),
-			}
-		}
-		managedIdentityCredential, err := azidentity.NewManagedIdentityCredential(managedIdentityOptions)
-		if err != nil {
-			return nil, fmt.Errorf("failed to set up managed identity Azure credentials: %s", err)
-		}
-		credential, err = azidentity.NewChainedTokenCredential([]azcore.TokenCredential{
-			workloadIdentityCredential,
-			managedIdentityCredential,
-		}, nil)
+		credential, err = azidentity.NewDefaultAzureCredential(nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to use default Azure credentials: %s", err)
 		}


### PR DESCRIPTION
The current logic looks like falling back to the `NewManagedIdentityCredential` when `NewWorkloadIdentityCredential` isn't created, but actually it's not working like that way. Instead, it's erroring out when `NewWorkloadIdentityCredential` failed to be created, making it impossible for the VM deployed collector to try out managed identity credential (workload identity credential is used for AKS setup).

With this change, avoid raising an error and early return when `NewWorkloadIdentityCredential` returns an error. Instead, try `NewManagedIdentityCredential` then raise an error when both of them failed.

For the reference, if `AZURE_AD_CLIENT_ID` is not specified and multiple identities are assigned to the VM, you'd see the following error:

```
E [default] ERROR - Could not get logs through Azure Event Hub: failed to connect to the Event Hub management node: ChainedTokenCredential: failed to acquire a token.
Attempted credentials:
        ManagedIdentityCredential: no default identity is assigned to this resource
```

### Reference

https://github.com/Azure/azure-sdk-for-go/blob/837ae161d16716d778dd414fbf963f5756c9d5cc/sdk/azidentity/default_azure_credential.go#L62
https://pganalyze.com/docs/collector/settings#azure-settings
https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication?tabs=bash