### PR TITLE
Amazon RDS/Aurora IAM Authentication: Default to DB port 5432

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -415,6 +415,15 @@ func (config ServerConfig) GetDbPort() int {
 	return config.DbPort
 }
 
+// GetDbPortOrDefault - Gets the database port from the given configuration, otherwise returns the default Postgres port (5432)
+func (config ServerConfig) GetDbPortOrDefault() int {
+	port := config.GetDbPort()
+	if port == 0 {
+		port = 5432
+	}
+	return port
+}
+
 // GetDbUsername - Gets the database hostname from the given configuration
 func (config ServerConfig) GetDbUsername() string {
 	if config.DbURL != "" {

--- a/input/postgres/establish_connection.go
+++ b/input/postgres/establish_connection.go
@@ -53,7 +53,7 @@ func connectToDb(ctx context.Context, config config.ServerConfig, logger *util.L
 			return nil, err
 		}
 		if dbToken, err := rdsutils.BuildAuthToken(
-			fmt.Sprintf("%s:%d", config.GetDbHost(), config.GetDbPort()),
+			fmt.Sprintf("%s:%d", config.GetDbHost(), config.GetDbPortOrDefault()),
 			config.AwsRegion,
 			config.GetDbUsername(),
 			sess.Config.Credentials,

--- a/util/awsutil/rds.go
+++ b/util/awsutil/rds.go
@@ -104,7 +104,7 @@ func FindRdsInstance(config config.ServerConfig, sess *session.Session) (*rds.DB
 	// If neither instance ID or cluster ID were specified, but we still have
 	// an RDS system type, attempt to find the instance based on the hostname
 	// (this is a long shot, but there are some cases where this helps)
-	return findRdsInstanceByHostAndPort(config.GetDbHost(), int64(config.GetDbPort()), svc)
+	return findRdsInstanceByHostAndPort(config.GetDbHost(), int64(config.GetDbPortOrDefault()), svc)
 }
 
 func GetRdsParameter(group *rds.DBParameterGroupStatus, name string, svc *rds.RDS) (parameter *rds.Parameter, err error) {


### PR DESCRIPTION
Previously IAM authentication would fail with "PAM authentication failed" when the port was not explicitly set in the collector configuration.

This instead falls back to the default (5432), which is the typical port used on Amazon RDS and Aurora.

In passing use the same logic in the fallback logic for identifying RDS instances by their hostname, since the DB instance list also always includes the port, and this was likely broken as well if the port wasn't set explicitly.