### PR TITLE
Build and release arm build using ubicloud

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       id: go
 
     - name: Set up protoc
-      uses: pganalyze/setup-protoc@ab6203da1c3118e4406048171b09238ad31ad73e
+      uses: pganalyze/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f
       with:
         version: 3.14.0
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,43 @@ jobs:
         name: pganalyze-collector-linux-amd64
         path: pganalyze-collector-linux-amd64
 
+  build_arm:
+    runs-on: ubicloud-standard-2-arm
+    permissions: {}
+    # ensure we don't release on create events for branches (only tags)
+    if: ${{ startsWith( github.ref, 'refs/tags' ) }}
+
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.21
+      id: go
+
+    - name: Set up protoc
+      uses: pganalyze/setup-protoc@ab6203da1c3118e4406048171b09238ad31ad73e
+      with:
+        version: 3.14.0
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Check out code
+      uses: actions/checkout@v3
+      with:
+        submodules: true
+
+    - name: Runs tests
+      run: |
+        make build OUTFILE=pganalyze-collector-linux-arm64
+        make test
+        DOCKER_BUILDKIT=1 make integration_test
+
+    - name: Upload build
+      uses: actions/upload-artifact@v2
+      with:
+        name: pganalyze-collector-linux-arm64
+        path: pganalyze-collector-linux-arm64
+
   build_packages:
     # Use older Ubuntu release to ensure availability of CGroupsv1 (which are necessary
     # currently to support older systemd on some of the test containers)
@@ -83,7 +120,7 @@ jobs:
         if-no-files-found: error
 
   release:
-    needs: [build, build_packages]
+    needs: [build, build_arm, build_packages]
     runs-on: ubuntu-latest
     # ensure we don't release on create events for branches (only tags)
     if: ${{ startsWith( github.ref, 'refs/tags' ) }}
@@ -93,6 +130,11 @@ jobs:
       uses: actions/download-artifact@v3
       with:
         name: pganalyze-collector-linux-amd64
+
+    - name: Download arm build
+      uses: actions/download-artifact@v3
+      with:
+        name: pganalyze-collector-linux-arm64
 
     - name: Download build packages
       uses: actions/download-artifact@v3
@@ -125,6 +167,17 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: ./pganalyze-collector-linux-amd64
         asset_name: pganalyze-collector-linux-amd64
+        asset_content_type: application/octet-stream
+
+    - name: Upload release build (arm)
+      id: upload-release-build-arm
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./pganalyze-collector-linux-arm64
+        asset_name: pganalyze-collector-linux-arm64
         asset_content_type: application/octet-stream
 
     - name: Upload release build package (RPM, x86-64)

--- a/integration_test/Makefile
+++ b/integration_test/Makefile
@@ -13,9 +13,16 @@ docker_run_cmd = docker run --name pganalyze-collector-test \
   -d pganalyze-collector-test $(1)
 docker_run_cmd_postgres = $(call docker_run_cmd,postgres -c pg_stat_statements.track_utility=off)
 
-.PHONY: pg10 pg11 pg12 pg13 pg14 pg15 pg16 citus reload guided-setup installer
+TARGETS := pg10 pg11 pg12 pg13 pg14 pg15 pg16 reload guided-setup installer
 
-all: pg10 pg11 pg12 pg13 pg14 pg15 pg16 citus reload guided-setup installer
+# Citus doesn't release ARM images, thus skip on ARM
+ifneq ($(shell uname -p), arm)
+	TARGETS += citus
+endif
+
+.PHONY: all $(TARGETS)
+
+all: $(TARGETS)
 
 pg10:
 	docker build -f Dockerfile.test-pg10 $(DOCKER_BUILD_OPTS)


### PR DESCRIPTION
Currently, we have an undocumented release step 7, to build arm build and upload to the release:

https://github.com/pganalyze/collector/blob/25220c7e66c7e60aed5122aaae706245c23bc467/CONTRIBUTING.md#release

With this PR, we use Ubicloud to build the collector on the arm runner and upload it, within the release GitHub Action.

* Updated `setup-protoc` version to use `149f6c87b92550901b26acd1632e11c3662e381f`, which support setting up protoc with arm
* Skip Citus integration test with arm, since the Citus base docker image doesn't have arm64 arch version (https://hub.docker.com/r/citusdata/citus/tags)