### PR TITLE
fix: Handle unexpected status code in GetClusterInfo

### DIFF
--- a/input/system/crunchy_bridge/client.go
+++ b/input/system/crunchy_bridge/client.go
@@ -104,7 +104,7 @@ func (c *Client) GetClusterInfo(ctx context.Context) (*ClusterInfo, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK || len(body) == 0 {
-		return nil, err
+		return nil, fmt.Errorf("unexpected status code: %d, response body: %s", resp.StatusCode, string(body))
 	}
 
 	clusterInfo := ClusterInfo{}


### PR DESCRIPTION
This handles the case where the HTTP response status code is not `200 OK` or the response body is empty in `client.go`. Instead of returning a `nil` error, it now returns a formatted error message with the status code and response body. This improves error handling and provides more information about the issue.

I hit this issue when PGAnalyze collector stopped working for me and the snapshots failed to be proccesed due the error 

```
Could not process server: runtime error: invalid memory address or nil pointer dereference
```

Due to the `nil` error, the subsequent code (https://github.com/pganalyze/collector/blob/5e8eab6bb9a6cdf41e8874fdd1e8b95fd1ee18fc/input/system/crunchy_bridge/system.go#L35) panics due to `clusterInfo` being `nil`. It turned out my CrunchyBridge API Key had expired resulting in this issue