### PR TITLE
Reduce HTTP retry rate from 5 to 3

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -405,7 +405,7 @@ func CreateHTTPClient(conf ServerConfig, logger *util.Logger, retry bool) *http.
 		client := retryablehttp.NewClient()
 		client.RetryWaitMin = 1 * time.Second
 		client.RetryWaitMax = 30 * time.Second
-		client.RetryMax = 4
+		client.RetryMax = 2
 		client.Logger = nil
 		client.HTTPClient.Timeout = 120 * time.Second
 		client.HTTPClient.Transport = transport


### PR DESCRIPTION
5 attempts is probably too much, especially when each can take 30 seconds (or is it 120 seconds from `Timeout`?). This might explain why we've seen the collector take so long to shut down after pressing Control-C.

For context: `RetryMax` is the max retries after an initial failure, so the actual number of requests will be `1 + RetryMax`