### PR TITLE
Package build: Pin dotenv version to last one that supports Ruby 2.7

### DIFF
--- a/packages/src/Dockerfile.build.deb-systemd
+++ b/packages/src/Dockerfile.build.deb-systemd
@@ -13,7 +13,7 @@ RUN apt-get update -qq \
   && apt-get install -y -q build-essential curl git ruby ruby-dev
 
 # FPM
-RUN gem install public_suffix -v 4.0.7 && gem install fpm -v 1.14.1
+RUN gem install public_suffix -v 4.0.7 && gem install dotenv -v 2.8.1 && gem install fpm -v 1.14.1
 
 # Golang
 RUN curl -o go.tar.gz -sSL "https://go.dev/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"

--- a/packages/src/Dockerfile.build.rpm-systemd
+++ b/packages/src/Dockerfile.build.rpm-systemd
@@ -9,10 +9,12 @@ ENV ROOT_DIR /root
 ENV SOURCE_DIR /source
 
 # Packages required for both building and packaging
-RUN yum install -y centos-release-scl scl-utils tar make git rpmdevtools gcc && yum install -y rh-ruby27 rh-ruby27-ruby-devel
+#
+# This uses Ruby 3.0 since 2.7 (which still used for Debian builds) does not work with fpm: https://github.com/jordansissel/fpm/issues/2048#issuecomment-1972196104
+RUN yum install -y centos-release-scl scl-utils tar make git rpmdevtools gcc && yum install -y rh-ruby30 rh-ruby30-ruby-devel
 
 # FPM
-RUN source scl_source enable rh-ruby27 && gem install fpm -v 1.14.1
+RUN source scl_source enable rh-ruby30 && gem install fpm -v 1.14.1
 
 # Golang
 RUN curl -o go.tar.gz -sSL "https://go.dev/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"


### PR DESCRIPTION
This is an interim fix until we can upgrade the Ruby version used for fpm in the build scripts. That is slightly complicated due to the base OS being intentionally old (to keep an older glibc base version).