### PR TITLE
Update links that point to README to point to official docs instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 
 * Track extended statistics created with `CREATE STATISTICS`
   - This is utilized by pganalyze Index Advisor to better detect functional dependencies, and improve multi-column index recommendations
-  - To allow the collector to access extended statistics data you need to create the new "get_relation_stats_ext" helper function (see https://github.com/pganalyze/collector?tab=readme-ov-file#setting-up-a-restricted-monitoring-user)
+  - To allow the collector to access extended statistics data you need to create the new "get_relation_stats_ext" helper function (see https://pganalyze.com/docs/install/troubleshooting/ext_stats_helper)
 * Docker image: Don't reload when calling "test" command
 
 
@@ -879,7 +879,7 @@
 * Add helper for log-based EXPLAIN access and use if available
   - This lets us avoid granting the pganalyze user any access to the data to follow
     the principle of least privilege
-  - See https://github.com/pganalyze/collector#setting-up-log-explain-helper
+  - See https://pganalyze.com/docs/explain/setup/log_explain
 * Avoid corrupted snapshots when OIDs get reused across databases
   - This would have shown as data not being visible in pganalyze,
     particularly for servers with many databases where tables were

--- a/input/postgres/buffercache.go
+++ b/input/postgres/buffercache.go
@@ -78,8 +78,8 @@ func GetBuffercache(ctx context.Context, logger *util.Logger, db *sql.DB, system
 		sourceTable = "pganalyze.get_buffercache()"
 	} else {
 		if !connectedAsSuperUser(ctx, db, systemType) && !connectedAsMonitoringRole(ctx, db) {
-			logger.PrintInfo("Warning: You are not connecting as superuser. Please setup" +
-				" the monitoring helper functions (https://github.com/pganalyze/collector#setting-up-a-restricted-monitoring-user)" +
+			logger.PrintInfo("Warning: You are not connecting as superuser. Please set up" +
+				" the additional monitoring helper functions (https://github.com/pganalyze/collector/?tab=readme-ov-file#additional-setup)" +
 				" or connect as superuser to run the buffercache report.")
 		}
 		sourceTable = "public.pg_buffercache"

--- a/input/postgres/explain.go
+++ b/input/postgres/explain.go
@@ -72,7 +72,7 @@ func RunExplain(ctx context.Context, server *state.Server, inputs []state.Postgr
 		}
 		if hasPermErr && !connectedAsSuperUser(ctx, db, server.Config.SystemType) {
 			logger.PrintInfo("Warning: pganalyze.explain() helper function not found in database \"%s\". Please set up"+
-				" the monitoring helper functions (https://github.com/pganalyze/collector#setting-up-a-restricted-monitoring-user)"+
+				" the monitoring helper functions (https://pganalyze.com/docs/explain/setup/log_explain/01_create_helper_functions)"+
 				" in every database you want to monitor to avoid permissions issues when running log-based EXPLAIN.", dbName)
 		}
 

--- a/input/postgres/relation_bloat.go
+++ b/input/postgres/relation_bloat.go
@@ -262,8 +262,8 @@ func GetBloatStats(ctx context.Context, logger *util.Logger, db *sql.DB, systemT
 		columnStatsSourceTable = "(SELECT * FROM pganalyze.get_column_stats()) pg_stats"
 	} else {
 		if !connectedAsSuperUser(ctx, db, systemType) && !connectedAsMonitoringRole(ctx, db) {
-			logger.PrintInfo("Warning: You are not connecting as superuser. Please setup" +
-				" the monitoring helper functions (https://github.com/pganalyze/collector#setting-up-a-restricted-monitoring-user)" +
+			logger.PrintInfo("Warning: You are not connecting as superuser. Please set up" +
+				" the monitoring helper functions (https://pganalyze.com/docs/install/troubleshooting/column_stats_helper)" +
 				" or connect as superuser to run the bloat report.")
 		}
 		columnStatsSourceTable = "pg_catalog.pg_stats"

--- a/input/postgres/relation_column_stats.go
+++ b/input/postgres/relation_column_stats.go
@@ -32,9 +32,9 @@ func GetColumnStats(ctx context.Context, logger *util.Logger, db *sql.DB, global
 				server.SelfTest.MarkDbCollectionAspectError(dbName, state.CollectionAspectColumnStats, "monitoring helper function pganalyze.get_column_stats not found")
 				server.SelfTest.HintDbCollectionAspect(dbName, state.CollectionAspectColumnStats, "Please set up"+
 					" the monitoring helper function pganalyze.get_column_stats (%s)"+
-					" or connect as superuser to get column statistics for all tables.", selftest.URLPrinter.Sprint("https://github.com/pganalyze/collector#setting-up-a-restricted-monitoring-user"))
+					" or connect as superuser to get column statistics for all tables.", selftest.URLPrinter.Sprint("https://pganalyze.com/docs/install/troubleshooting/column_stats_helper"))
 				logger.PrintInfo("Warning: Limited access to table column statistics detected in database %s. Please set up"+
-					" the monitoring helper function pganalyze.get_column_stats (https://github.com/pganalyze/collector#setting-up-a-restricted-monitoring-user)"+
+					" the monitoring helper function pganalyze.get_column_stats (https://pganalyze.com/docs/install/troubleshooting/column_stats_helper)"+
 					" or connect as superuser, to get column statistics for all tables.", dbName)
 			}
 		}

--- a/input/postgres/relation_stats_ext.go
+++ b/input/postgres/relation_stats_ext.go
@@ -63,9 +63,9 @@ func GetRelationStatsExtended(ctx context.Context, logger *util.Logger, db *sql.
 				server.SelfTest.MarkDbCollectionAspectError(dbName, state.CollectionAspectExtendedStats, "monitoring helper function pganalyze.get_relation_stats_ext not found")
 				server.SelfTest.HintDbCollectionAspect(dbName, state.CollectionAspectExtendedStats, "Please set up"+
 					" the monitoring helper function pganalyze.get_relation_stats_ext (%s)"+
-					" or connect as superuser, to get extended statistics for all tables.", selftest.URLPrinter.Sprint("https://github.com/pganalyze/collector#setting-up-a-restricted-monitoring-user"))
+					" or connect as superuser, to get extended statistics for all tables.", selftest.URLPrinter.Sprint("https://pganalyze.com/docs/install/troubleshooting/ext_stats_helper"))
 				logger.PrintInfo("Warning: Limited access to extended table statistics detected in database %s. Please set up"+
-					" the monitoring helper function pganalyze.get_relation_stats_ext (https://github.com/pganalyze/collector#setting-up-a-restricted-monitoring-user)"+
+					" the monitoring helper function pganalyze.get_relation_stats_ext (https://pganalyze.com/docs/install/troubleshooting/ext_stats_helper)"+
 					" or connect as superuser, to get extended statistics for all tables.", dbName)
 			}
 		}

--- a/input/postgres/replication.go
+++ b/input/postgres/replication.go
@@ -93,7 +93,7 @@ func GetReplication(ctx context.Context, logger *util.Logger, db *sql.DB, postgr
 	} else {
 		if systemType != "heroku" && !connectedAsSuperUser(ctx, db, systemType) && !connectedAsMonitoringRole(ctx, db) {
 			logger.PrintInfo("Warning: You are not connecting as superuser. Please setup" +
-				" the monitoring helper functions (https://github.com/pganalyze/collector#setting-up-a-restricted-monitoring-user)" +
+				" the monitoring helper functions (https://pganalyze.com/docs/install/aiven/01_create_monitoring_user)" +
 				" or connect as superuser, to get replication statistics.")
 		}
 		sourceTable = "pg_stat_replication"

--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -186,9 +186,9 @@ func GetStatements(ctx context.Context, server *state.Server, logger *util.Logge
 			server.SelfTest.MarkCollectionAspectWarning(state.CollectionAspectPgStatStatements, "monitoring user may have insufficient permissions to capture all queries")
 			server.SelfTest.HintCollectionAspect(state.CollectionAspectPgStatStatements, "Please set up"+
 				" the monitoring helper functions (%s)"+
-				" or connect as superuser to get query statistics for all roles.", selftest.URLPrinter.Sprint("https://github.com/pganalyze/collector#setting-up-a-restricted-monitoring-user"))
+				" or connect as superuser to get query statistics for all roles.", selftest.URLPrinter.Sprint("https://pganalyze.com/docs/install/aiven/03_create_pg_stat_statements_helpers"))
 			logger.PrintInfo("Warning: You are not connecting as superuser. Please setup" +
-				" the monitoring helper functions (https://github.com/pganalyze/collector#setting-up-a-restricted-monitoring-user)" +
+				" the monitoring helper functions (https://pganalyze.com/docs/install/aiven/03_create_pg_stat_statements_helpers)" +
 				" or connect as superuser, to get query statistics for all roles.")
 		}
 		if !showtext {

--- a/integration_test/Makefile
+++ b/integration_test/Makefile
@@ -255,7 +255,7 @@ guided-setup:
 	grep -v db_password guided-setup.collector-config.out > guided-setup.collector-config.nopass.out
 	diff -Nau guided-setup.collector-config.nopass.expected guided-setup.collector-config.nopass.out \
 		&& grep --extended-regexp --quiet 'db_password\s+=\s+[a-f0-9]{32}' guided-setup.collector-config.out && echo 'collector config file modified as expected'
-	jq '{fns: .functionReferences, roles: .roleReferences[] |  select(.name == "pganalyze")}' < guided-setup.snapshot.json.out > guided-setup.snapshot-subset.json.out
+	jq '{roles: .roleReferences[] |  select(.name == "pganalyze")}' < guided-setup.snapshot.json.out > guided-setup.snapshot-subset.json.out
 	if [ "`grep 'Local log test successful' guided-setup-snapshot.log.out | wc -l`" -ne 2 ]; then \
 		echo "expected post-setup log test to succeed with both full and reduced privileges; test failed:"; \
 		cat guided-setup-snapshot.log.out; \

--- a/integration_test/guided-setup.snapshot-subset.json.expected
+++ b/integration_test/guided-setup.snapshot-subset.json.expected
@@ -1,10 +1,4 @@
 {
-  "fns": [
-    {
-      "schemaName": "pganalyze",
-      "functionName": "get_stat_replication"
-    }
-  ],
   "roles": {
     "name": "pganalyze"
   }

--- a/setup/steps/ensure_pganalyze_schema.go
+++ b/setup/steps/ensure_pganalyze_schema.go
@@ -7,7 +7,6 @@ import (
 	survey "github.com/AlecAivazis/survey/v2"
 	"github.com/lib/pq"
 	s "github.com/pganalyze/collector/setup/state"
-	"github.com/pganalyze/collector/setup/util"
 )
 
 var EnsurePganalyzeSchema = &s.Step{
@@ -33,13 +32,6 @@ var EnsurePganalyzeSchema = &s.Step{
 		}
 		hasUsage := row.GetBool(0)
 		if !hasUsage {
-			return false, nil
-		}
-		valid, err := util.ValidateHelperFunction(util.GetStatReplicationHelper, state.QueryRunner)
-		if err != nil {
-			return false, err
-		}
-		if !valid {
 			return false, nil
 		}
 
@@ -78,7 +70,7 @@ var EnsurePganalyzeSchema = &s.Step{
 			fmt.Sprintf(
 				`CREATE SCHEMA IF NOT EXISTS pganalyze; GRANT USAGE ON SCHEMA pganalyze TO %s;`,
 				pq.QuoteIdentifier(pgaUser),
-			) + util.GetStatReplicationHelper.GetDefinition(),
+			),
 		)
 	},
 }

--- a/setup/util/helper_functions.go
+++ b/setup/util/helper_functions.go
@@ -66,13 +66,6 @@ END`,
 	tail: "$$ LANGUAGE plpgsql VOLATILE SECURITY DEFINER;",
 }
 
-var GetStatReplicationHelper = PGHelperFn{
-	name: "get_stat_replication",
-	head: "CREATE OR REPLACE FUNCTION pganalyze.get_stat_replication() RETURNS SETOF pg_stat_replication AS $$",
-	body: "/* pganalyze-collector */ SELECT * FROM pg_catalog.pg_stat_replication;",
-	tail: "$$ LANGUAGE sql VOLATILE SECURITY DEFINER;",
-}
-
 func ValidateHelperFunction(fn PGHelperFn, runner *query.Runner) (bool, error) {
 	row, err := runner.QueryRow(
 		fmt.Sprintf(


### PR DESCRIPTION
Some of the README documentation was out of date, and it's hard to
keep these two copies in sync, so for a more seamless onboarding
experience, we'll focus our documentation on https://github.com/pganalyze/pganalyze-docs/

In passing, drop the get_stat_replication helper, which is no longer
necessary with pg_monitor.
