### PR TITLE
Add workaround for CentOS 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@
 * Add packages for Ubuntu 24.04
 * Remove "report" functionality
   - This has long been deprecated. Removing the code as a cleanup
+* Stop building packages for CentOS 7 / RHEL 7
+  * CentOS 7 / RHEL 7 is end of life. The minimum required glibc version for RPM packages is
+    now 2.26 (e.g. Amazon Linux 2)
 
 
 ## 0.56.0      2024-04-19

--- a/packages/README.md
+++ b/packages/README.md
@@ -31,8 +31,8 @@ When changing the initial package build step one needs to be careful to not incr
 
 Currently the following minimum glibc versions apply:
 
-* RPM, systemd: glibc 2.17 (CentOS 7)
-* DEB, systemd: glibc 2.19 (Debian Jessie)
+* RPM, systemd: glibc 2.26 (Amazon Linux 2)
+* DEB, systemd: glibc 2.31 (Debian Bullseye)
 
 
 Requirements

--- a/packages/repo/Dockerfile.repo-rpm
+++ b/packages/repo/Dockerfile.repo-rpm
@@ -1,7 +1,5 @@
 FROM amazonlinux:2
 
-# Replace with ARM base image when building on ARM
-
 # Build arguments
 ARG VERSION
 ENV NAME pganalyze-collector

--- a/packages/repo/Dockerfile.repo-rpm
+++ b/packages/repo/Dockerfile.repo-rpm
@@ -1,7 +1,6 @@
-FROM centos:7
+FROM amazonlinux:2
 
-# Replace with ARM base image when building on ARM:
-#FROM arm64v8/centos:7
+# Replace with ARM base image when building on ARM
 
 # Build arguments
 ARG VERSION
@@ -10,12 +9,6 @@ ENV NAME pganalyze-collector
 ENV RPM_DIR /rpm
 RUN mkdir -p $RPM_DIR
 RUN mkdir -p $RPM_DIR/systemd
-
-# Workaround for mirrorlist.centos.org
-# https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve
-RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
-RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
 RUN yum install -y -q rpm-sign createrepo
 

--- a/packages/repo/Dockerfile.repo-rpm
+++ b/packages/repo/Dockerfile.repo-rpm
@@ -11,6 +11,12 @@ ENV RPM_DIR /rpm
 RUN mkdir -p $RPM_DIR
 RUN mkdir -p $RPM_DIR/systemd
 
+# Workaround for mirrorlist.centos.org
+# https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 RUN yum install -y -q rpm-sign createrepo
 
 RUN echo "%_gpg_name team@pganalyze.com" > /root/.rpmmacros

--- a/packages/src/Dockerfile.build.rpm-systemd
+++ b/packages/src/Dockerfile.build.rpm-systemd
@@ -15,9 +15,16 @@ RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
 RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
 
 # Packages required for both building and packaging
-#
+RUN yum install -y centos-release-scl scl-utils tar make git rpmdevtools gcc
+
+# Workaround for mirrorlist.centos.org
+# https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 # This uses Ruby 3.0 since 2.7 (which still used for Debian builds) does not work with fpm: https://github.com/jordansissel/fpm/issues/2048#issuecomment-1972196104
-RUN yum install -y centos-release-scl scl-utils tar make git rpmdevtools gcc rh-ruby30 rh-ruby30-ruby-devel
+RUN yum install -y rh-ruby30 rh-ruby30-ruby-devel
 
 # FPM
 RUN source scl_source enable rh-ruby30 && gem install fpm -v 1.14.1

--- a/packages/src/Dockerfile.build.rpm-systemd
+++ b/packages/src/Dockerfile.build.rpm-systemd
@@ -16,7 +16,7 @@ RUN amazon-linux-extras install ruby3.0
 RUN yum install -y ruby-devel
 
 # FPM
-RUN source scl_source enable rh-ruby30 && gem install fpm -v 1.14.1
+RUN gem install fpm -v 1.14.1
 
 # Golang
 RUN curl -o go.tar.gz -sSL "https://go.dev/dl/go${GOVERSION}.linux-${TARGETARCH}.tar.gz"

