### PR TITLE
Add helm chart package support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -250,16 +250,6 @@ jobs:
         asset_name: pganalyze-collector_${{ steps.get_version.outputs.version }}_arm64.deb
         asset_content_type: application/octet-stream
 
-    - name: Upload helm package
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./pganalyze-collector-${{ steps.get_version.outputs.version }}.tgz
-        asset_name: pganalyze-collector-${{ steps.get_version.outputs.version }}.tgz
-        asset_content_type: application/octet-stream
-
   release_charts:
     needs: [release]
     runs-on: ubuntu-latest
@@ -286,7 +276,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: arn:aws:iam::123456789012:role/HelmChartPackageRole
+        role-to-assume: arn:aws:iam::793741702295:role/CollectorChartsPackage
         aws-region: us-east-1
 
     - name: Upload package to S3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,8 +119,32 @@ jobs:
           packages/tmp/pganalyze-collector_*_arm64.deb
         if-no-files-found: error
 
+  build_charts:
+    runs-on: ubuntu-latest
+    # ensure we don't release on create events for branches (only tags)
+    if: ${{ startsWith( github.ref, 'refs/tags' ) }}
+
+    steps:
+    - name: Install Helm
+      uses: azure/setup-helm@v4
+
+    - name: Check out code
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Create helm package
+      run: helm package contrib/helm/pganalyze-collector
+
+    - name: Upload packages as artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: packages
+        path: packages/tmp/pganalyze-collector-*.tgz
+        if-no-files-found: error
+
   release:
-    needs: [build, build_arm, build_packages]
+    needs: [build, build_arm, build_packages, build_charts]
     runs-on: ubuntu-latest
     # ensure we don't release on create events for branches (only tags)
     if: ${{ startsWith( github.ref, 'refs/tags' ) }}
@@ -218,4 +242,14 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./pganalyze-collector_${{ steps.get_version.outputs.version }}_arm64.deb
         asset_name: pganalyze-collector_${{ steps.get_version.outputs.version }}_arm64.deb
+        asset_content_type: application/octet-stream
+
+    - name: Upload helm package
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./pganalyze-collector-${{ steps.get_version.outputs.version }}.tgz
+        asset_name: pganalyze-collector-${{ steps.get_version.outputs.version }}.tgz
         asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,8 +139,9 @@ jobs:
     - name: Upload packages as artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: packages
-        path: packages/tmp/pganalyze-collector-*.tgz
+        name: charts
+        path: |
+          pganalyze-collector-*.tgz
         if-no-files-found: error
 
   release:
@@ -164,6 +165,11 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: packages
+
+    - name: Download helm package
+      uses: actions/download-artifact@v3
+      with:
+        name: charts
 
     - name: Get version and git version from tag
       id: get_version
@@ -253,3 +259,41 @@ jobs:
         asset_path: ./pganalyze-collector-${{ steps.get_version.outputs.version }}.tgz
         asset_name: pganalyze-collector-${{ steps.get_version.outputs.version }}.tgz
         asset_content_type: application/octet-stream
+
+  release_charts:
+    needs: [release]
+    runs-on: ubuntu-latest
+    # ensure we don't release on create events for branches (only tags)
+    if: ${{ startsWith( github.ref, 'refs/tags' ) }}
+
+    steps:
+    - name: Download helm package
+      uses: actions/download-artifact@v3
+      with:
+        name: charts
+
+    - name: Install Helm
+      uses: azure/setup-helm@v4
+
+    - name: Get version from tag
+      id: get_version
+      run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+
+    - name: Load the current index.yaml
+      run: curl -o index.yaml https://charts.pganalyze.com/index.yaml
+      continue-on-error: true
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: arn:aws:iam::123456789012:role/HelmChartPackageRole
+        aws-region: us-east-1
+
+    - name: Upload package to S3
+      run: aws s3 cp pganalyze-collector-${{ steps.get_version.outputs.version }}.tgz s3://charts.pganalyze.com/pganalyze-collector-${{ steps.get_version.outputs.version }}.tgz
+
+    - name: Create or update index.yaml
+      run: helm repo index . --merge index.yaml --url https://charts.pganalyze.com/
+
+    - name: Upload index.yaml to S3
+      run: aws s3 cp index.yaml s3://charts.pganalyze.com/index.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,8 +64,7 @@ Note the integration tests require Docker, and will take a while to run through.
 3. Once a new tag is pushed, GitHub Action Release will be kicked and create a new release (this will take about 2 hours, due to the package build and test)
 4. Modify the newly created release's description to match to CHANGELOG.md
 5. Release docker images using `make docker_release` (this requires access to the Quay.io push key, as well as "docker buildx" with QEMU emulation support, see below)
