### PR TITLE
Improve duplicate server error message

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -768,7 +768,7 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 					}
 				}
 				if skip {
-					logger.PrintError("Skipping config section %s, detected as duplicate. Note: to montior multiple databases in the same server, db_name accepts a comma-separated list.", config.SectionName)
+					logger.PrintError("Skipping config section %s, detected as duplicate. Note: To monitor multiple databases on the same server, db_name accepts a comma-separated list.", config.SectionName)
 				} else {
 					conf.Servers = append(conf.Servers, *config)
 				}

--- a/config/read.go
+++ b/config/read.go
@@ -768,7 +768,7 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 					}
 				}
 				if skip {
-					logger.PrintError("Skipping config section %s, detected as duplicate", config.SectionName)
+					logger.PrintError("Skipping config section %s, detected as duplicate. Note: to montior multiple databases in the same server, db_name accepts a comma-separated list.", config.SectionName)
 				} else {
 					conf.Servers = append(conf.Servers, *config)
 				}


### PR DESCRIPTION
As seen in support ticket 5504, users may run into the duplicate server error when trying to set up the collector to monitor multiple databases in the same server. This PR updates the error message to note that `db_name` accepts a comma-separated list to monitor multiple databases.