### PR TITLE
Fix DISABLE_CITUS_SCHEMA_STATS config reading

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -305,7 +305,7 @@ func getDefaultConfig() *ServerConfig {
 		config.AlwaysCollectSystemData = parseConfigBool(alwaysCollectSystemData)
 	}
 	if disableCitusSchemaStats := os.Getenv("DISABLE_CITUS_SCHEMA_STATS"); disableCitusSchemaStats != "" {
-		config.DisableCitusSchemaStats = parseConfigDisableCitusSchemaStats(disableCitusSchemaStats)
+		config.DisableCitusSchemaStats = disableCitusSchemaStats
 	}
 	if logPgReadFile := os.Getenv("LOG_PG_READ_FILE"); logPgReadFile != "" {
 		config.LogPgReadFile = parseConfigBool(logPgReadFile)
@@ -703,6 +703,10 @@ func preprocessConfig(config *ServerConfig) (*ServerConfig, error) {
 				config.LogOtelK8SLabelSelectors = append(config.LogOtelK8SLabelSelectors, selector)
 			}
 		}
+	}
+
+	if config.DisableCitusSchemaStats != "" {
+		config.DisableCitusSchemaStats = parseConfigDisableCitusSchemaStats(config.DisableCitusSchemaStats)
 	}
 
 	return config, nil


### PR DESCRIPTION
The changes in #562 missed that the updated config-reading code was
only for config read from environment variables. Config from the
config file was not pre-processed, so any currently-documented values
of disable_citus_schema_stats specified there would be ignored, and
relation and index stats would always be collected. Config specified
via individual environment variables worked as expected.

Since the new buggy behavior of the setting is not yet in a released
version, and not yet documented, it does not need a CHANGELOG entry.
