### PR TITLE
Work around RDS pg_stats and pg_stats_ext issue

### DIFF
--- a/runner/generate_helper_sql.go
+++ b/runner/generate_helper_sql.go
@@ -19,7 +19,7 @@ $$
     n_distinct, NULL::anyarray, most_common_freqs, NULL::anyarray, correlation, NULL::anyarray,
     most_common_elem_freqs, elem_count_histogram
   FROM pg_catalog.pg_stats
-  WHERE schemaname NOT IN ('pg_catalog', 'information_schema');
+  WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND tablename <> 'pg_subscription';
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`,
 
 	// Extended stats
@@ -33,7 +33,7 @@ $$
   (row_to_json(se.*)::jsonb ->> 'inherited')::boolean AS inherited, n_distinct, dependencies,
   most_common_val_nulls, most_common_freqs, most_common_base_freqs
   FROM pg_catalog.pg_stats_ext se
-  WHERE schemaname NOT IN ('pg_catalog', 'information_schema');
+  WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND tablename <> 'pg_subscription';
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
 
 func GenerateStatsHelperSql(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (string, error) {


### PR DESCRIPTION
It looks like RDS has some custom patches that can run the permission
check for stats before running the related filter, causing a
permission failure fetching stats for tables that we don't want to see
in the first place (and that should be pruned by the `schemaname`
filter).

Ignore the 'pg_subscription' table explicitly.
