### PR TITLE
Allow HTTP clients to be cancelled by passing along context

### DIFF
--- a/grant/default.go
+++ b/grant/default.go
@@ -1,6 +1,7 @@
 package grant
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,8 +11,8 @@ import (
 	"github.com/pganalyze/collector/util"
 )
 
-func GetDefaultGrant(server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (state.Grant, error) {
-	req, err := http.NewRequest("GET", server.Config.APIBaseURL+"/v2/snapshots/grant", nil)
+func GetDefaultGrant(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (state.Grant, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", server.Config.APIBaseURL+"/v2/snapshots/grant", nil)
 	if err != nil {
 		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectApiConnection, err.Error())
 		return state.Grant{}, err

--- a/grant/logs.go
+++ b/grant/logs.go
@@ -1,6 +1,7 @@
 package grant
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -10,8 +11,8 @@ import (
 	"github.com/pganalyze/collector/util"
 )
 
-func GetLogsGrant(server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (state.GrantLogs, error) {
-	req, err := http.NewRequest("GET", server.Config.APIBaseURL+"/v2/snapshots/grant_logs", nil)
+func GetLogsGrant(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (state.GrantLogs, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", server.Config.APIBaseURL+"/v2/snapshots/grant_logs", nil)
 	if err != nil {
 		return state.GrantLogs{}, err
 	}

--- a/input/full.go
+++ b/input/full.go
@@ -152,7 +152,7 @@ func CollectFull(ctx context.Context, server *state.Server, connection *sql.DB, 
 	}
 
 	if globalCollectionOpts.CollectSystemInformation {
-		ps.System = system.GetSystemState(server, logger, globalCollectionOpts)
+		ps.System = system.GetSystemState(ctx, server, logger, globalCollectionOpts)
 	}
 
 	server.SetLogTimezone(ts.Settings)

--- a/input/system/crunchy_bridge/client.go
+++ b/input/system/crunchy_bridge/client.go
@@ -1,6 +1,7 @@
 package crunchy_bridge
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -74,8 +75,8 @@ type DiskUsageMetrics struct {
 	WalSize      uint64
 }
 
-func (c *Client) NewRequest(method string, path string) (*http.Request, error) {
-	req, err := http.NewRequest(method, c.BaseURL+path, nil)
+func (c *Client) NewRequest(ctx context.Context, method string, path string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -86,8 +87,8 @@ func (c *Client) NewRequest(method string, path string) (*http.Request, error) {
 	return req, nil
 }
 
-func (c *Client) GetClusterInfo() (*ClusterInfo, error) {
-	req, err := c.NewRequest("GET", "/clusters/"+c.ClusterID)
+func (c *Client) GetClusterInfo(ctx context.Context) (*ClusterInfo, error) {
+	req, err := c.NewRequest(ctx, "GET", "/clusters/"+c.ClusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -114,8 +115,8 @@ func (c *Client) GetClusterInfo() (*ClusterInfo, error) {
 	return &clusterInfo, err
 }
 
-func (c *Client) getMetrics(name string) (*MetricViews, error) {
-	req, err := c.NewRequest("GET", fmt.Sprintf("/metric-views/%s?cluster_id=%s&period=15m", name, c.ClusterID))
+func (c *Client) getMetrics(ctx context.Context, name string) (*MetricViews, error) {
+	req, err := c.NewRequest(ctx, "GET", fmt.Sprintf("/metric-views/%s?cluster_id=%s&period=15m", name, c.ClusterID))
 	if err != nil {
 		return nil, err
 	}
@@ -143,8 +144,8 @@ func (c *Client) getMetrics(name string) (*MetricViews, error) {
 	return &metricViews, nil
 }
 
-func (c *Client) GetCPUMetrics() (*CPUMetrics, error) {
-	metricViews, err := c.getMetrics("cpu")
+func (c *Client) GetCPUMetrics(ctx context.Context) (*CPUMetrics, error) {
+	metricViews, err := c.getMetrics(ctx, "cpu")
 	if err != nil {
 		return nil, err
 	}
@@ -166,8 +167,8 @@ func (c *Client) GetCPUMetrics() (*CPUMetrics, error) {
 	return &metrics, err
 }
 
-func (c *Client) GetMemoryMetrics() (*MemoryMetrics, error) {
-	metricViews, err := c.getMetrics("memory")
+func (c *Client) GetMemoryMetrics(ctx context.Context) (*MemoryMetrics, error) {
+	metricViews, err := c.getMetrics(ctx, "memory")
 	if err != nil {
 		return nil, err
 	}
@@ -185,8 +186,8 @@ func (c *Client) GetMemoryMetrics() (*MemoryMetrics, error) {
 	return &metrics, err
 }
 
-func (c *Client) GetIOPSMetrics() (*IOPSMetrics, error) {
-	metricViews, err := c.getMetrics("iops")
+func (c *Client) GetIOPSMetrics(ctx context.Context) (*IOPSMetrics, error) {
+	metricViews, err := c.getMetrics(ctx, "iops")
 	if err != nil {
 		return nil, err
 	}
@@ -204,8 +205,8 @@ func (c *Client) GetIOPSMetrics() (*IOPSMetrics, error) {
 	return &metrics, err
 }
 
-func (c *Client) GetLoadAverageMetrics() (*LoadAverageMetrics, error) {
-	metricViews, err := c.getMetrics("load-average")
+func (c *Client) GetLoadAverageMetrics(ctx context.Context) (*LoadAverageMetrics, error) {
+	metricViews, err := c.getMetrics(ctx, "load-average")
 	if err != nil {
 		return nil, err
 	}
@@ -221,8 +222,8 @@ func (c *Client) GetLoadAverageMetrics() (*LoadAverageMetrics, error) {
 	return &metrics, err
 }
 
-func (c *Client) GetDiskUsageMetrics() (*DiskUsageMetrics, error) {
-	metricViews, err := c.getMetrics("disk-usage")
+func (c *Client) GetDiskUsageMetrics(ctx context.Context) (*DiskUsageMetrics, error) {
+	metricViews, err := c.getMetrics(ctx, "disk-usage")
 	if err != nil {
 		return nil, err
 	}

--- a/input/system/crunchy_bridge/system.go
+++ b/input/system/crunchy_bridge/system.go
@@ -1,6 +1,7 @@
 package crunchy_bridge
 
 import (
+	"context"
 	"time"
 
 	"github.com/pganalyze/collector/input/system/selfhosted"
@@ -9,7 +10,7 @@ import (
 )
 
 // GetSystemState - Gets system information about a Crunchy Bridge instance
-func GetSystemState(server *state.Server, logger *util.Logger) (system state.SystemState) {
+func GetSystemState(ctx context.Context, server *state.Server, logger *util.Logger) (system state.SystemState) {
 	config := server.Config
 	// With Crunchy Bridge, we are assuming that the collector is deployed on Container Apps,
 	// which run directly on the database server. Most of the metrics can be obtained
@@ -25,7 +26,7 @@ func GetSystemState(server *state.Server, logger *util.Logger) (system state.Sys
 	}
 	client := Client{Client: *config.HTTPClientWithRetry, BaseURL: apiBaseURL, BearerToken: config.CrunchyBridgeAPIKey, ClusterID: config.CrunchyBridgeClusterID}
 
-	clusterInfo, err := client.GetClusterInfo()
+	clusterInfo, err := client.GetClusterInfo(ctx)
 	if err != nil {
 		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectSystemStats, "error getting cluster info: %s", err)
 		logger.PrintError("CrunchyBridge/System: Encountered error when getting cluster info %v\n", err)
@@ -44,7 +45,7 @@ func GetSystemState(server *state.Server, logger *util.Logger) (system state.Sys
 		system.Info.CrunchyBridge.CreatedAt = parsedCreatedAt
 	}
 
-	diskUsageMetrics, err := client.GetDiskUsageMetrics()
+	diskUsageMetrics, err := client.GetDiskUsageMetrics(ctx)
 	if err != nil {
 		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectSystemStats, "error getting cluster disk usage metrics: %s", err)
 		logger.PrintError("CrunchyBridge/System: Encountered error when getting cluster disk usage metrics %v\n", err)

--- a/input/system/heroku/logs.go
+++ b/input/system/heroku/logs.go
@@ -69,7 +69,7 @@ func processSystemMetrics(ctx context.Context, timestamp time.Time, content []by
 
 	prefixedLogger := logger.WithPrefix(server.Config.SectionName)
 
-	grant, err := grant.GetDefaultGrant(server, globalCollectionOpts, prefixedLogger)
+	grant, err := grant.GetDefaultGrant(ctx, server, globalCollectionOpts, prefixedLogger)
 	if err != nil {
 		prefixedLogger.PrintError("Could not get default grant for system snapshot: %s", err)
 		return

--- a/input/system/system.go
+++ b/input/system/system.go
@@ -33,7 +33,7 @@ func DownloadLogFiles(ctx context.Context, server *state.Server, globalCollectio
 }
 
 // GetSystemState - Retrieves a system snapshot for this system and returns it
-func GetSystemState(server *state.Server, logger *util.Logger, globalCollectionOpts state.CollectionOpts) (system state.SystemState) {
+func GetSystemState(ctx context.Context, server *state.Server, logger *util.Logger, globalCollectionOpts state.CollectionOpts) (system state.SystemState) {
 	config := server.Config
 	dbHost := config.GetDbHost()
 	if config.SystemType == "amazon_rds" {
@@ -48,12 +48,12 @@ func GetSystemState(server *state.Server, logger *util.Logger, globalCollectionO
 		system.Info.Type = state.HerokuSystem
 		server.SelfTest.MarkCollectionAspectNotAvailable(state.CollectionAspectSystemStats, "not available on this platform")
 	} else if config.SystemType == "crunchy_bridge" {
-		system = crunchy_bridge.GetSystemState(server, logger)
+		system = crunchy_bridge.GetSystemState(ctx, server, logger)
 	} else if config.SystemType == "aiven" {
 		system.Info.Type = state.AivenSystem
 		server.SelfTest.MarkCollectionAspectNotAvailable(state.CollectionAspectSystemStats, "not available on this platform")
 	} else if config.SystemType == "tembo" {
-		system = tembo.GetSystemState(server, logger)
+		system = tembo.GetSystemState(ctx, server, logger)
 	} else if dbHost == "" || dbHost == "localhost" || dbHost == "127.0.0.1" || config.AlwaysCollectSystemData {
 		system = selfhosted.GetSystemState(server, logger)
 	} else {

--- a/runner/activity.go
+++ b/runner/activity.go
@@ -42,7 +42,7 @@ func processActivityForServer(ctx context.Context, server *state.Server, globalC
 	}
 
 	if !globalCollectionOpts.ForceEmptyGrant {
-		newGrant, err = grant.GetDefaultGrant(server, globalCollectionOpts, logger)
+		newGrant, err = grant.GetDefaultGrant(ctx, server, globalCollectionOpts, logger)
 		if err != nil {
 			return newState, false, errors.Wrap(err, "could not get default grant for activity snapshot")
 		}

--- a/runner/full.go
+++ b/runner/full.go
@@ -96,7 +96,7 @@ func processServer(ctx context.Context, server *state.Server, globalCollectionOp
 
 	if !globalCollectionOpts.ForceEmptyGrant {
 		// Note: In case of server errors, we should reuse the old grant if its still recent (i.e. less than 50 minutes ago)
-		newGrant, err = grant.GetDefaultGrant(server, globalCollectionOpts, logger)
+		newGrant, err = grant.GetDefaultGrant(ctx, server, globalCollectionOpts, logger)
 		if err != nil {
 			if server.Grant.Valid {
 				logger.PrintVerbose("Could not acquire snapshot grant, reusing previous grant: %s", err)

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -147,7 +147,7 @@ func downloadLogsForServerWithLocksAndCallbacks(ctx context.Context, wg *sync.Wa
 }
 
 func downloadLogsForServer(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (state.PersistedLogState, bool, error) {
-	grant, err := getLogsGrant(server, globalCollectionOpts, logger)
+	grant, err := getLogsGrant(ctx, server, globalCollectionOpts, logger)
 	if err != nil || !grant.Valid {
 		return server.LogPrevState, false, err
 	}
@@ -254,7 +254,7 @@ func processLogStream(ctx context.Context, server *state.Server, logLines []stat
 		return tooFreshLogLines
 	}
 
-	grant, err := getLogsGrant(server, globalCollectionOpts, logger)
+	grant, err := getLogsGrant(ctx, server, globalCollectionOpts, logger)
 	if err != nil {
 		// Note we intentionally discard log lines here (and in the other
 		// error case below), because the HTTP client already retries to work
@@ -276,8 +276,8 @@ func processLogStream(ctx context.Context, server *state.Server, logLines []stat
 	return tooFreshLogLines
 }
 
-func getLogsGrant(server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (logGrant state.GrantLogs, err error) {
-	logGrant, err = grant.GetLogsGrant(server, globalCollectionOpts, logger)
+func getLogsGrant(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (logGrant state.GrantLogs, err error) {
+	logGrant, err = grant.GetLogsGrant(ctx, server, globalCollectionOpts, logger)
 	if err != nil {
 		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectLogs, "error getting log grant: %s", err)
 		return state.GrantLogs{Valid: false}, errors.Wrap(err, "could not get log grant")


### PR DESCRIPTION
This replaces all calls of "http.NewRequest" with
"http.NewRequestWithContext", to ensure that the HTTP client stops what its doing immediately when the context gets canceled.

The main motivation here is to better handle network connectivity problems to the pganalyze snapshot API, which otherwise make it seem like the collector hangs when trying to cancel a test run with CTRL+C (SIGINT).