### PR TITLE
Update pg_stat_statements logic to match field names in Postgres 17

### DIFF
--- a/state/postgres_version.go
+++ b/state/postgres_version.go
@@ -8,6 +8,8 @@ const (
 	PostgresVersion13 = 130000
 	PostgresVersion14 = 140000
 	PostgresVersion15 = 150000
+	PostgresVersion16 = 160000
+	PostgresVersion17 = 170000
 
 	// MinRequiredPostgresVersion - We require PostgreSQL 10 or newer
 	MinRequiredPostgresVersion = PostgresVersion10


### PR DESCRIPTION
Whilst 17 is still in development, this change landed a while ago, so its likely to stay in, and I think we're okay to take this for now (since otherwise statement stats don't work on 17 at all).