### PR TITLE
Accept PGA_API_BASE_URL env var in addition to PGA_API_BASEURL

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -55,6 +55,11 @@ func getDefaultConfig() *ServerConfig {
 	if apiKey := os.Getenv("PGA_API_KEY"); apiKey != "" {
 		config.APIKey = apiKey
 	}
+	// Since there's a discrepancy here between the config file key (api_base_url) and the
+	// env var key (PGA_API_BASEURL), also accept PGA_API_BASE_URL to make our lives easier.
+	if apiBaseURL := os.Getenv("PGA_API_BASE_URL"); apiBaseURL != "" {
+		config.APIBaseURL = apiBaseURL
+	}
 	if apiBaseURL := os.Getenv("PGA_API_BASEURL"); apiBaseURL != "" {
 		config.APIBaseURL = apiBaseURL
 	}

--- a/config/read.go
+++ b/config/read.go
@@ -55,12 +55,13 @@ func getDefaultConfig() *ServerConfig {
 	if apiKey := os.Getenv("PGA_API_KEY"); apiKey != "" {
 		config.APIKey = apiKey
 	}
-	// Since there's a discrepancy here between the config file key (api_base_url) and the
-	// env var key (PGA_API_BASEURL), also accept PGA_API_BASE_URL to make our lives easier.
-	if apiBaseURL := os.Getenv("PGA_API_BASE_URL"); apiBaseURL != "" {
+	// Since there used to be a discrepancy here between the config file key
+	// (api_base_url) and the env var key (PGA_API_BASEURL), also accept the old
+	// spelling (but prefer the new).
+	if apiBaseURL := os.Getenv("PGA_API_BASEURL"); apiBaseURL != "" {
 		config.APIBaseURL = apiBaseURL
 	}
-	if apiBaseURL := os.Getenv("PGA_API_BASEURL"); apiBaseURL != "" {
+	if apiBaseURL := os.Getenv("PGA_API_BASE_URL"); apiBaseURL != "" {
 		config.APIBaseURL = apiBaseURL
 	}
 	if systemID := os.Getenv("PGA_API_SYSTEM_ID"); systemID != "" {


### PR DESCRIPTION
Currently, the env var corresponding to the config setting
api_base_url is PGA_API_BASEURL, which has different spacing.

Allow both (but prefer the documented version).
