### PR TITLE
Handle newline within auto_explain query text with text format

### DIFF
--- a/logs/analyze_test.go
+++ b/logs/analyze_test.go
@@ -4133,39 +4133,6 @@ var tests = []testpair{
 				"          Index Cond: (pgbench_branches.bid = 59)",
 		}},
 	},
-	{ // Heroku text explain + new line in Query Text (due to the query being too long)
-		[]state.LogLine{{
-			Content: "duration: 1681.452 ms  plan:\n" +
-				"\tQuery Text: UPDATE pgbench_branches SET bbalance = bbalance +\n 2656 WHERE bid = 59;\n" +
-				"\tUpdate on public.pgbench_branches  (cost=0.27..8.29 rows=1 width=370) (actual rows=0 loops=1)\n" +
-				"\t  Buffers: shared hit=7\n" +
-				"\t  ->  Index Scan using pgbench_branches_pkey on public.pgbench_branches  (cost=0.27..8.29 rows=1 width=370) (actual rows=1 loops=1)\n" +
-				"\t        Output: bid, (bbalance + 2656), filler, ctid\n" +
-				"\t        Index Cond: (pgbench_branches.bid = 59)",
-		}},
-		[]state.LogLine{{
-			Query:              "UPDATE pgbench_branches SET bbalance = bbalance +\n 2656 WHERE bid = 59;",
-			Classification:     pganalyze_collector.LogLineInformation_STATEMENT_AUTO_EXPLAIN,
-			ReviewedForSecrets: true,
-			SecretMarkers: []state.LogSecretMarker{{
-				ByteStart: 30,
-				ByteEnd:   469,
-				Kind:      state.StatementTextLogSecret,
-			}},
-		}},
-		[]state.PostgresQuerySample{{
-			Query:         "UPDATE pgbench_branches SET bbalance = bbalance +\n 2656 WHERE bid = 59;",
-			RuntimeMs:     1681.452,
-			HasExplain:    true,
-			ExplainSource: pganalyze_collector.QuerySample_AUTO_EXPLAIN_EXPLAIN_SOURCE,
-			ExplainFormat: pganalyze_collector.QuerySample_TEXT_EXPLAIN_FORMAT,
-			ExplainOutputText: "Update on public.pgbench_branches  (cost=0.27..8.29 rows=1 width=370) (actual rows=0 loops=1)\n" +
-				"\t  Buffers: shared hit=7\n" +
-				"\t  ->  Index Scan using pgbench_branches_pkey on public.pgbench_branches  (cost=0.27..8.29 rows=1 width=370) (actual rows=1 loops=1)\n" +
-				"\t        Output: bid, (bbalance + 2656), filler, ctid\n" +
-				"\t        Index Cond: (pgbench_branches.bid = 59)",
-		}},
-	},
 	// pganalyze-collector-identify
 	{
 		[]state.LogLine{{
@@ -4210,6 +4177,65 @@ var tests = []testpair{
 
 func TestAnalyzeLogLines(t *testing.T) {
 	for _, pair := range tests {
+		l, s := logs.AnalyzeLogLines(pair.logLinesIn)
+
+		cfg := pretty.CompareConfig
+		cfg.SkipZeroFields = true
+
+		if diff := cfg.Compare(pair.logLinesOut, l); diff != "" {
+			t.Errorf("For %v: log lines diff: (-want +got)\n%s", pair.logLinesIn, diff)
+		}
+		if diff := cfg.Compare(pair.samplesOut, s); diff != "" {
+			t.Errorf("For %v: query samples diff: (-want +got)\n%s", pair.samplesOut, diff)
+		}
+
+		for idx, line := range pair.logLinesOut {
+			if !line.ReviewedForSecrets && line.LogLevel != pganalyze_collector.LogLineInformation_STATEMENT && line.LogLevel != pganalyze_collector.LogLineInformation_QUERY {
+				t.Errorf("Missing secret review for:\n%s %s\n", pair.logLinesIn[idx].LogLevel, pair.logLinesIn[idx].Content)
+			}
+		}
+	}
+}
+
+var testsHeroku = []testpair{{ // Heroku text explain + new line in Query Text (due to the query being too long)
+	[]state.LogLine{{
+		Content: "duration: 1681.452 ms  plan:\n" +
+			"\tQuery Text: UPDATE pgbench_branches SET bbalance = bbalance +\n 2656 WHERE bid = 59;\n" +
+			"\tUpdate on public.pgbench_branches  (cost=0.27..8.29 rows=1 width=370) (actual rows=0 loops=1)\n" +
+			"\t  Buffers: shared hit=7\n" +
+			"\t  ->  Index Scan using pgbench_branches_pkey on public.pgbench_branches  (cost=0.27..8.29 rows=1 width=370) (actual rows=1 loops=1)\n" +
+			"\t        Output: bid, (bbalance + 2656), filler, ctid\n" +
+			"\t        Index Cond: (pgbench_branches.bid = 59)",
+	}},
+	[]state.LogLine{{
+		Query:              "UPDATE pgbench_branches SET bbalance = bbalance +\n 2656 WHERE bid = 59;",
+		Classification:     pganalyze_collector.LogLineInformation_STATEMENT_AUTO_EXPLAIN,
+		ReviewedForSecrets: true,
+		SecretMarkers: []state.LogSecretMarker{{
+			ByteStart: 30,
+			ByteEnd:   469,
+			Kind:      state.StatementTextLogSecret,
+		}},
+	}},
+	[]state.PostgresQuerySample{{
+		Query:         "UPDATE pgbench_branches SET bbalance = bbalance +\n 2656 WHERE bid = 59;",
+		RuntimeMs:     1681.452,
+		HasExplain:    true,
+		ExplainSource: pganalyze_collector.QuerySample_AUTO_EXPLAIN_EXPLAIN_SOURCE,
+		ExplainFormat: pganalyze_collector.QuerySample_TEXT_EXPLAIN_FORMAT,
+		ExplainOutputText: "Update on public.pgbench_branches  (cost=0.27..8.29 rows=1 width=370) (actual rows=0 loops=1)\n" +
+			"\t  Buffers: shared hit=7\n" +
+			"\t  ->  Index Scan using pgbench_branches_pkey on public.pgbench_branches  (cost=0.27..8.29 rows=1 width=370) (actual rows=1 loops=1)\n" +
+			"\t        Output: bid, (bbalance + 2656), filler, ctid\n" +
+			"\t        Index Cond: (pgbench_branches.bid = 59)",
+	}},
+},
+}
+
+func TestAnalyzeLogLinesHeroku(t *testing.T) {
+	t.Setenv("DYNO", "dummy")
+	t.Setenv("PORT", "dummy")
+	for _, pair := range testsHeroku {
 		l, s := logs.AnalyzeLogLines(pair.logLinesIn)
 
 		cfg := pretty.CompareConfig

--- a/logs/analyze_test.go
+++ b/logs/analyze_test.go
@@ -4133,6 +4133,39 @@ var tests = []testpair{
 				"          Index Cond: (pgbench_branches.bid = 59)",
 		}},
 	},
+	{ // Heroku text explain + new line in Query Text (due to the query being too long)
+		[]state.LogLine{{
+			Content: "duration: 1681.452 ms  plan:\n" +
+				"\tQuery Text: UPDATE pgbench_branches SET bbalance = bbalance +\n 2656 WHERE bid = 59;\n" +
+				"\tUpdate on public.pgbench_branches  (cost=0.27..8.29 rows=1 width=370) (actual rows=0 loops=1)\n" +
+				"\t  Buffers: shared hit=7\n" +
+				"\t  ->  Index Scan using pgbench_branches_pkey on public.pgbench_branches  (cost=0.27..8.29 rows=1 width=370) (actual rows=1 loops=1)\n" +
+				"\t        Output: bid, (bbalance + 2656), filler, ctid\n" +
+				"\t        Index Cond: (pgbench_branches.bid = 59)",
+		}},
+		[]state.LogLine{{
+			Query:              "UPDATE pgbench_branches SET bbalance = bbalance +\n 2656 WHERE bid = 59;",
+			Classification:     pganalyze_collector.LogLineInformation_STATEMENT_AUTO_EXPLAIN,
+			ReviewedForSecrets: true,
+			SecretMarkers: []state.LogSecretMarker{{
+				ByteStart: 30,
+				ByteEnd:   469,
+				Kind:      state.StatementTextLogSecret,
+			}},
+		}},
+		[]state.PostgresQuerySample{{
+			Query:         "UPDATE pgbench_branches SET bbalance = bbalance +\n 2656 WHERE bid = 59;",
+			RuntimeMs:     1681.452,
+			HasExplain:    true,
+			ExplainSource: pganalyze_collector.QuerySample_AUTO_EXPLAIN_EXPLAIN_SOURCE,
+			ExplainFormat: pganalyze_collector.QuerySample_TEXT_EXPLAIN_FORMAT,
+			ExplainOutputText: "Update on public.pgbench_branches  (cost=0.27..8.29 rows=1 width=370) (actual rows=0 loops=1)\n" +
+				"\t  Buffers: shared hit=7\n" +
+				"\t  ->  Index Scan using pgbench_branches_pkey on public.pgbench_branches  (cost=0.27..8.29 rows=1 width=370) (actual rows=1 loops=1)\n" +
+				"\t        Output: bid, (bbalance + 2656), filler, ctid\n" +
+				"\t        Index Cond: (pgbench_branches.bid = 59)",
+		}},
+	},
 	// pganalyze-collector-identify
 	{
 		[]state.LogLine{{

--- a/logs/querysample/querysample.go
+++ b/logs/querysample/querysample.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pganalyze/collector/logs/util"
 	"github.com/pganalyze/collector/output/pganalyze_collector"
 	"github.com/pganalyze/collector/state"
+	cUtil "github.com/pganalyze/collector/util"
 )
 
 func TransformAutoExplainToQuerySample(logLine state.LogLine, explainText string, queryRuntime string) (state.PostgresQuerySample, error) {
@@ -65,7 +66,7 @@ func transformExplainTextToQuerySample(logLine state.LogLine, explainText string
 	// likely it's hitting the Heroku's newline break in "Query Text:" chunk
 	// Handle the separation of the query and the explain output text with the tab for these cases
 	explainOutputFirstChar := explainParts[2][0]
-	if !(explainOutputFirstChar >= 'A' && explainOutputFirstChar <= 'Z') {
+	if cUtil.IsHeroku() && !(explainOutputFirstChar >= 'A' && explainOutputFirstChar <= 'Z') {
 		if parts := herokuAutoExplainWithTabRegexp.FindStringSubmatch(explainText); len(parts) == 3 {
 			explainParts = parts
 		}


### PR DESCRIPTION
We saw some cases where the explain output text is including the part of query for the case with Heroku logs when the new line is added in the middle of query text because query text is too long.
This is purely a workaround and I'm not even sure if this is a good workaround (probably bad), but this at least will fix the issue, at least with the customer who is seeing the issue.

I think the change is pretty safe. If the explain output is not starting with the capital letter (the first word should be a node type), I think that's a problem anyways, so trying something different won't hurt.
I glanced https://github.com/postgres/postgres/blob/89ad3e1316bf0374f9e57456bf2888d14bf070f6/src/backend/commands/explain.c#L1360 to see what the possible explain output to justify. Technically I'm not matching with "???" case but I think that's also another edge case that should be failing to parse anyways.