### PR TITLE
Add logs test with OpenTelemetry log receiver 

### DIFF
--- a/runner/logs.go
+++ b/runner/logs.go
@@ -549,6 +549,7 @@ func testOtelLog(ctx context.Context, wg *sync.WaitGroup, server *state.Server, 
 		break
 	case <-time.After(10 * time.Second):
 		logger.PrintError("ERROR - OpenTelemetry log tail timed out after 10 seconds - did not find expected log event in stream")
+		logger.PrintInfo("HINT - This error may be a false positive if the collector is also running in the background and receiving logs")
 		return false
 	}
 

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -416,6 +416,8 @@ func TestLogsForAllServers(ctx context.Context, servers []*state.Server, globalC
 			}
 		} else if server.Config.GcpCloudSQLInstanceID != "" && server.Config.GcpPubsubSubscription != "" {
 			success = testGoogleCloudsqlLogStream(ctx, &wg, server, globalCollectionOpts, prefixedLogger)
+		} else if server.Config.LogOtelServer != "" {
+			success = testOtelLog(ctx, &wg, server, globalCollectionOpts, prefixedLogger)
 		}
 
 		if !success {
@@ -520,6 +522,33 @@ func testGoogleCloudsqlLogStream(ctx context.Context, wg *sync.WaitGroup, server
 	case <-time.After(10 * time.Second):
 		logger.PrintError("ERROR - Google Cloud Pub/Sub log tail timed out after 10 seconds - did not find expected log event in stream")
 		logger.PrintInfo("HINT - This error may be a false positive if the collector is also running in the background and consumes the same Google Cloud Pub/Sub stream")
+		return false
+	}
+
+	logger.PrintInfo("  Log test successful")
+	return true
+}
+
+func testOtelLog(ctx context.Context, wg *sync.WaitGroup, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) bool {
+	logger.PrintInfo("Testing log collection (OpenTelemetry Log receiving)...")
+
+	logTestSucceeded := make(chan bool, 1)
+	parsedLogStream := setupLogStreamer(ctx, wg, globalCollectionOpts, logger, []*state.Server{server}, logTestSucceeded, stream.LogTestCollectorIdentify)
+
+	err := selfhosted.SetupOtelHandlerForServer(ctx, wg, globalCollectionOpts, logger, server, parsedLogStream)
+	if err != nil {
+		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectLogs, "error setting up OTLP HTTP server for server: %s", err)
+		logger.PrintError("ERROR - Could not set up OTLP HTTP server for server: %s", err)
+		return false
+	}
+
+	EmitTestLogMsg(ctx, server, globalCollectionOpts, logger)
+
+	select {
+	case <-logTestSucceeded:
+		break
+	case <-time.After(10 * time.Second):
+		logger.PrintError("ERROR - OpenTelemetry log tail timed out after 10 seconds - did not find expected log event in stream")
 		return false
 	}
 


### PR DESCRIPTION
Follow-up of https://github.com/pganalyze/collector/pull/544

Here is how it looks with success:

```
/ $ LOG_OTEL_SERVER=0.0.0.0:4318 /home/pganalyze/collector --test-logs
2024/05/16 03:01:31 I Running collector test with pganalyze-collector 0.56.0
2024/05/16 03:01:31 I [default] Testing log collection (OpenTelemetry Log receiving)...
2024/05/16 03:01:31 I [default] Setting up OTLP HTTP server receiving logs with 0.0.0.0:4318
2024/05/16 03:01:35 I [default]   Log test successful
```

When the collector is already running well and receiving logs in background, it'll look like the following:

```
/ $ /home/pganalyze/collector --test-logs
2024/05/16 03:02:24 I Running collector test with pganalyze-collector 0.56.0
2024/05/16 03:02:24 I [default] Testing log collection (OpenTelemetry Log receiving)...
2024/05/16 03:02:24 I [default] Setting up OTLP HTTP server receiving logs with 0.0.0.0:4318
2024/05/16 03:02:34 E [default] ERROR - OpenTelemetry log tail timed out after 10 seconds - did not find expected log event in stream
2024/05/16 03:02:24 I [default] HINT - This error may be a false positive if the collector is also running in the background and receiving logs
```