### PR TITLE
Test run: Avoid collector hanging when interrupted via CTRL+C (SIGINT)

### DIFF
--- a/main.go
+++ b/main.go
@@ -160,7 +160,9 @@ func run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 	// a later SIGHUP that fixes the config (or a temporarily unreachable server at start)
 	if globalCollectionOpts.TestRun {
 		wg.Add(1)
-		testRunSuccess = make(chan bool)
+		// This channel is buffered so the function can exit (and mark the wait group as done)
+		// without the caller consuming the channel, e.g. when the context gets canceled
+		testRunSuccess = make(chan bool, 1)
 		go func() {
 			if globalCollectionOpts.TestExplain {
 				success := true


### PR DESCRIPTION
Due to the way the signal handling is written, we stop checking the testRunSuccess channel once a SIGINT is received. However the code that marks the wait groups as done could only return once it finished writing to the channel, since it was unbuffered. Make the channel buffered so that the code can return as intended.

Fixes #561