### PR TITLE
Address docker warnings and GH Action Node.js 16 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.21
       id: go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.21
       id: go
@@ -54,7 +54,7 @@ jobs:
     steps:
 
     - name: Set up Go 1.x
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: 1.21
       id: go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -66,7 +66,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -93,12 +93,12 @@ jobs:
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Build packages
       run: |
@@ -129,7 +129,7 @@ jobs:
       uses: azure/setup-helm@v4
 
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         DOCKER_BUILDKIT=1 make integration_test
 
     - name: Upload build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: pganalyze-collector-linux-amd64
         path: pganalyze-collector-linux-amd64
@@ -77,7 +77,7 @@ jobs:
         DOCKER_BUILDKIT=1 make integration_test
 
     - name: Upload build
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: pganalyze-collector-linux-arm64
         path: pganalyze-collector-linux-arm64
@@ -109,7 +109,7 @@ jobs:
         DOCKER_BUILDKIT=1 make -C packages test
 
     - name: Upload packages as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: packages
         path: |
@@ -137,7 +137,7 @@ jobs:
       run: helm package contrib/helm/pganalyze-collector
 
     - name: Upload packages as artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: charts
         path: |
@@ -152,22 +152,22 @@ jobs:
 
     steps:
     - name: Download build
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: pganalyze-collector-linux-amd64
 
     - name: Download arm build
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: pganalyze-collector-linux-arm64
 
     - name: Download build packages
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: packages
 
     - name: Download helm package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: charts
 
@@ -260,7 +260,7 @@ jobs:
 
     steps:
     - name: Download helm package
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: charts
 

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -16,12 +16,12 @@ jobs:
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: arm64
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM golang:1.21-alpine as base
-MAINTAINER team@pganalyze.com
+FROM golang:1.21-alpine AS base
 LABEL org.opencontainers.image.authors="team@pganalyze.com"
 
-ENV GOPATH /go
-ENV HOME_DIR /home/pganalyze
-ENV CODE_DIR $GOPATH/src/github.com/pganalyze/collector
+ENV GOPATH=/go
+ENV HOME_DIR=/home/pganalyze
+ENV CODE_DIR=$GOPATH/src/github.com/pganalyze/collector
 
 RUN apk add --no-cache --virtual .build-deps make curl libc-dev gcc git tar \
   && mkdir -p $HOME_DIR
@@ -19,7 +18,7 @@ COPY contrib/sslrootcert/rds-ca-global.pem /usr/share/pganalyze-collector/sslroo
 COPY contrib/docker-entrypoint.sh $HOME_DIR
 RUN chmod +x $HOME_DIR/docker-entrypoint.sh
 
-FROM alpine:3.18 as slim
+FROM alpine:3.18 AS slim
 
 RUN apk add --no-cache ca-certificates tzdata
 


### PR DESCRIPTION
I'm not addressing all the warnings for both Docker and GH Action, but we have too many now and I'm addressing some.
For GH Action version bump, I made sure that every bump is pretty safe. The `actions/upload-artifact` action had some breaking changes (which didn't affect to us), but otherwise all bumps are pretty much to support Node.js 16 deprecation.

https://github.com/pganalyze/collector/actions/runs/9770203430