### PR TITLE
Enable log filtering by default

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -318,6 +318,8 @@ func getDefaultConfig() *ServerConfig {
 	}
 	if filterLogSecret := os.Getenv("FILTER_LOG_SECRET"); filterLogSecret != "" {
 		config.FilterLogSecret = filterLogSecret
+	} else {
+		config.FilterLogSecret = "credential,parsing_error,unidentified"
 	}
 	if filterQuerySample := os.Getenv("FILTER_QUERY_SAMPLE"); filterQuerySample != "" {
 		config.FilterQuerySample = filterQuerySample


### PR DESCRIPTION
To reduce the likelihood that logs contain passwords, this PR enables log filtering by default for credentials, parsing errors, and unidentified log lines.

Any users that change this setting need to take care to re-enable these filters, so for example if they wanted to add `statement_parameter` filtering they should set `statement_parameter,credential,parsing_error,unidentified`.