### PR TITLE
Update a config file location with Docker

### DIFF
--- a/contrib/docker-entrypoint.sh
+++ b/contrib/docker-entrypoint.sh
@@ -3,7 +3,7 @@
 set -e
 
 if [ -n "$CONFIG_CONTENTS" ]; then
-  echo "$CONFIG_CONTENTS" > /home/pganalyze/.pganalyze_collector.conf
+  echo "$CONFIG_CONTENTS" > /config/pganalyze-collector.conf
 fi
 
 CMD_PREFIX=exec
@@ -13,13 +13,13 @@ fi
 
 if [ "$1" = 'test' ]; then
   shift
-  eval $CMD_PREFIX /home/pganalyze/collector --test --no-log-timestamps --no-reload "$@"
+  eval $CMD_PREFIX /home/pganalyze/collector --config=/config/pganalyze-collector.conf --test --no-log-timestamps --no-reload "$@"
 elif [ "$1" = 'test-explain' ]; then
   shift
-  eval $CMD_PREFIX /home/pganalyze/collector --test-explain --no-log-timestamps "$@"
+  eval $CMD_PREFIX /home/pganalyze/collector --config=/config/pganalyze-collector.conf --test-explain --no-log-timestamps "$@"
 elif  [ "$1" = 'collector' ]; then
   shift
-  eval $CMD_PREFIX /home/pganalyze/collector --statefile=/state/pganalyze-collector.state --no-log-timestamps "$@"
+  eval $CMD_PREFIX /home/pganalyze/collector --config=/config/pganalyze-collector.conf --statefile=/state/pganalyze-collector.state --no-log-timestamps "$@"
 else
   eval $CMD_PREFIX "$@"
 fi

--- a/contrib/helm/pganalyze-collector/values.yaml
+++ b/contrib/helm/pganalyze-collector/values.yaml
@@ -100,6 +100,9 @@ volumeMounts:
   - mountPath: /state
     name: scratch
     subPath: state
+  - mountPath: /config
+    name: scratch
+    subPath: config
 
 nodeSelector: {}
 


### PR DESCRIPTION
Currently, `/home/pganalyze/.pganalyze_collector.conf` is used to store the config file when `CONFIG_CONTENTS` env var is passed, with Docker. However, this was failing to work when using helm chart, because `/home/pganalyze` is readonly.

With this PR, update that location to `/config/pganalyze-collector.conf`, then create such dir in Docker side. Also make sure to add this dir in helm chart side too, so that it'll be properly written within the docker entrypoint.