-6. Release a helm chart (see below)
-7. Sign and release packages using `make -C packages repo` (this requires access to the Keybase GPG key)
+6. Sign and release packages using `make -C packages repo` (this requires access to the Keybase GPG key)
 
 To run step 5 from an Ubuntu 22.04 VM, do the following:
 
@@ -95,25 +94,4 @@ sudo docker login -u="REPLACE_ME" -p="REPLACE_ME" quay.io
 git clone https://github.com/pganalyze/collector.git
 cd collector
 sudo make docker_release
-```
-
-For step 6. This can be done within the same VM as step 5 too:
-
-```
-# Preparing for helm package release (if you continue doing this within the same VM as `make docker_release``)
-# Alternatively, you can do this part locally too https://helm.sh/docs/intro/install/
-curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
-sudo apt-get install apt-transport-https --yes
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-sudo apt-get update
-sudo apt-get install helm
-
-# Get credentials from Quay.io
-helm registry login quay.io
-
-# Create a package
-helm package contrib/helm/pganalyze-collector
-
-# Push a package (replace the version x.y.z to the created version one)
-helm push pganalyze-collector-x.y.z.tgz oci://quay.io/pganalyze
 ```

--- a/README.md
+++ b/README.md
@@ -323,33 +323,15 @@ The script will also have the following environment variables set:
 Helm Chart
 ----------
 
-The pganalyze collector uses the OCI ([Open Container Initiative](https://opencontainers.org/)) registry to publish the Helm chart.
 You can install the Helm chart for the collector like the following:
 
 ```bash
-helm install pga-collector oci://quay.io/pganalyze/pganalyze-collector --values=myvalues.yml
+helm repo add pganalyze https://charts.pganalyze.com/
+helm install my-collector pganalyze/pganalyze-collector --values=myvalues.yml
 ```
 
-Note that this [requires the Helm CLI v3.8.0 and above](https://helm.sh/docs/topics/registries/#enabling-oci-support).
-
-You can find values for this chart using `helm show values oci://quay.io/pganalyze/pganalyze-collector`,
+You can find values for this chart using `helm show values pganalyze/pganalyze-collector`,
 or you can also find in the [README in the Helm chart directory](/contrib/helm/pganalyze-collector/README.md).
-
-You can also use the Terraform `helm_release` like the following:
-
-```
-resource "helm_release" "example" {
-  name        = "pga-collector"
-  namespace   = "pganalyze"
-  repository  = "oci://quay.io/pganalyze"
-  version     = "0.x.x"
-  chart       = "pganalyze-collector"
-
-  values = [
-    "${file("myvalues.yaml")}"
-  ]
-}
-```
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -320,6 +320,37 @@ The script will also have the following environment variables set:
 * PGA_ERROR_MESSAGE (error message, in the case of the error callback)
 
 
