### PR TITLE
Rename rel stats collection func for Citus not to use ext

### DIFF
--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -195,7 +195,7 @@ func GetRelationStats(ctx context.Context, db *sql.DB, postgresVersion state.Pos
 		return
 	}
 
-	relStats, err = handleRelationStatsCitus(ctx, db, relStats, postgresVersion, server)
+	relStats, err = handleRelationStatsAux(ctx, db, relStats, postgresVersion, server)
 
 	return
 }
@@ -236,7 +236,7 @@ func GetIndexStats(ctx context.Context, db *sql.DB, postgresVersion state.Postgr
 		return
 	}
 
-	indexStats, err = handleIndexStatsCitus(ctx, db, indexStats, postgresVersion, server)
+	indexStats, err = handleIndexStatsAux(ctx, db, indexStats, postgresVersion, server)
 
 	return
 }

--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -195,7 +195,7 @@ func GetRelationStats(ctx context.Context, db *sql.DB, postgresVersion state.Pos
 		return
 	}
 
-	relStats, err = handleRelationStatsExt(ctx, db, relStats, postgresVersion, server)
+	relStats, err = handleRelationStatsCitus(ctx, db, relStats, postgresVersion, server)
 
 	return
 }
@@ -236,7 +236,7 @@ func GetIndexStats(ctx context.Context, db *sql.DB, postgresVersion state.Postgr
 		return
 	}
 
-	indexStats, err = handleIndexStatsExt(ctx, db, indexStats, postgresVersion, server)
+	indexStats, err = handleIndexStatsCitus(ctx, db, indexStats, postgresVersion, server)
 
 	return
 }

--- a/input/postgres/relation_stats_aux.go
+++ b/input/postgres/relation_stats_aux.go
@@ -21,7 +21,7 @@ SELECT logicalrelid::oid,
  WHERE ($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)
 `
 
-func handleRelationStatsCitus(ctx context.Context, db *sql.DB, relStats state.PostgresRelationStatsMap, postgresVersion state.PostgresVersion, server *state.Server) (state.PostgresRelationStatsMap, error) {
+func handleRelationStatsAux(ctx context.Context, db *sql.DB, relStats state.PostgresRelationStatsMap, postgresVersion state.PostgresVersion, server *state.Server) (state.PostgresRelationStatsMap, error) {
 	if postgresVersion.IsCitus && !server.Config.DisableCitusSchemaStats {
 		stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+citusRelationSizeSQL)
 		if err != nil {
@@ -105,7 +105,7 @@ GROUP BY
   oid;
 `
 
-func handleIndexStatsCitus(ctx context.Context, db *sql.DB, idxStats state.PostgresIndexStatsMap, postgresVersion state.PostgresVersion, server *state.Server) (state.PostgresIndexStatsMap, error) {
+func handleIndexStatsAux(ctx context.Context, db *sql.DB, idxStats state.PostgresIndexStatsMap, postgresVersion state.PostgresVersion, server *state.Server) (state.PostgresIndexStatsMap, error) {
 	if postgresVersion.IsCitus && !server.Config.DisableCitusSchemaStats {
 		stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+citusIndexSizeSQL)
 		if err != nil {

--- a/input/postgres/relation_stats_citus.go
+++ b/input/postgres/relation_stats_citus.go
@@ -21,7 +21,7 @@ SELECT logicalrelid::oid,
  WHERE ($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)
 `
 
-func handleRelationStatsExt(ctx context.Context, db *sql.DB, relStats state.PostgresRelationStatsMap, postgresVersion state.PostgresVersion, server *state.Server) (state.PostgresRelationStatsMap, error) {
+func handleRelationStatsCitus(ctx context.Context, db *sql.DB, relStats state.PostgresRelationStatsMap, postgresVersion state.PostgresVersion, server *state.Server) (state.PostgresRelationStatsMap, error) {
 	if postgresVersion.IsCitus && !server.Config.DisableCitusSchemaStats {
 		stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+citusRelationSizeSQL)
 		if err != nil {
@@ -105,7 +105,7 @@ GROUP BY
   oid;
 `
 
-func handleIndexStatsExt(ctx context.Context, db *sql.DB, idxStats state.PostgresIndexStatsMap, postgresVersion state.PostgresVersion, server *state.Server) (state.PostgresIndexStatsMap, error) {
+func handleIndexStatsCitus(ctx context.Context, db *sql.DB, idxStats state.PostgresIndexStatsMap, postgresVersion state.PostgresVersion, server *state.Server) (state.PostgresIndexStatsMap, error) {
 	if postgresVersion.IsCitus && !server.Config.DisableCitusSchemaStats {
 		stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+citusIndexSizeSQL)
 		if err != nil {


### PR DESCRIPTION
Some refactor that I would like to split from https://github.com/pganalyze/collector/pull/476

Currently, in order to support collecting relation stats information for Citus, the name "ext" is used, like `handleRelationStatsExt`. In https://github.com/pganalyze/collector/pull/476, I would like to use the term `RelationStatsExtended` for the extended statistic info.
To avoid these two mixing together, I would like to rename the Citus one specific to Citus.