### PR TITLE
Support TLS for syslog

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -140,10 +140,11 @@ type ServerConfig struct {
 	// Configures the collector to start a built-in syslog server that listens
 	// on the specified "hostname:port" for Postgres log messages
 	LogSyslogServer string `ini:"db_log_syslog_server"`
-	// For TLS support for syslog drain
-	LogSyslogServerCAPath   string `ini:"db_log_syslog_server_ca_path"`
-	LogSyslogServerCertPath string `ini:"db_log_syslog_server_cert_path"`
-	LogSyslogServerKeyPath  string `ini:"db_log_syslog_server_key_path"`
+	// For TLS support for syslog server
+	LogSyslogServerCAFile       string `ini:"db_log_syslog_server_ca_file"`
+	LogSyslogServerCertFile     string `ini:"db_log_syslog_server_cert_file"`
+	LogSyslogServerKeyFile      string `ini:"db_log_syslog_server_key_file"`
+	LogSyslogServerClientCAFile string `ini:"db_log_syslog_server_client_ca_file"`
 
 	// Configures the collector to use the "pg_read_file" (superuser) or
 	// "pganalyze.read_log_file" (helper) function to retrieve log data

--- a/config/config.go
+++ b/config/config.go
@@ -138,8 +138,12 @@ type ServerConfig struct {
 	LogDockerTail string `ini:"db_log_docker_tail"`
 
 	// Configures the collector to start a built-in syslog server that listens
-	// on the specifed "hostname:port" for Postgres log messages
+	// on the specified "hostname:port" for Postgres log messages
 	LogSyslogServer string `ini:"db_log_syslog_server"`
+	// For TLS support for syslog drain
+	LogSyslogServerCAPath   string `ini:"db_log_syslog_server_ca_path"`
+	LogSyslogServerCertPath string `ini:"db_log_syslog_server_cert_path"`
+	LogSyslogServerKeyPath  string `ini:"db_log_syslog_server_key_path"`
 
 	// Configures the collector to use the "pg_read_file" (superuser) or
 	// "pganalyze.read_log_file" (helper) function to retrieve log data

--- a/config/config.go
+++ b/config/config.go
@@ -141,10 +141,14 @@ type ServerConfig struct {
 	// on the specified "hostname:port" for Postgres log messages
 	LogSyslogServer string `ini:"db_log_syslog_server"`
 	// For TLS support for syslog server
-	LogSyslogServerCAFile       string `ini:"db_log_syslog_server_ca_file"`
-	LogSyslogServerCertFile     string `ini:"db_log_syslog_server_cert_file"`
-	LogSyslogServerKeyFile      string `ini:"db_log_syslog_server_key_file"`
-	LogSyslogServerClientCAFile string `ini:"db_log_syslog_server_client_ca_file"`
+	LogSyslogServerCAFile           string `ini:"db_log_syslog_server_ca_file"`
+	LogSyslogServerCertFile         string `ini:"db_log_syslog_server_cert_file"`
+	LogSyslogServerKeyFile          string `ini:"db_log_syslog_server_key_file"`
+	LogSyslogServerClientCAFile     string `ini:"db_log_syslog_server_client_ca_file"`
+	LogSyslogServerCAContents       string `ini:"db_log_syslog_server_ca_contents"`
+	LogSyslogServerCertContents     string `ini:"db_log_syslog_server_cert_contents"`
+	LogSyslogServerKeyContents      string `ini:"db_log_syslog_server_key_contents"`
+	LogSyslogServerClientCAContents string `ini:"db_log_syslog_server_client_ca_contents"`
 
 	// Configures the collector to use the "pg_read_file" (superuser) or
 	// "pganalyze.read_log_file" (helper) function to retrieve log data

--- a/config/read.go
+++ b/config/read.go
@@ -233,14 +233,17 @@ func getDefaultConfig() *ServerConfig {
 	if logSyslogServer := os.Getenv("LOG_SYSLOG_SERVER"); logSyslogServer != "" {
 		config.LogSyslogServer = logSyslogServer
 	}
-	if logSyslogServerCAPath := os.Getenv("LOG_SYSLOG_SERVER_CA_PATH"); logSyslogServerCAPath != "" {
-		config.LogSyslogServerCAPath = logSyslogServerCAPath
+	if logSyslogServerCAFile := os.Getenv("LOG_SYSLOG_SERVER_CA_FILE"); logSyslogServerCAFile != "" {
+		config.LogSyslogServerCAFile = logSyslogServerCAFile
 	}
-	if logSyslogServerCertPath := os.Getenv("LOG_SYSLOG_SERVER_CERT_PATH"); logSyslogServerCertPath != "" {
-		config.LogSyslogServerCertPath = logSyslogServerCertPath
+	if logSyslogServerCertFile := os.Getenv("LOG_SYSLOG_SERVER_CERT_FILE"); logSyslogServerCertFile != "" {
+		config.LogSyslogServerCertFile = logSyslogServerCertFile
 	}
-	if logSyslogServerKeyPath := os.Getenv("LOG_SYSLOG_SERVER_KEY_PATH"); logSyslogServerKeyPath != "" {
-		config.LogSyslogServerKeyPath = logSyslogServerKeyPath
+	if logSyslogServerKeyFile := os.Getenv("LOG_SYSLOG_SERVER_KEY_FILE"); logSyslogServerKeyFile != "" {
+		config.LogSyslogServerKeyFile = logSyslogServerKeyFile
+	}
+	if logSyslogServerClientCAFile := os.Getenv("LOG_SYSLOG_SERVER_CLIENT_CA_FILE"); logSyslogServerClientCAFile != "" {
+		config.LogSyslogServerClientCAFile = logSyslogServerClientCAFile
 	}
 	if alwaysCollectSystemData := os.Getenv("PGA_ALWAYS_COLLECT_SYSTEM_DATA"); alwaysCollectSystemData != "" {
 		config.AlwaysCollectSystemData = parseConfigBool(alwaysCollectSystemData)

--- a/config/read.go
+++ b/config/read.go
@@ -233,6 +233,15 @@ func getDefaultConfig() *ServerConfig {
 	if logSyslogServer := os.Getenv("LOG_SYSLOG_SERVER"); logSyslogServer != "" {
 		config.LogSyslogServer = logSyslogServer
 	}
+	if logSyslogServerCAPath := os.Getenv("LOG_SYSLOG_SERVER_CA_PATH"); logSyslogServerCAPath != "" {
+		config.LogSyslogServerCAPath = logSyslogServerCAPath
+	}
+	if logSyslogServerCertPath := os.Getenv("LOG_SYSLOG_SERVER_CERT_PATH"); logSyslogServerCertPath != "" {
+		config.LogSyslogServerCertPath = logSyslogServerCertPath
+	}
+	if logSyslogServerKeyPath := os.Getenv("LOG_SYSLOG_SERVER_KEY_PATH"); logSyslogServerKeyPath != "" {
+		config.LogSyslogServerKeyPath = logSyslogServerKeyPath
+	}
 	if alwaysCollectSystemData := os.Getenv("PGA_ALWAYS_COLLECT_SYSTEM_DATA"); alwaysCollectSystemData != "" {
 		config.AlwaysCollectSystemData = parseConfigBool(alwaysCollectSystemData)
 	}

--- a/config/read.go
+++ b/config/read.go
@@ -245,6 +245,18 @@ func getDefaultConfig() *ServerConfig {
 	if logSyslogServerClientCAFile := os.Getenv("LOG_SYSLOG_SERVER_CLIENT_CA_FILE"); logSyslogServerClientCAFile != "" {
 		config.LogSyslogServerClientCAFile = logSyslogServerClientCAFile
 	}
+	if logSyslogServerCAContents := os.Getenv("LOG_SYSLOG_SERVER_CA_CONTENTS"); logSyslogServerCAContents != "" {
+		config.LogSyslogServerCAContents = logSyslogServerCAContents
+	}
+	if logSyslogServerCertContents := os.Getenv("LOG_SYSLOG_SERVER_CERT_CONTENTS"); logSyslogServerCertContents != "" {
+		config.LogSyslogServerCertContents = logSyslogServerCertContents
+	}
+	if logSyslogServerKeyContents := os.Getenv("LOG_SYSLOG_SERVER_KEY_CONTENTS"); logSyslogServerKeyContents != "" {
+		config.LogSyslogServerKeyContents = logSyslogServerKeyContents
+	}
+	if logSyslogServerClientCAContents := os.Getenv("LOG_SYSLOG_SERVER_CLIENT_CA_CONTENTS"); logSyslogServerClientCAContents != "" {
+		config.LogSyslogServerClientCAContents = logSyslogServerClientCAContents
+	}
 	if alwaysCollectSystemData := os.Getenv("PGA_ALWAYS_COLLECT_SYSTEM_DATA"); alwaysCollectSystemData != "" {
 		config.AlwaysCollectSystemData = parseConfigBool(alwaysCollectSystemData)
 	}
@@ -592,6 +604,34 @@ func preprocessConfig(config *ServerConfig) (*ServerConfig, error) {
 
 	if config.CrunchyBridgeClusterID != "" {
 		config.LogPgReadFile = true
+	}
+
+	if config.LogSyslogServerCAContents != "" {
+		config.LogSyslogServerCAFile, err = writeValueToTempfile(config.LogSyslogServerCAContents)
+		if err != nil {
+			return config, err
+		}
+	}
+
+	if config.LogSyslogServerCertContents != "" {
+		config.LogSyslogServerCertFile, err = writeValueToTempfile(config.LogSyslogServerCertContents)
+		if err != nil {
+			return config, err
+		}
+	}
+
+	if config.LogSyslogServerKeyContents != "" {
+		config.LogSyslogServerKeyFile, err = writeValueToTempfile(config.LogSyslogServerKeyContents)
+		if err != nil {
+			return config, err
+		}
+	}
+
+	if config.LogSyslogServerClientCAContents != "" {
+		config.LogSyslogServerClientCAFile, err = writeValueToTempfile(config.LogSyslogServerClientCAContents)
+		if err != nil {
+			return config, err
+		}
 	}
 
 	return config, nil

--- a/input/system/selfhosted/logs.go
+++ b/input/system/selfhosted/logs.go
@@ -157,7 +157,7 @@ func SetupLogTails(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts
 			}
 		} else if server.Config.LogSyslogServer != "" {
 			logStream := setupLogTransformer(ctx, wg, server, globalCollectionOpts, prefixedLogger, parsedLogStream)
-			err := setupSyslogHandler(ctx, server.Config.LogSyslogServer, logStream, prefixedLogger)
+			err := setupSyslogHandler(ctx, server.Config, logStream, prefixedLogger)
 			if err != nil {
 				prefixedLogger.PrintError("ERROR - %s", err)
 			}

--- a/input/system/selfhosted/syslog_handler.go
+++ b/input/system/selfhosted/syslog_handler.go
@@ -54,7 +54,7 @@ func setupSyslogHandler(ctx context.Context, config config.ServerConfig, out cha
 		}
 
 		tlsConfig := tls.Config{
-			ClientAuth:   tls.RequireAndVerifyClientCert,
+			ClientAuth:   tls.VerifyClientCertIfGiven,
 			Certificates: []tls.Certificate{tlsCert},
 			ClientCAs:    caPool,
 		}

--- a/input/system/selfhosted/syslog_handler.go
+++ b/input/system/selfhosted/syslog_handler.go
@@ -27,6 +27,13 @@ func setupSyslogHandler(ctx context.Context, config config.ServerConfig, out cha
 	server := syslog.NewServer()
 	server.SetFormat(syslog.RFC5424)
 	server.SetHandler(handler)
+	// By default, go-syslog assumes that there will be the peer cert given by the client (of this syslog server) side
+	// as it's checking the PeerCertificates of the connection state.
+	// On the server side, this can be empty if Config.ClientAuth is not RequireAnyClientCert or
+	// RequireAndVerifyClientCert.
+	// https://github.com/mcuadros/go-syslog/blob/6f9fc1a03371148d69a5c32492cc902e3f8827bd/server.go#L82-L83
+	// https://pkg.go.dev/crypto/tls#ConnectionState
+	server.SetTlsPeerNameFunc(nil)
 
 	if config.LogSyslogServerCertFile != "" {
 		serverCaPool := x509.NewCertPool()


### PR DESCRIPTION
Add TLS support for Log Insights integration using syslog. Tested with Aiven + rsyslog integration with a self-signed certificate, it went well.

With this PR, we will introduce 4 config params:

* LogSyslogServerCAFile: optional, but required if the cert is self-signed
* LogSyslogServerCertFile: cert
* LogSyslogServerKeyFile: key
* LogSyslogServerClientCAFile: optional, but required if the client is providing a cert and it is self-signed

Preparing the cert part is a bit hand wavy here, but I think we can improve a document around here.

Docs PR: https://github.com/pganalyze/pganalyze-docs/pull/210