### PR TITLE
Log filtering: redact statement for syntax errors

### DIFF
--- a/logs/analyze_test.go
+++ b/logs/analyze_test.go
@@ -2950,10 +2950,16 @@ var tests = []testpair{
 			LogLevel:           pganalyze_collector.LogLineInformation_STATEMENT,
 			ParentUUID:         uuid.UUID{1},
 			ReviewedForSecrets: true,
-			SecretMarkers: []state.LogSecretMarker{{
-				ByteEnd: 36,
-				Kind:    state.StatementTextLogSecret,
-			}},
+			SecretMarkers: []state.LogSecretMarker{
+				{
+					ByteEnd: 36,
+					Kind:    state.StatementTextLogSecret,
+				},
+				{
+					ByteEnd: 36,
+					Kind:    state.ParsingErrorLogSecret,
+				},
+			},
 		}},
 		nil,
 	},
@@ -2976,10 +2982,16 @@ var tests = []testpair{
 			LogLevel:           pganalyze_collector.LogLineInformation_STATEMENT,
 			ParentUUID:         uuid.UUID{1},
 			ReviewedForSecrets: true,
-			SecretMarkers: []state.LogSecretMarker{{
-				ByteEnd: 23,
-				Kind:    state.StatementTextLogSecret,
-			}},
+			SecretMarkers: []state.LogSecretMarker{
+				{
+					ByteEnd: 23,
+					Kind:    state.StatementTextLogSecret,
+				},
+				{
+					ByteEnd: 23,
+					Kind:    state.ParsingErrorLogSecret,
+				},
+			},
 		}},
 		nil,
 	},


### PR DESCRIPTION
Currently, setting `parsing_error` in [filter_log_secret](https://pganalyze.com/docs/collector/settings#pii-filtering-settings) only redacts the fragment in the main log line, while the following log line contains the statement in full:

```
ERROR: syntax error at or near "XXXX" at character 1 
STATEMENT: test;
```

With this PR, the statement is also redacted:
```
ERROR: syntax error at or near "XXXX" at character 1 
STATEMENT: XXXXXX
```

This is implemented by adding a duplicate `LogSecretMarker` so the statement can be redacted if either `parsing_error` or `statement_text` log filtering is enabled.