### PR TITLE
Test run: Don't print summary if interrupted via CTRL+C (SIGINT)

### DIFF
--- a/main.go
+++ b/main.go
@@ -198,7 +198,9 @@ func run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 					doLogTest(ctx, servers, globalCollectionOpts, logger)
 				}
 
-				selftest.PrintSummary(servers, logger.Verbose)
+				if ctx.Err() == nil {
+					selftest.PrintSummary(servers, logger.Verbose)
+				}
 				success := allFullSuccessful && allActivitySuccessful
 				if success {
 					fmt.Fprintln(os.Stderr, "Test successful")


### PR DESCRIPTION
Its potentially confusing if we print the summary despite the run having been interrupted, since the summary will show "context canceled" errors that someone not familiar with Go terminology won't understand.

Instead, don't print anything, so its more clear the program was stopped in the middle of its work.

---

Note that we have an existing "Interrupt" message that is not affected by this:

```
lfittl@starfish pganalyze-collector % ./pganalyze-collector --test
2024/07/10 17:39:42 I Running collector test with pganalyze-collector 0.57.0
2024/07/10 17:39:42 I [server1] Testing statistics collection...
^C2024/07/10 17:39:43 E Interrupt
2024/07/10 17:39:43 E [server1] Could not process server: Get "http://localhost:5100/v2/snapshots/grant": context canceled
```