### PR TITLE
Add option to avoid collecting distributed index stats for Citus

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -131,9 +131,8 @@ type ServerConfig struct {
 	SystemTypeFallback  string `ini:"api_system_type_fallback"`
 	SystemScopeFallback string `ini:"api_system_scope_fallback"`
 
-	AlwaysCollectSystemData bool `ini:"always_collect_system_data"`
-	DisableCitusSchemaStats bool `ini:"disable_citus_schema_stats"`
-	DisableCitusIndexStats  bool `ini:"disable_citus_index_stats"`
+	AlwaysCollectSystemData bool   `ini:"always_collect_system_data"`
+	DisableCitusSchemaStats string `ini:"disable_citus_schema_stats"` // none/all/index
 
 	// Configures the location where logfiles are - this can either be a directory,
 	// or a file - needs to readable by the regular pganalyze user

--- a/config/config.go
+++ b/config/config.go
@@ -133,6 +133,7 @@ type ServerConfig struct {
 
 	AlwaysCollectSystemData bool `ini:"always_collect_system_data"`
 	DisableCitusSchemaStats bool `ini:"disable_citus_schema_stats"`
+	DisableCitusIndexStats  bool `ini:"disable_citus_index_stats"`
 
 	// Configures the location where logfiles are - this can either be a directory,
 	// or a file - needs to readable by the regular pganalyze user

--- a/config/read.go
+++ b/config/read.go
@@ -42,6 +42,20 @@ func parseConfigBool(value string) bool {
 	return true
 }
 
+func parseConfigDisableCitusSchemaStats(value string) string {
+	// this setting was previously boolean, but now supports several enum values;
+	// map the old boolean values to the enum values for backward compatibility
+	var val = strings.ToLower(value)
+	if val == "none" || val == "" || val == "0" || val == "off" || val == "false" || val == "no" || val == "f" || val == "n" {
+		return "none"
+	}
+	if val == "index" {
+		return "index"
+	}
+	// any other values are considered as "all"
+	return "all"
+}
+
 func getDefaultConfig() *ServerConfig {
 	config := &ServerConfig{
 		APIBaseURL:              DefaultAPIBaseURL,
@@ -291,10 +305,7 @@ func getDefaultConfig() *ServerConfig {
 		config.AlwaysCollectSystemData = parseConfigBool(alwaysCollectSystemData)
 	}
 	if disableCitusSchemaStats := os.Getenv("DISABLE_CITUS_SCHEMA_STATS"); disableCitusSchemaStats != "" {
-		config.DisableCitusSchemaStats = parseConfigBool(disableCitusSchemaStats)
-	}
-	if disableCitusIndexStats := os.Getenv("DISABLE_CITUS_INDEX_STATS"); disableCitusIndexStats != "" {
-		config.DisableCitusIndexStats = parseConfigBool(disableCitusIndexStats)
+		config.DisableCitusSchemaStats = parseConfigDisableCitusSchemaStats(disableCitusSchemaStats)
 	}
 	if logPgReadFile := os.Getenv("LOG_PG_READ_FILE"); logPgReadFile != "" {
 		config.LogPgReadFile = parseConfigBool(logPgReadFile)

--- a/config/read.go
+++ b/config/read.go
@@ -293,6 +293,9 @@ func getDefaultConfig() *ServerConfig {
 	if disableCitusSchemaStats := os.Getenv("DISABLE_CITUS_SCHEMA_STATS"); disableCitusSchemaStats != "" {
 		config.DisableCitusSchemaStats = parseConfigBool(disableCitusSchemaStats)
 	}
+	if disableCitusIndexStats := os.Getenv("DISABLE_CITUS_INDEX_STATS"); disableCitusIndexStats != "" {
+		config.DisableCitusIndexStats = parseConfigBool(disableCitusIndexStats)
+	}
 	if logPgReadFile := os.Getenv("LOG_PG_READ_FILE"); logPgReadFile != "" {
 		config.LogPgReadFile = parseConfigBool(logPgReadFile)
 	}

--- a/input/postgres/relation_stats_aux.go
+++ b/input/postgres/relation_stats_aux.go
@@ -106,7 +106,7 @@ GROUP BY
 `
 
 func handleIndexStatsAux(ctx context.Context, db *sql.DB, idxStats state.PostgresIndexStatsMap, postgresVersion state.PostgresVersion, server *state.Server) (state.PostgresIndexStatsMap, error) {
-	if postgresVersion.IsCitus && !server.Config.DisableCitusSchemaStats {
+	if postgresVersion.IsCitus && !server.Config.DisableCitusSchemaStats && !server.Config.DisableCitusIndexStats {
 		stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+citusIndexSizeSQL)
 		if err != nil {
 			return idxStats, fmt.Errorf("IndexStatsExt/Prepare: %s", err)


### PR DESCRIPTION
In some situations, the problems that DISABLE_CITUS_SCHEMA_STATS is
intended to solve are actually only with indexes, not with other
schema stats. By adding an index-specific setting, we can support more
functionality for affected users.