--- a/packages/src/Dockerfile.build.rpm-systemd
+++ b/packages/src/Dockerfile.build.rpm-systemd
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM amazonlinux:2
 
 ARG TARGETARCH
 ENV GOPATH /go
@@ -8,23 +8,12 @@ ENV PATH $PATH:/usr/local/go/bin
 ENV ROOT_DIR /root
 ENV SOURCE_DIR /source
 
-# Workaround for mirrorlist.centos.org
-# https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve
-RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
-RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-
 # Packages required for both building and packaging
 RUN yum install -y centos-release-scl scl-utils tar make git rpmdevtools gcc
 
-# Workaround for mirrorlist.centos.org
-# https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve
-RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
-RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
-RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
-
 # This uses Ruby 3.0 since 2.7 (which still used for Debian builds) does not work with fpm: https://github.com/jordansissel/fpm/issues/2048#issuecomment-1972196104
-RUN yum install -y rh-ruby30 rh-ruby30-ruby-devel
+RUN amazon-linux-extras install ruby3.0
+RUN yum install -y ruby-devel
 
 # FPM
 RUN source scl_source enable rh-ruby30 && gem install fpm -v 1.14.1
@@ -63,7 +52,7 @@ RUN cp $CODE_DIR/contrib/sslrootcert/* $SOURCE_DIR/usr/share/pganalyze-collector
 
 # Build the package
 WORKDIR $ROOT_DIR
-RUN scl enable rh-ruby30 -- fpm \
+RUN fpm \
   -n $NAME -v ${VERSION} -t rpm --rpm-os linux \
   --config-files /etc/pganalyze-collector.conf \
   --after-install $CODE_DIR/packages/src/rpm-systemd/post.sh \

--- a/packages/src/Dockerfile.build.rpm-systemd
+++ b/packages/src/Dockerfile.build.rpm-systemd
@@ -8,10 +8,16 @@ ENV PATH $PATH:/usr/local/go/bin
 ENV ROOT_DIR /root
 ENV SOURCE_DIR /source
 
+# Workaround for mirrorlist.centos.org
+# https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+
 # Packages required for both building and packaging
 #
 # This uses Ruby 3.0 since 2.7 (which still used for Debian builds) does not work with fpm: https://github.com/jordansissel/fpm/issues/2048#issuecomment-1972196104
-RUN yum install -y centos-release-scl scl-utils tar make git rpmdevtools gcc && yum install -y rh-ruby30 rh-ruby30-ruby-devel
+RUN yum install -y centos-release-scl scl-utils tar make git rpmdevtools gcc rh-ruby30 rh-ruby30-ruby-devel
 
 # FPM
 RUN source scl_source enable rh-ruby30 && gem install fpm -v 1.14.1

--- a/packages/test/Makefile
+++ b/packages/test/Makefile
@@ -9,7 +9,8 @@ docker_test_and_clean = docker exec pga-collector-test /root/systemd_test.sh && 
 
 # Note: The default list excludes rockylinux9 since there is an open issue with
 # /sbin/init not being present, see https://github.com/rocky-linux/sig-cloud-instance-images/issues/39
-DISTROS=centos7 rhel8 rockylinux8 rhel9 fedora36 fedora37 amazonlinux2 amazonlinux2023 ubuntu-focal ubuntu-jammy ubuntu-noble debian-bullseye debian-bookworm
+# Note: The default list also excludes centos7 since it's EOL, we will drop the support near future
+DISTROS=rhel8 rockylinux8 rhel9 fedora36 fedora37 amazonlinux2 amazonlinux2023 ubuntu-focal ubuntu-jammy ubuntu-noble debian-bullseye debian-bookworm
 
 .PHONY: all $(DISTROS)
 


### PR DESCRIPTION
Currently, build_packages CI is failing because of the EOL of CentOS 7 and the retirement of its mirror for packages.
https://serverfault.com/questions/1161816/mirrorlist-centos-org-no-longer-resolve

I've placed several workarounds, seems to be working locally. Until we have a better plan for how to retire CentOS 7 support, maybe we can use this workaround?