### PR TITLE
Fix typo with version in helm chart

### DIFF
--- a/contrib/helm/pganalyze-collector/Chart.yaml
+++ b/contrib/helm/pganalyze-collector/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pganalyze-collector
-version: 0.53.1
+version: 0.54.0
 appVersion: "v0.54.0"
 type: application
 description: pganalyze statistics collector


### PR DESCRIPTION
Just realized that I forgot to fix one typo (I forgot to update there to 0.54.0)