### PR TITLE
Correct snapshot upload error message

### DIFF
--- a/output/compact.go
+++ b/output/compact.go
@@ -56,7 +56,7 @@ func uploadAndSubmitCompactSnapshot(ctx context.Context, s pganalyze_collector.C
 
 	s3Location, err := uploadSnapshot(ctx, server.Config.HTTPClientWithRetry, grant, logger, compressedData, snapshotUUID.String())
 	if err != nil {
-		logger.PrintError("Error uploading to S3: %s", err)
+		logger.PrintError("Error uploading snapshot: %s", err)
 		return err
 	}
 

--- a/output/full.go
+++ b/output/full.go
@@ -80,7 +80,7 @@ func submitFull(ctx context.Context, s snapshot.FullSnapshot, server *state.Serv
 
 	s3Location, err := uploadSnapshot(ctx, server.Config.HTTPClientWithRetry, server.Grant, logger, compressedData, snapshotUUID.String())
 	if err != nil {
-		logger.PrintError("Error uploading to S3: %s", err)
+		logger.PrintError("Error uploading snapshot: %s", err)
 		return err
 	}
 


### PR DESCRIPTION
The message currently says "Error uploading to S3", but with direct
snapshot upload or Enterprise server with different object storage
configured, snapshots may be going somewhere else.

Remove "S3" from the message.
