### PR TITLE
Tembo Logs: Filter Out App Service Logs

### DIFF
--- a/input/system/tembo/logs.go
+++ b/input/system/tembo/logs.go
@@ -44,7 +44,8 @@ func connectWebsocket(ctx context.Context, logger *util.Logger, server *state.Se
 	connCtx, cancelConn := context.WithCancel(ctx)
 
 	// Construct query for Tembo Logs API
-	query := "{tembo_instance_id=\"" + server.Config.TemboInstanceID + "\"}"
+	// Note this does not yet handle multiple replicas in cases like HA
+	query := "{tembo_instance_id=\"" + server.Config.TemboInstanceID + "\", pod=\"" + server.Config.TemboNamespace + "-1" + "\"}"
 
 	// URI encode query
 	encodedQuery := url.QueryEscape(query)


### PR DESCRIPTION
At Tembo, we recently started to collect and serve logs from `AppServices` in a Tembo Instance's namespace alongside Postgres logs. This means that the collector will receive those logs by default, which is not what we want.

This PR resolves the issue by filtering the logs we receive by the Postgres pod name.