### PR TITLE
Add --generate-stats-helper-sql command to generate helpers psql install script

### DIFF
--- a/input/full.go
+++ b/input/full.go
@@ -127,7 +127,7 @@ func CollectFull(ctx context.Context, server *state.Server, connection *sql.DB, 
 		return
 	}
 
-	ps, ts, err = postgres.CollectAllSchemas(ctx, server, globalCollectionOpts, logger, ps, ts, systemType)
+	ps, ts, err = postgres.CollectAllSchemas(ctx, server, globalCollectionOpts, logger, ps, ts)
 	if err != nil {
 		logger.PrintError("Error collecting schema information: %s", err)
 		return

--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ func run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 					fmt.Fprintf(os.Stderr, "ERROR - %s\n", err)
 					testRunSuccess <- false
 				} else {
-					fmt.Println(output)
+					fmt.Print(output)
 					testRunSuccess <- true
 				}
 			}
@@ -313,7 +313,7 @@ func main() {
 	flag.BoolVar(&testRunLogs, "test-logs", false, "Tests whether log collection works (does not test privilege dropping for local log collection, use --test for that)")
 	flag.BoolVar(&testExplain, "test-explain", false, "Tests whether EXPLAIN collection works by issuing a dummy query (ensure log collection works first)")
 	flag.StringVar(&testSection, "test-section", "", "Tests a particular section of the config file, i.e. a specific server, and ignores all other config sections")
-	flag.StringVar(&generateStatsHelperSql, "generate-stats-helper-sql", "", "Generates a SQL script for the given server (name of section in the config file), that can be run with \"psql -f\" for installing the collector stats helpers on all configured databases")
+	flag.StringVar(&generateStatsHelperSql, "generate-stats-helper-sql", "", "Generates a SQL script for the given server (name of section in the config file, or \"default\" for env variables), that can be run with \"psql -f\" for installing the collector stats helpers on all configured databases")
 	flag.BoolVar(&reloadRun, "reload", false, "Reloads the collector daemon thats running on the host")
 	flag.BoolVar(&noReload, "no-reload", false, "Disables automatic config reloading during a test run")
 	flag.BoolVarP(&logger.Verbose, "verbose", "v", false, "Outputs additional debugging information, use this if you're encoutering errors or other problems")

--- a/main.go
+++ b/main.go
@@ -120,21 +120,21 @@ func run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 		}
 	}
 
