### PR TITLE
Support multiline logs with AlloyDB

### DIFF
--- a/input/system/google_cloudsql/logs.go
+++ b/input/system/google_cloudsql/logs.go
@@ -206,7 +206,7 @@ func setupLogTransformer(ctx context.Context, wg *sync.WaitGroup, servers []*sta
 					}
 					if in.GcpProjectID == server.Config.GcpProjectID && in.GcpAlloyDBClusterID != "" && in.GcpAlloyDBClusterID == server.Config.GcpAlloyDBClusterID && in.GcpAlloyDBInstanceID != "" && in.GcpAlloyDBInstanceID == server.Config.GcpAlloyDBInstanceID {
 						// AlloyDB adds a special [filename:lineno] prefix to all log lines (not part of log_line_prefix)
-						parts := regexp.MustCompile(`^\[[\w.-]+:\d+\]  (.*)`).FindStringSubmatch(string(logLine.Content))
+						parts := regexp.MustCompile(`(?s)^\[[\w.-]+:\d+\]  (.*)`).FindStringSubmatch(string(logLine.Content))
 						if len(parts) == 2 {
 							logLine.Content = parts[1]
 						}


### PR DESCRIPTION
With AlloyDB, when the log line contains a new line, it was cutting anything after a new line unintentionally.
This updates the regex to make sure that all content will be kept.

Confirmed that it'll match: https://go.dev/play/p/ym6RhMU26ud