### PR TITLE
Docker image: Don't reload when calling "test" command

### DIFF
--- a/contrib/docker-entrypoint.sh
+++ b/contrib/docker-entrypoint.sh
@@ -12,7 +12,7 @@ if [ $(id -u) = 0 ]; then
 fi
 
 if [ "$1" = 'test' ]; then
-  eval $CMD_PREFIX /home/pganalyze/collector --test --no-log-timestamps
+  eval $CMD_PREFIX /home/pganalyze/collector --test --no-log-timestamps --no-reload
 fi
 
 if [ "$1" = 'test-explain' ]; then


### PR DESCRIPTION
When we changed --test to automatically reload, we forgot to explicitly avoid that in the case of the Docker image. In the Docker situation we would typically find two separate containers during a test, the one used for the test, and the regular container running in the background. Thus, the test won't be able to reload the PID that's running in a separate container / cgroups namespace.