### PR TITLE
Add more verbose output for the --test-explain flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,8 +148,11 @@ func run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 					if err != nil {
 						prefixedLogger.PrintError("Failed to run test explain: %s", err)
 						success = false
+					} else {
+						prefixedLogger.PrintInfo("Emitted test explain; check pganalyze EXPLAIN Plans page for result")
 					}
 				}
+
 				testRunSuccess <- success
 			} else if globalCollectionOpts.TestRunLogs {
 				success := doLogTest(ctx, servers, globalCollectionOpts, logger)


### PR DESCRIPTION
Currently, we only surface errors, and produce no output on success
(or if EXPLAIN-related settings are disabled).

Update the check to emit output on success and guidance when the
settings are disabled.
