### PR TITLE
Syslog handler: Allow leading spaces before parts regexp

### DIFF
--- a/input/system/selfhosted/syslog_handler.go
+++ b/input/system/selfhosted/syslog_handler.go
@@ -16,7 +16,7 @@ import (
 	"github.com/pganalyze/collector/util"
 )
 
-var logLinePartsRegexp = regexp.MustCompile(`^\[(\d+)-(\d+)\] (.*)`)
+var logLinePartsRegexp = regexp.MustCompile(`^\s*\[(\d+)-(\d+)\] (.*)`)
 var logLineNumberPartsRegexp = regexp.MustCompile(`^\[(\d+)-(\d+)\]$`)
 
 func setupSyslogHandler(ctx context.Context, config config.ServerConfig, out chan<- SelfHostedLogStreamItem, prefixedLogger *util.Logger) error {


### PR DESCRIPTION
When configuring rsyslogd for RFC5424 output with the RSYSLOG_SyslogProtocol23Format template, it adds a leading space that we didn't anticipate correctly.