### PR TITLE
Fix parse error handling when statement line is missing

### DIFF
--- a/logs/analyze.go
+++ b/logs/analyze.go
@@ -1284,11 +1284,13 @@ func classifyAndSetDetails(logLine state.LogLine, statementLine state.LogLine, d
 			logLine.Classification = syntaxError.classification
 			// The statement already has a LogSecretMarker, but we add another one so it's
 			// redacted for both `statement_text` and `parsing_error` log filters.
-			statementLine.SecretMarkers = append(statementLine.SecretMarkers, state.LogSecretMarker{
-				ByteStart: statementLine.SecretMarkers[0].ByteStart,
-				ByteEnd:   statementLine.SecretMarkers[0].ByteEnd,
-				Kind:      state.ParsingErrorLogSecret,
-			})
+			if len(statementLine.SecretMarkers) > 0 {
+				statementLine.SecretMarkers = append(statementLine.SecretMarkers, state.LogSecretMarker{
+					ByteStart: statementLine.SecretMarkers[0].ByteStart,
+					ByteEnd:   statementLine.SecretMarkers[0].ByteEnd,
+					Kind:      state.ParsingErrorLogSecret,
+				})
+			}
 			return logLine, statementLine, detailLine, contextLine, hintLine, samples
 		}
 	}


### PR DESCRIPTION
For #566. A parse error can sometimes not include a statement line, so this PR updates the code to check for the statement's presence.