### PR TITLE
Fix spurious errors on Heroku

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -736,7 +736,7 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 			return conf, fmt.Errorf("Configuration file is empty, please edit %s and reload the collector", filename)
 		}
 	} else {
-		if os.Getenv("DYNO") != "" && os.Getenv("PORT") != "" {
+		if util.IsHeroku() {
 			for _, kv := range os.Environ() {
 				parts := strings.SplitN(kv, "=", 2)
 				parsedKey := parts[0]

--- a/main.go
+++ b/main.go
@@ -230,7 +230,7 @@ func run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 
 	if hasAnyLogsEnabled {
 		runner.SetupLogCollection(ctx, wg, servers, globalCollectionOpts, logger, hasAnyHeroku, hasAnyGoogleCloudSQL, hasAnyAzureDatabase, hasAnyTembo)
-	} else if os.Getenv("DYNO") != "" && os.Getenv("PORT") != "" {
+	} else if util.IsHeroku() {
 		// Even if logs are deactivated, Heroku still requires us to have a functioning web server
 		util.SetupHttpHandlerDummy()
 	}
@@ -630,6 +630,9 @@ func checkOneInitialCollectionStatus(ctx context.Context, server *state.Server, 
 }
 
 func Reload(logger *util.Logger) {
+	if util.IsHeroku() {
+		return
+	}
 	pid, err := util.Reload()
 	if err != nil {
 		logger.PrintError("Error: Failed to reload collector: %s\n", err)

--- a/state/state_file.go
+++ b/state/state_file.go
@@ -32,7 +32,9 @@ func ReadStateFile(servers []*Server, globalCollectionOpts CollectionOpts, logge
 
 	file, err := os.Open(globalCollectionOpts.StateFilename)
 	if err != nil {
-		logger.PrintVerbose("Did not open state file: %s", err)
+		if !util.IsHeroku() {
+			logger.PrintVerbose("Did not open state file: %s", err)
+		}
 		return
 	}
 	decoder := gob.NewDecoder(file)

--- a/util/heroku.go
+++ b/util/heroku.go
@@ -1,0 +1,7 @@
+package util
+
+import "os"
+
+func IsHeroku() bool {
+	return os.Getenv("DYNO") != "" && os.Getenv("PORT") != ""
+}


### PR DESCRIPTION
 - don't complain about a missing state file: this is expected since
   dynos are stateless and there's unlikely to have been a previous
   run of the collector in the same dyno

 - do nothing on reload: our reload mechanism looks for a running
   collector process, but on heroku, that's going to be in a different
   dyno