-	if globalCollectionOpts.GenerateHelperSql != "" {
+	if globalCollectionOpts.GenerateStatsHelperSql != "" {
 		wg.Add(1)
 		testRunSuccess = make(chan bool)
 		go func() {
 			var matchingServer *state.Server
 			for _, server := range servers {
-				if globalCollectionOpts.GenerateHelperSql == server.Config.SectionName {
+				if globalCollectionOpts.GenerateStatsHelperSql == server.Config.SectionName {
 					matchingServer = server
 				}
 			}
 			if matchingServer == nil {
-				fmt.Fprintf(os.Stderr, "ERROR - Specified configuration section name '%s' not known\n", globalCollectionOpts.GenerateHelperSql)
+				fmt.Fprintf(os.Stderr, "ERROR - Specified configuration section name '%s' not known\n", globalCollectionOpts.GenerateStatsHelperSql)
 				testRunSuccess <- false
 			} else {
-				output, err := runner.GenerateHelperSql(ctx, matchingServer, globalCollectionOpts, logger.WithPrefix(matchingServer.Config.SectionName))
+				output, err := runner.GenerateStatsHelperSql(ctx, matchingServer, globalCollectionOpts, logger.WithPrefix(matchingServer.Config.SectionName))
 				if err != nil {
 					fmt.Fprintf(os.Stderr, "ERROR - %s\n", err)
 					testRunSuccess <- false
@@ -288,7 +288,7 @@ func main() {
 	var testRunLogs bool
 	var testExplain bool
 	var testSection string
-	var generateHelperSql string
+	var generateStatsHelperSql string
 	var forceStateUpdate bool
 	var configFilename string
 	var stateFilename string
@@ -313,7 +313,7 @@ func main() {
 	flag.BoolVar(&testRunLogs, "test-logs", false, "Tests whether log collection works (does not test privilege dropping for local log collection, use --test for that)")
 	flag.BoolVar(&testExplain, "test-explain", false, "Tests whether EXPLAIN collection works by issuing a dummy query (ensure log collection works first)")
 	flag.StringVar(&testSection, "test-section", "", "Tests a particular section of the config file, i.e. a specific server, and ignores all other config sections")
-	flag.StringVar(&generateHelperSql, "generate-helper-sql", "", "Generates a SQL script for the given server (name of section in the config file), that can be run with \"psql -f\" for installing the collector helpers on all configured databases")
+	flag.StringVar(&generateStatsHelperSql, "generate-stats-helper-sql", "", "Generates a SQL script for the given server (name of section in the config file), that can be run with \"psql -f\" for installing the collector stats helpers on all configured databases")
 	flag.BoolVar(&reloadRun, "reload", false, "Reloads the collector daemon thats running on the host")
 	flag.BoolVar(&noReload, "no-reload", false, "Disables automatic config reloading during a test run")
 	flag.BoolVarP(&logger.Verbose, "verbose", "v", false, "Outputs additional debugging information, use this if you're encoutering errors or other problems")
@@ -383,7 +383,7 @@ func main() {
 		}
 	}
 
-	if testReport != "" || testRunLogs || testRunAndTrace || testExplain || generateHelperSql != "" {
+	if testReport != "" || testRunLogs || testRunAndTrace || testExplain || generateStatsHelperSql != "" {
 		testRun = true
 	}
 
@@ -395,7 +395,7 @@ func main() {
 		TestRunLogs:              testRunLogs || dryRunLogs,
 		TestExplain:              testExplain,
 		TestSection:              testSection,
-		GenerateHelperSql:        generateHelperSql,
+		GenerateStatsHelperSql:   generateStatsHelperSql,
 		DebugLogs:                debugLogs,
 		DiscoverLogLocation:      discoverLogLocation,
 		CollectPostgresRelations: !noPostgresRelations,

--- a/runner/generate_helper_sql.go
+++ b/runner/generate_helper_sql.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/lib/pq"
 	"github.com/pganalyze/collector/input/postgres"
@@ -50,16 +51,16 @@ func GenerateStatsHelperSql(ctx context.Context, server *state.Server, globalCol
 		return "", fmt.Errorf("error collecting pg_databases: %s", err)
 	}
 
-	output := ""
+	output := strings.Builder{}
 	for _, dbName := range postgres.GetDatabasesToCollect(server, databases) {
-		output += fmt.Sprintf("\\c %s\n", pq.QuoteIdentifier(dbName))
-		output += "CREATE SCHEMA IF NOT EXISTS pganalyze;\n"
-		output += fmt.Sprintf("GRANT USAGE ON SCHEMA pganalyze TO %s;\n", server.Config.GetDbUsername())
+		output.WriteString(fmt.Sprintf("\\c %s\n", pq.QuoteIdentifier(dbName)))
+		output.WriteString("CREATE SCHEMA IF NOT EXISTS pganalyze;\n")
+		output.WriteString(fmt.Sprintf("GRANT USAGE ON SCHEMA pganalyze TO %s;\n", server.Config.GetDbUsername()))
 		for _, helper := range statsHelpers {
-			output += helper + "\n"
+			output.WriteString(helper + "\n")
 		}
-		output += "\n"
+		output.WriteString("\n")
 	}
 
-	return output, nil
+	return output.String(), nil
 }

--- a/runner/generate_helper_sql.go
+++ b/runner/generate_helper_sql.go
@@ -1,0 +1,65 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pganalyze/collector/input/postgres"
+	"github.com/pganalyze/collector/state"
+	"github.com/pganalyze/collector/util"
+)
+
+var helpers = []string{
+	// Column stats
+	`CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS SETOF pg_stats AS
+$$
+  /* pganalyze-collector */ SELECT schemaname, tablename, attname, inherited, null_frac, avg_width,
+    n_distinct, NULL::anyarray, most_common_freqs, NULL::anyarray, correlation, NULL::anyarray,
+    most_common_elem_freqs, elem_count_histogram
+  FROM pg_catalog.pg_stats;
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER;`,
+
+	// Extended stats
+	`CREATE OR REPLACE FUNCTION pganalyze.get_relation_stats_ext() RETURNS TABLE(
+  statistics_schemaname text, statistics_name text,
+  inherited boolean, n_distinct pg_ndistinct, dependencies pg_dependencies,
+  most_common_val_nulls boolean[], most_common_freqs float8[], most_common_base_freqs float8[]
+) AS
+$$
+  /* pganalyze-collector */ SELECT statistics_schemaname::text, statistics_name::text,
+  (row_to_json(se.*)::jsonb ->> 'inherited')::boolean AS inherited, n_distinct, dependencies,
+  most_common_val_nulls, most_common_freqs, most_common_base_freqs
+  FROM pg_catalog.pg_stats_ext se;
+$$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
+
+func GenerateHelperSql(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (string, error) {
+	db, err := postgres.EstablishConnection(ctx, server, logger, globalCollectionOpts, "")
+	if err != nil {
+		return "", err
+	}
+	defer db.Close()
+
+	version, err := postgres.GetPostgresVersion(ctx, logger, db)
+	if err != nil {
+		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectPgVersion, err.Error())
+		return "", fmt.Errorf("error collecting Postgres version: %s", err)
+	}
+
+	databases, _, err := postgres.GetDatabases(ctx, logger, db, version)
+	if err != nil {
+		return "", fmt.Errorf("error collecting pg_databases: %s", err)
+	}
+
+	output := ""
+	for _, dbName := range postgres.GetDatabasesToCollect(server, databases) {
+		output += fmt.Sprintf("\\c \"%s\"\n", dbName)
+		output += "CREATE SCHEMA IF NOT EXISTS pganalyze;\n"
+		output += fmt.Sprintf("GRANT USAGE ON SCHEMA pganalyze TO %s;\n", server.Config.GetDbUsername())
+		for _, helper := range helpers {
+			output += helper + "\n"
+		}
+		output += "\n"
+	}
+
+	return output, nil
+}

--- a/runner/generate_helper_sql.go
+++ b/runner/generate_helper_sql.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pganalyze/collector/util"
 )
 
-var helpers = []string{
+var statsHelpers = []string{
 	// Column stats
 	`CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS SETOF pg_stats AS
 $$
@@ -33,7 +33,7 @@ $$
   FROM pg_catalog.pg_stats_ext se;
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
 
-func GenerateHelperSql(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (string, error) {
+func GenerateStatsHelperSql(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (string, error) {
 	db, err := postgres.EstablishConnection(ctx, server, logger, globalCollectionOpts, "")
 	if err != nil {
 		return "", err
@@ -55,7 +55,7 @@ func GenerateHelperSql(ctx context.Context, server *state.Server, globalCollecti
 		output += fmt.Sprintf("\\c %s\n", pq.QuoteIdentifier(dbName))
 		output += "CREATE SCHEMA IF NOT EXISTS pganalyze;\n"
 		output += fmt.Sprintf("GRANT USAGE ON SCHEMA pganalyze TO %s;\n", server.Config.GetDbUsername())
-		for _, helper := range helpers {
+		for _, helper := range statsHelpers {
 			output += helper + "\n"
 		}
 		output += "\n"

--- a/state/state.go
+++ b/state/state.go
@@ -203,6 +203,7 @@ type CollectionOpts struct {
 	TestRunLogs         bool
 	TestExplain         bool
 	TestSection         string
+	GenerateHelperSql   string
 	DebugLogs           bool
 	DiscoverLogLocation bool
 

--- a/state/state.go
+++ b/state/state.go
@@ -197,15 +197,15 @@ type CollectionOpts struct {
 
 	DiffStatements bool
 
-	SubmitCollectedData bool
-	TestRun             bool
-	TestReport          string
-	TestRunLogs         bool
-	TestExplain         bool
-	TestSection         string
-	GenerateHelperSql   string
-	DebugLogs           bool
-	DiscoverLogLocation bool
+	SubmitCollectedData    bool
+	TestRun                bool
+	TestReport             string
+	TestRunLogs            bool
+	TestExplain            bool
+	TestSection            string
+	GenerateStatsHelperSql string
+	DebugLogs              bool
+	DiscoverLogLocation    bool
 
 	StateFilename    string
 	WriteStateUpdate bool


### PR DESCRIPTION
Passing the new "--generate-stats-helper-sql" command to the collector will generate a SQL script that can be passed to "psql" to install stats helpers (e.g. for collecting column stats) on all configured databases for the specified server.

The command takes the name of the configuration section of a specific server in the collector configuration (e.g. "server1").

It can be used manually by saving the output to a file, or by piping it to psql like this:

```
pganalyze-collector --generate-stats-helper-sql=server1 | psql -f -
```

Make sure to execute the generated SQL as an administrative user or database owner (not the pganalyze user!) in order for the SECURITY DEFINER functions to have sufficient privileges assigned.