### PR TITLE
Warn in guided setup integration test when collector warnings present

### DIFF
--- a/integration_test/Makefile
+++ b/integration_test/Makefile
@@ -254,6 +254,11 @@ guided-setup:
 		cat guided-setup-snapshot.log.out; \
 		exit 1; \
 	fi
+	if grep -q -E '[0-9]{4}\/[0-9]{2}\/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2} W ' guided-setup-snapshot.log.out; then \
+		echo "expected no warnings in collector log; test failed:"; \
+		cat guided-setup-snapshot.log.out; \
+		exit 1; \
+	fi
 	diff -Nau guided-setup.snapshot-subset.json.expected guided-setup.snapshot-subset.json.out && echo 'success'
 
 installer:


### PR DESCRIPTION
We don't expect any warnings and should confirm that's the
case. Warnings will often also cause a test failure, but that can be
hard to track down since the collector log is a number of lines
earlier than the diff failure output, and there's a lot of output in
integration tests.
