### PR TITLE
Avoid using apt-key command for Debian

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -162,26 +162,14 @@ metadata_expire=300" | $maybe_sudo tee -a /etc/yum.repos.d/pganalyze_collector.r
   $maybe_sudo yum $yum_opts install pganalyze-collector <$user_input
 elif [ "$pkg" = deb ];
 then
-  # on Debian, gnupg, required for apt-key add, is not installed by default, so install
-  # it before trying to invoke it if necessary
-  if ! dpkg --verify gnupg 2>/dev/null && ! dpkg --verify gnupg1 2>/dev/null && ! dpkg --verify gnupg2 2>/dev/null;
-  then
-    if confirm "The gnupg package is required to verify the collector package signature; install it now?";
-    then
-      $maybe_sudo apt-get $apt_opts update <$user_input
-      $maybe_sudo apt-get $apt_opts install gnupg <$user_input
-    else
-      fail "cannot install without gnupg"
-    fi
-  fi
   if [ "$arch" = 'x86_64' ];
   then
-    apt_source="deb [arch=amd64] https://packages.pganalyze.com/${distribution}/${version}/ stable main"
+    apt_source="deb [arch=amd64 signed-by=/etc/apt/keyrings/pganalyze_signing_key.asc] https://packages.pganalyze.com/${distribution}/${version}/ stable main"
   elif [ "$arch" = 'arm64' ] || [ "$arch" = 'aarch64' ];
   then
-    apt_source="deb [arch=arm64] https://packages.pganalyze.com/${distribution}/${version}/ stable main"
+    apt_source="deb [arch=arm64 signed-by=/etc/apt/keyrings/pganalyze_signing_key.asc] https://packages.pganalyze.com/${distribution}/${version}/ stable main"
   fi
-  curl -s -L https://packages.pganalyze.com/pganalyze_signing_key.asc | $maybe_sudo apt-key add -
+  $maybe_sudo curl -L https://packages.pganalyze.com/pganalyze_signing_key.asc -o /etc/apt/keyrings/pganalyze_signing_key.asc
   echo "$apt_source" | $maybe_sudo tee /etc/apt/sources.list.d/pganalyze_collector.list
   $maybe_sudo apt-get $apt_opts update <$user_input
   $maybe_sudo apt-get $apt_opts install pganalyze-collector <$user_input

--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -169,6 +169,7 @@ then
   then
     apt_source="deb [arch=arm64 signed-by=/etc/apt/keyrings/pganalyze_signing_key.asc] https://packages.pganalyze.com/${distribution}/${version}/ stable main"
   fi
+  $maybe_sudo mkdir -p /etc/apt/keyrings
   $maybe_sudo curl -L https://packages.pganalyze.com/pganalyze_signing_key.asc -o /etc/apt/keyrings/pganalyze_signing_key.asc
   echo "$apt_source" | $maybe_sudo tee /etc/apt/sources.list.d/pganalyze_collector.list
   $maybe_sudo apt-get $apt_opts update <$user_input

--- a/packages/repo/sync_deb.sh
+++ b/packages/repo/sync_deb.sh
@@ -31,9 +31,9 @@ reprepro --basedir /repo/debian/bookworm includedeb stable /deb/systemd/$DEB_PAC
 reprepro --basedir /repo/debian/bookworm includedeb stable /deb/systemd/$DEB_PACKAGE_ARM64
 
 # Verify signatures
-apt-key add /repo/pganalyze_signing_key.asc
-gpgv --keyring /etc/apt/trusted.gpg /repo/ubuntu/focal/dists/stable/InRelease
-gpgv --keyring /etc/apt/trusted.gpg /repo/ubuntu/jammy/dists/stable/InRelease
-gpgv --keyring /etc/apt/trusted.gpg /repo/ubuntu/noble/dists/stable/InRelease
-gpgv --keyring /etc/apt/trusted.gpg /repo/debian/bullseye/dists/stable/InRelease
-gpgv --keyring /etc/apt/trusted.gpg /repo/debian/bookworm/dists/stable/InRelease
+gpg --dearmor -o /repo/pganalyze_signing_key.gpg /repo/pganalyze_signing_key.asc
+gpgv --keyring /repo/pganalyze_signing_key.gpg /repo/ubuntu/focal/dists/stable/InRelease
+gpgv --keyring /repo/pganalyze_signing_key.gpg /repo/ubuntu/jammy/dists/stable/InRelease
+gpgv --keyring /repo/pganalyze_signing_key.gpg /repo/ubuntu/noble/dists/stable/InRelease
+gpgv --keyring /repo/pganalyze_signing_key.gpg /repo/debian/bullseye/dists/stable/InRelease
+gpgv --keyring /repo/pganalyze_signing_key.gpg /repo/debian/bookworm/dists/stable/InRelease


### PR DESCRIPTION
As `apt-key add` is deprecated in Debian 11 (“Bullseye”) and Ubuntu 20.04 LTS (“Focal Fossa”), which are our minimal supported versions of the collector, let's remove the usage of it.

This thread has a great answer of why we shouldn't use `apt-key add`, and I updated the command to make sure to follow the best practice here.
https://askubuntu.com/questions/1286545/what-commands-exactly-should-replace-the-deprecated-apt-key


As a reference, the following message was shown during the installation process:

```
Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).

W: https://packages.pganalyze.com/ubuntu/noble/dists/stable/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
```