### PR TITLE
CHANGELOG: Fix typo in release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Track extended statistics created with `CREATE STATISTICS`
   - This is utilized by pganalyze Index Advisor to better detect functional dependencies, and improve multi-column index recommendations
-  - To allow the collector to access external statistics data you need to create the new "get_relation_stats_ext" helper function (see https://github.com/pganalyze/collector?tab=readme-ov-file#setting-up-a-restricted-monitoring-user)
+  - To allow the collector to access extended statistics data you need to create the new "get_relation_stats_ext" helper function (see https://github.com/pganalyze/collector?tab=readme-ov-file#setting-up-a-restricted-monitoring-user)
 * Docker image: Don't reload when calling "test" command
 
 


### PR DESCRIPTION
"external" => "extended" (I got that wrong in my suggestion on the release PR)