+Helm Chart
+----------
+
+The pganalyze collector uses the OCI ([Open Container Initiative](https://opencontainers.org/)) registry to publish the Helm chart.
+You can install the Helm chart for the collector like the following:
+
+```bash
+helm install pga-collector oci://quay.io/pganalyze/pganalyze-collector --values=myvalues.yml
+```
+
+Note that this [requires the Helm CLI v3.8.0 and above](https://helm.sh/docs/topics/registries/#enabling-oci-support).
+
+You can find values for this chart using `helm show values oci://quay.io/pganalyze/pganalyze-collector`,
+or you can also find in the [README in the Helm chart directory](/contrib/helm/pganalyze-collector/README.md).
+
+You can also use the Terraform `helm_release` like the following:
+
+```
+resource "helm_release" "example" {
+  name        = "pga-collector"
+  namespace   = "pganalyze"
+  repository  = "oci://quay.io/pganalyze"
+  version     = "0.x.x"
+  chart       = "pganalyze-collector"
+
+  values = [
+    "${file("myvalues.yaml")}"
+  ]
+}
+```
+
 License
 -------
 

--- a/contrib/helm/pganalyze-collector/values.yaml
+++ b/contrib/helm/pganalyze-collector/values.yaml
@@ -14,9 +14,12 @@ nameOverride: ""
 fullnameOverride: ""
 
 # -- Environment variables to be passed to the container
+# Config settings can be defined here, or can be defined via configMap + secret
 extraEnv: {}
+#   DB_HOST: your_database_host
 #   DB_NAME: your_database_name
-#   DB_ALL_NAMES: 1
+#   DB_ALL_NAMES: 1 (monitor all databases on the server)
+#   DB_USERNAME: your_monitoring_user
 
 configMap:
   # -- Specifies whether a config map should be created.
@@ -28,8 +31,10 @@ configMap:
   # -- Values to initialize the ConfigMap with.
   # Only applicable if create is true
   values: {}
+  #   DB_HOST: your_database_host
   #   DB_NAME: your_database_name
-  #   DB_ALL_NAMES: 1
+  #   DB_ALL_NAMES: 1 (monitor all databases on the server)
+  #   DB_USERNAME: your_monitoring_user
 
 secret:
   # -- Specifies whether a secret should be created.


### PR DESCRIPTION
Closes https://github.com/pganalyze/collector/issues/328

🗒️ I changed the direction quite a bit, so updating the PR summary here too.

With this PR, I added the following steps in the release CI:

* build_charts (new!): this creates a helm package of pganalyze-collector (e.g. pganalyze-collector-0.55.0.tgz)
* release (existing): added the section to upload created pganalyze-collector-0.55.0.tgz to the GitHub release
* release_charts (new!): this uploads a helm package, as well as update index.yaml file and update it to s3

In theory, CI will do the helm chart release for us so we don't need to do anything further.

I also did the following to set up charts.pganalyze.com:

* created s3 bucket and did the CNAME thingy, etc. to make sure the host works
* uploaded index.yaml, pganalyze-collector-0.55.0.tgz, and index.html manually to make sure that charts.pganalyze.com works

Other notes:

* looks like lots of companies are using https://github.com/helm/chart-releaser-action (e.g. datadog, new relic, etc.)
* above is convenient and does everything for us, we could consider adopting
  * with this, the package will be placed in GitHub release
  * the website is hosted using GitHub pages
  
I'm currently kinda doing these github action steps manually, but I can also remove lots things because our case is really simple.

<details>
  <summary>previous description</summary>
I admit that I don't have much knowledge around here so maybe I'm saying something pretty off, though at least publishing the chart worked (currently publishing as a private so it doesn't work for everyone yet).

Lukas said that we might be able to push this chart to the same place as the current collector docker image, like `quay.io/pganalyze/collector`. However, I'm not quite sure about this from several points, and I'd say that we might be okay to publish the helm chart under `quay.io/pganalyze/pganalyze-collector`:

* In quay.io UI, I don't really see how this can be supported. You can't `helm pull quay.io/pganalyze/collector` and also can't `docker pull quay.io/pganalyze/pganalyze-collector`, though I don't see how this can be coexist in the same "repo" and easily tell which one is in which state in the UI, so it might be safe to publish this separately
* when you run `helm package contrib/helm/pganalyze-collector`, it will automatically crate a package using the name `pganalyze-collector`, so if we want to publish the helm chart with `pganalyze/collector`, we need to change lots of place under `contrib/helm` to support it
</details>