### PR TITLE
Only collect extended stats for postgres version 12 and above

### DIFF
--- a/input/postgres/schema.go
+++ b/input/postgres/schema.go
@@ -141,12 +141,14 @@ func collectSchemaData(ctx context.Context, collectionOpts state.CollectionOpts,
 			ps.SchemaStats[databaseOid].ColumnStats[k] = v
 		}
 
-		newRelationStatsExtended, err := GetRelationStatsExtended(ctx, logger, db, postgresVersion, server, collectionOpts, systemType, dbName)
-		if err != nil {
-			return ps, ts, fmt.Errorf("error collecting extended relation statistics: %s", err)
-		}
-		for k, v := range newRelationStatsExtended {
-			ps.SchemaStats[databaseOid].RelationStatsExtended[k] = v
+		if postgresVersion.Numeric >= state.PostgresVersion12 {
+			newRelationStatsExtended, err := GetRelationStatsExtended(ctx, logger, db, postgresVersion, server, collectionOpts, systemType, dbName)
+			if err != nil {
+				return ps, ts, fmt.Errorf("error collecting extended relation statistics: %s", err)
+			}
+			for k, v := range newRelationStatsExtended {
+				ps.SchemaStats[databaseOid].RelationStatsExtended[k] = v
+			}
 		}
 	}
 


### PR DESCRIPTION
The view `pg_stats_ext` was introduced from Postgres 12, so let's only try to collect extended stats data if the version is 12 and above.
https://www.postgresql.org/docs/current/view-pg-stats-ext.html