### PR TITLE
Add id-token: write permission for helm chart upload workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,8 @@ jobs:
   release_charts:
     needs: [release]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # for AWS credentials
     # ensure we don't release on create events for branches (only tags)
     if: ${{ startsWith( github.ref, 'refs/tags' ) }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,10 +282,14 @@ jobs:
         aws-region: us-east-1
 
     - name: Upload package to S3
-      run: aws s3 cp pganalyze-collector-${{ steps.get_version.outputs.version }}.tgz s3://charts.pganalyze.com/pganalyze-collector-${{ steps.get_version.outputs.version }}.tgz
+      run: |
+        aws s3 cp --acl public-read \
+        pganalyze-collector-${{ steps.get_version.outputs.version }}.tgz s3://charts.pganalyze.com/pganalyze-collector-${{ steps.get_version.outputs.version }}.tgz
 
     - name: Create or update index.yaml
       run: helm repo index . --merge index.yaml --url https://charts.pganalyze.com/
 
     - name: Upload index.yaml to S3
-      run: aws s3 cp index.yaml s3://charts.pganalyze.com/index.yaml
+      run: |
+        aws s3 cp --acl public-read --content-type application/yaml --cache-control no-cache \
+          index.yaml s3://charts.pganalyze.com/index.yaml


### PR DESCRIPTION
Current release is failing with the following error:

> It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission? If you are not trying to authenticate with OIDC and the action is working successfully, you can ignore this message.

https://github.com/pganalyze/collector/actions/runs/8756953063/job/24037550811

Looks like I indeed missed that: https://github.com/aws-actions/configure-aws-credentials?tab=readme-ov-file#oidc

For the [v0.56.0](https://github.com/pganalyze/collector/releases/tag/v0.56.0) release, I'll manually update the chart file to s3 in the meantime.