### PR TITLE
Utilize UUID v7 for log lines/files, as well as snapshot IDs

### DIFF
--- a/logs/parse.go
+++ b/logs/parse.go
@@ -620,7 +620,7 @@ func ParseAndAnalyzeBuffer(logStream LineReader, linesNewerThan time.Time, serve
 		logLine.ByteEnd = byteStart + int64(len(line))
 
 		// Generate unique ID that can be used to reference this line
-		logLine.UUID, err = uuid.NewRandom()
+		logLine.UUID, err = uuid.NewV7()
 		if err != nil {
 			fmt.Printf("Failed to generate log line UUID: %s", err)
 			continue

--- a/output/compact.go
+++ b/output/compact.go
@@ -26,7 +26,7 @@ func uploadAndSubmitCompactSnapshot(ctx context.Context, s pganalyze_collector.C
 	var err error
 	var data []byte
 
-	snapshotUUID, err := uuid.NewRandom()
+	snapshotUUID, err := uuid.NewV7()
 	if err != nil {
 		logger.PrintError("Error generating snapshot UUID: %s", err)
 		return err

--- a/output/full.go
+++ b/output/full.go
@@ -47,7 +47,7 @@ func submitFull(ctx context.Context, s snapshot.FullSnapshot, server *state.Serv
 	var err error
 	var data []byte
 
-	snapshotUUID, err := uuid.NewRandom()
+	snapshotUUID, err := uuid.NewV7()
 	if err != nil {
 		logger.PrintError("Error generating snapshot UUID: %s", err)
 		return err

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -217,7 +217,7 @@ func setupLogStreamer(ctx context.Context, wg *sync.WaitGroup, globalCollectionO
 				}
 
 				in.LogLine.CollectedAt = time.Now()
-				in.LogLine.UUID, err = uuid.NewRandom()
+				in.LogLine.UUID, err = uuid.NewV7()
 				if err != nil {
 					logger.PrintError("Could not generate log line UUID: %s", err)
 					continue

--- a/state/logs.go
+++ b/state/logs.go
@@ -191,7 +191,7 @@ func NewLogFile(tmpFile *os.File, originalName string) (LogFile, error) {
 			return LogFile{}, fmt.Errorf("error allocating tempfile for logs: %s", err)
 		}
 	}
-	uuid, err := uuid.NewRandom()
+	uuid, err := uuid.NewV7()
 	if err != nil {
 		return LogFile{}, fmt.Errorf("error generating log file UUID: %s", err)
 	}


### PR DESCRIPTION
The server side already overwrites assigned log line/file IDs with ULIDs, so this does not make any practical difference for them, but may allow us to remove that logic on the server side in the future.

Collector provided snapshot IDs are currently mainly intended for debugging purposes (the server-side assigns its own ID), but it seems reasonable to use a more index-friendly ID here as well.