### PR TITLE
Support Query Parameters with auto_explain and support new lines better with text format

### DIFF
--- a/logs/analyze.go
+++ b/logs/analyze.go
@@ -47,7 +47,7 @@ var duration = analyzeGroup{
 		remainderKind: state.StatementTextLogSecret,
 	},
 	detail: match{
-		regexp:  regexp.MustCompile(`(?:parameters: |, )\$\d+ = (?:(NULL)|'([^']*)')`),
+		regexp:  regexp.MustCompile(`(?:parameters: |, )\$\d+ = (?:(NULL)|'((?:[^']|'')*)')`),
 		secrets: []state.LogSecretKind{state.StatementParameterLogSecret, state.StatementParameterLogSecret},
 	},
 }

--- a/logs/analyze_test.go
+++ b/logs/analyze_test.go
@@ -45,7 +45,7 @@ var tests = []testpair{
 			Content:  "duration: 4079.697 ms  execute <unnamed>: \nSELECT * FROM x WHERE y = $1 LIMIT $2",
 			LogLevel: pganalyze_collector.LogLineInformation_LOG,
 		}, {
-			Content:  "parameters: $1 = 'long string', $2 = '1'",
+			Content:  "parameters: $1 = 'o''clock', $2 = '1'",
 			LogLevel: pganalyze_collector.LogLineInformation_DETAIL,
 		}},
 		[]state.LogLine{{
@@ -63,11 +63,11 @@ var tests = []testpair{
 			ReviewedForSecrets: true,
 			SecretMarkers: []state.LogSecretMarker{{
 				ByteStart: 18,
-				ByteEnd:   29,
+				ByteEnd:   26,
 				Kind:      state.StatementParameterLogSecret,
 			}, {
-				ByteStart: 38,
-				ByteEnd:   39,
+				ByteStart: 35,
+				ByteEnd:   36,
 				Kind:      state.StatementParameterLogSecret,
 			}},
 		}},
@@ -75,7 +75,7 @@ var tests = []testpair{
 			Query:     "SELECT * FROM x WHERE y = $1 LIMIT $2",
 			RuntimeMs: 4079.697,
 			Parameters: []null.String{
-				null.StringFrom("long string"),
+				null.StringFrom("o''clock"),
 				null.StringFrom("1"),
 			},
 		}},

--- a/logs/analyze_test.go
+++ b/logs/analyze_test.go
@@ -4145,6 +4145,54 @@ var tests = []testpair{
 				"          Index Cond: (pgbench_branches.bid = 59)",
 		}},
 	},
+	{
+		[]state.LogLine{{
+			Content: "duration: 0.006 ms  plan:\n" +
+				"\t{\n" +
+				"\t  \"Query Text\": \"PREPARE show_values (text, uuid, integer, text) AS SELECT $1, $2, $3, $4;\",\n" +
+				"\t  \"Query Parameters\": \"$1 = 'o''clock', $2 = '13f82cb8-a0cf-424e-903a-6f8d7db83191', $3 = '1234', $4 = NULL\",\n" +
+				"\t  \"Plan\": {\n" +
+				"\t    \"Node Type\": \"Result\",\n" +
+				"\t    \"Parallel Aware\": false,\n" +
+				"\t    \"Async Capable\": false,\n" +
+				"\t    \"Startup Cost\": 0.00,\n" +
+				"\t    \"Total Cost\": 0.01,\n" +
+				"\t    \"Plan Rows\": 1,\n" +
+				"\t    \"Plan Width\": 84\n" +
+				"\t  }\n" +
+				"\t}\n",
+		}},
+		[]state.LogLine{{
+			Query:              "PREPARE show_values (text, uuid, integer, text) AS SELECT $1, $2, $3, $4;",
+			Classification:     pganalyze_collector.LogLineInformation_STATEMENT_AUTO_EXPLAIN,
+			ReviewedForSecrets: true,
+			SecretMarkers: []state.LogSecretMarker{{
+				ByteStart: 27,
+				ByteEnd:   436,
+				Kind:      state.StatementTextLogSecret,
+			}},
+		}},
+		[]state.PostgresQuerySample{{
+			Query:         "PREPARE show_values (text, uuid, integer, text) AS SELECT $1, $2, $3, $4;",
+			RuntimeMs:     0.006,
+			HasExplain:    true,
+			ExplainSource: pganalyze_collector.QuerySample_AUTO_EXPLAIN_EXPLAIN_SOURCE,
+			ExplainFormat: pganalyze_collector.QuerySample_JSON_EXPLAIN_FORMAT,
+			Parameters:    []null.String{null.StringFrom("o''clock"), null.StringFrom("13f82cb8-a0cf-424e-903a-6f8d7db83191"), null.StringFrom("1234"), null.NewString("", false)},
+			ExplainOutputJSON: &state.ExplainPlanContainer{
+				Plan: []byte("{\n" +
+					"\t    \"Node Type\": \"Result\",\n" +
+					"\t    \"Parallel Aware\": false,\n" +
+					"\t    \"Async Capable\": false,\n" +
+					"\t    \"Startup Cost\": 0.00,\n" +
+					"\t    \"Total Cost\": 0.01,\n" +
+					"\t    \"Plan Rows\": 1,\n" +
+					"\t    \"Plan Width\": 84\n" +
+					"\t  }"),
+				QueryParameters: "$1 = 'o''clock', $2 = '13f82cb8-a0cf-424e-903a-6f8d7db83191', $3 = '1234', $4 = NULL",
+			},
+		}},
+	},
 	// pganalyze-collector-identify
 	{
 		[]state.LogLine{{

--- a/logs/analyze_test.go
+++ b/logs/analyze_test.go
@@ -4193,6 +4193,68 @@ var tests = []testpair{
 			},
 		}},
 	},
+	// new lines
+	{
+		[]state.LogLine{{
+			Content: "duration: 1681.452 ms  plan:\n" +
+				"\tQuery Text: PREPARE pga_keys (text) AS\n" +
+				"\t    SELECT * FROM api_keys WHERE access_scope_type = $1\n" +
+				"\t    AND organization_id = '13f82cb8-a0cf-424e-903a-6f8d7db83191';\n" +
+				"\tSeq Scan on api_keys  (cost=0.00..11.93 rows=1 width=132)\n" +
+				"\t  Filter: ((access_scope_type = 'organization'::text) AND (organization_id = '13f82cb8-a0cf-424e-903a-6f8d7db83191'::uuid))",
+		}},
+		[]state.LogLine{{
+			Query:              "PREPARE pga_keys (text) AS\n\t    SELECT * FROM api_keys WHERE access_scope_type = $1\n\t    AND organization_id = '13f82cb8-a0cf-424e-903a-6f8d7db83191';",
+			Classification:     pganalyze_collector.LogLineInformation_STATEMENT_AUTO_EXPLAIN,
+			ReviewedForSecrets: true,
+			SecretMarkers: []state.LogSecretMarker{{
+				ByteStart: 30,
+				ByteEnd:   376,
+				Kind:      state.StatementTextLogSecret,
+			}},
+		}},
+		[]state.PostgresQuerySample{{
+			Query:         "PREPARE pga_keys (text) AS\n\t    SELECT * FROM api_keys WHERE access_scope_type = $1\n\t    AND organization_id = '13f82cb8-a0cf-424e-903a-6f8d7db83191';",
+			RuntimeMs:     1681.452,
+			HasExplain:    true,
+			ExplainSource: pganalyze_collector.QuerySample_AUTO_EXPLAIN_EXPLAIN_SOURCE,
+			ExplainFormat: pganalyze_collector.QuerySample_TEXT_EXPLAIN_FORMAT,
+			ExplainOutputText: "Seq Scan on api_keys  (cost=0.00..11.93 rows=1 width=132)\n" +
+				"\t  Filter: ((access_scope_type = 'organization'::text) AND (organization_id = '13f82cb8-a0cf-424e-903a-6f8d7db83191'::uuid))",
+		}},
+	},
+	// new lines + Query Parameters
+	{
+		[]state.LogLine{{
+			Content: "duration: 1681.452 ms  plan:\n" +
+				"\tQuery Text: PREPARE pga_keys (text) AS\n" +
+				"\t    SELECT * FROM api_keys WHERE access_scope_type = $1\n" +
+				"\t    AND organization_id = '13f82cb8-a0cf-424e-903a-6f8d7db83191';\n" +
+				"\tQuery Parameters: $1 = 'organizati...'\n" +
+				"\tSeq Scan on api_keys  (cost=0.00..11.93 rows=1 width=132)\n" +
+				"\t  Filter: ((access_scope_type = 'organization'::text) AND (organization_id = '13f82cb8-a0cf-424e-903a-6f8d7db83191'::uuid))",
+		}},
+		[]state.LogLine{{
+			Query:              "PREPARE pga_keys (text) AS\n\t    SELECT * FROM api_keys WHERE access_scope_type = $1\n\t    AND organization_id = '13f82cb8-a0cf-424e-903a-6f8d7db83191';",
+			Classification:     pganalyze_collector.LogLineInformation_STATEMENT_AUTO_EXPLAIN,
+			ReviewedForSecrets: true,
+			SecretMarkers: []state.LogSecretMarker{{
+				ByteStart: 30,
+				ByteEnd:   416,
+				Kind:      state.StatementTextLogSecret,
+			}},
+		}},
+		[]state.PostgresQuerySample{{
+			Query:         "PREPARE pga_keys (text) AS\n\t    SELECT * FROM api_keys WHERE access_scope_type = $1\n\t    AND organization_id = '13f82cb8-a0cf-424e-903a-6f8d7db83191';",
+			RuntimeMs:     1681.452,
+			HasExplain:    true,
+			ExplainSource: pganalyze_collector.QuerySample_AUTO_EXPLAIN_EXPLAIN_SOURCE,
+			ExplainFormat: pganalyze_collector.QuerySample_TEXT_EXPLAIN_FORMAT,
+			ExplainOutputText: "Seq Scan on api_keys  (cost=0.00..11.93 rows=1 width=132)\n" +
+				"\t  Filter: ((access_scope_type = 'organization'::text) AND (organization_id = '13f82cb8-a0cf-424e-903a-6f8d7db83191'::uuid))",
+			Parameters: []null.String{null.StringFrom("organizati...")},
+		}},
+	},
 	// pganalyze-collector-identify
 	{
 		[]state.LogLine{{

--- a/logs/querysample/querysample.go
+++ b/logs/querysample/querysample.go
@@ -122,7 +122,7 @@ func findQueryParameters(paramText string) []null.String {
 	var parameters []null.String
 	// Regular expression to find all values in single quotes or NULL
 	// Query Parameters example: $1 = 'foo', $2 = '123', $3 = NULL, $4 = 'bo''o'
-	re := regexp.MustCompile(`'((?:[^']|'')*)'|NULL`)
+	re := regexp.MustCompile(`(?:(NULL)|'((?:[^']|'')*)')`)
 	for _, part := range re.FindAllString(paramText, -1) {
 		if part == "NULL" {
 			parameters = append(parameters, null.NewString("", false))

--- a/logs/querysample/querysample.go
+++ b/logs/querysample/querysample.go
@@ -39,18 +39,6 @@ func transformExplainJSONToQuerySample(logLine state.LogLine, explainText string
 	// Remove query text from EXPLAIN itself, to avoid duplication and match EXPLAIN (FORMAT JSON)
 	sampleQueryText := strings.TrimSpace(explainJSONOutput.QueryText)
 	explainJSONOutput.QueryText = ""
-	// Handle Query Parameters (available from Postgres 16+)
-	var parameters []null.String
-	// Regular expression to find all values in single quotes or NULL
-	// Query Parameters example: $1 = 'foo', $2 = '123', $3 = NULL, $4 = 'bo''o'
-	re := regexp.MustCompile(`'((?:[^']|'')*)'|NULL`)
-	for _, part := range re.FindAllString(explainJSONOutput.QueryParameters, -1) {
-		if part == "NULL" {
-			parameters = append(parameters, null.NewString("", false))
-		} else {
-			parameters = append(parameters, null.StringFrom(strings.Trim(part, "'")))
-		}
-	}
 
 	return state.PostgresQuerySample{
 		Query:             sampleQueryText,
@@ -63,39 +51,55 @@ func transformExplainJSONToQuerySample(logLine state.LogLine, explainText string
 		ExplainSource:     pganalyze_collector.QuerySample_AUTO_EXPLAIN_EXPLAIN_SOURCE,
 		ExplainFormat:     pganalyze_collector.QuerySample_JSON_EXPLAIN_FORMAT,
 		ExplainOutputJSON: &explainJSONOutput,
-		Parameters:        parameters,
+		Parameters:        findQueryParameters(explainJSONOutput.QueryParameters),
 	}, nil
 }
 
 var autoExplainTextPlanDetailsRegexp = regexp.MustCompile(`^Query Text: (.+)\s+([\s\S]+)`)
 var herokuAutoExplainWithTabRegexp = regexp.MustCompile(`^Query Text: ([^\t]+)\t([\s\S]+)`)
+var autoExplainTextWithQueryParametersRegexp = regexp.MustCompile(`^Query Text: ([\s\S]+)\r?\n\s*Query Parameters: (.+)\r?\n\s*([\s\S]+)`)
+var autoExplainTextWithCostsRegexp = regexp.MustCompile(`^Query Text: ([\s\S]+?)\r?\n\s*([\S ]+  \(cost=\d+\.\d{2}\.\.\d+\.\d{2} rows=\d+ width=\d+\)[\s\S]+)`)
 
 func transformExplainTextToQuerySample(logLine state.LogLine, explainText string, queryRuntimeMs float64) (state.PostgresQuerySample, error) {
-	explainParts := autoExplainTextPlanDetailsRegexp.FindStringSubmatch(explainText)
-	if len(explainParts) != 3 {
-		return state.PostgresQuerySample{}, fmt.Errorf("auto_explain output doesn't match expected format")
+	querySample := state.PostgresQuerySample{
+		RuntimeMs:     queryRuntimeMs,
+		OccurredAt:    logLine.OccurredAt,
+		Username:      logLine.Username,
+		Database:      logLine.Database,
+		LogLineUUID:   logLine.UUID,
+		HasExplain:    true,
+		ExplainSource: pganalyze_collector.QuerySample_AUTO_EXPLAIN_EXPLAIN_SOURCE,
+		ExplainFormat: pganalyze_collector.QuerySample_TEXT_EXPLAIN_FORMAT,
 	}
-	// If EXPLAIN output's first char is not a capital letter (e.g. not something like "Update on" or "Index Scan"),
-	// likely it's hitting the Heroku's newline break in "Query Text:" chunk
-	// Handle the separation of the query and the explain output text with the tab for these cases
-	explainOutputFirstChar := explainParts[2][0]
-	if cUtil.IsHeroku() && !(explainOutputFirstChar >= 'A' && explainOutputFirstChar <= 'Z') {
-		if parts := herokuAutoExplainWithTabRegexp.FindStringSubmatch(explainText); len(parts) == 3 {
-			explainParts = parts
+	withParametersParts := autoExplainTextWithQueryParametersRegexp.FindStringSubmatch(explainText)
+	if len(withParametersParts) == 4 {
+		querySample.Parameters = findQueryParameters(withParametersParts[2])
+		querySample.Query = withParametersParts[1]
+		querySample.ExplainOutputText = withParametersParts[3]
+	} else {
+		explainParts := autoExplainTextWithCostsRegexp.FindStringSubmatch(explainText)
+		if len(explainParts) != 3 {
+			// Fallback to the old way (not supporting new lines in Query Text, but does support EXPLAIN without costs)
+			explainParts = autoExplainTextPlanDetailsRegexp.FindStringSubmatch(explainText)
+			if len(explainParts) != 3 {
+				return state.PostgresQuerySample{}, fmt.Errorf("auto_explain output doesn't match expected format")
+			}
 		}
+
+		// If EXPLAIN output's first char is not a capital letter (e.g. not something like "Update on" or "Index Scan"),
+		// likely it's hitting the Heroku's newline break in "Query Text:" chunk
+		// Handle the separation of the query and the explain output text with the tab for these cases
+		// (this can be retired with the autoExplainTextWithCostsRegexp, but leaving here for the EXPLAIN without costs case)
+		explainOutputFirstChar := explainParts[2][0]
+		if cUtil.IsHeroku() && !(explainOutputFirstChar >= 'A' && explainOutputFirstChar <= 'Z') {
+			if parts := herokuAutoExplainWithTabRegexp.FindStringSubmatch(explainText); len(parts) == 3 {
+				explainParts = parts
+			}
+		}
+		querySample.Query = explainParts[1]
+		querySample.ExplainOutputText = explainParts[2]
 	}
-	return state.PostgresQuerySample{
-		Query:             strings.TrimSpace(explainParts[1]),
-		RuntimeMs:         queryRuntimeMs,
-		OccurredAt:        logLine.OccurredAt,
-		Username:          logLine.Username,
-		Database:          logLine.Database,
-		LogLineUUID:       logLine.UUID,
-		HasExplain:        true,
-		ExplainSource:     pganalyze_collector.QuerySample_AUTO_EXPLAIN_EXPLAIN_SOURCE,
-		ExplainFormat:     pganalyze_collector.QuerySample_TEXT_EXPLAIN_FORMAT,
-		ExplainOutputText: explainParts[2],
-	}, nil
+	return querySample, nil
 }
 
 func TransformLogMinDurationStatementToQuerySample(logLine state.LogLine, queryText string, queryRuntime string, queryProtocolStep string, parameterParts [][]string) (s state.PostgresQuerySample, ok bool) {
@@ -128,4 +132,20 @@ func TransformLogMinDurationStatementToQuerySample(logLine state.LogLine, queryT
 		}
 	}
 	return sample, true
+}
+
+func findQueryParameters(paramText string) []null.String {
+	// Handle Query Parameters (available from Postgres 16+)
+	var parameters []null.String
+	// Regular expression to find all values in single quotes or NULL
+	// Query Parameters example: $1 = 'foo', $2 = '123', $3 = NULL, $4 = 'bo''o'
+	re := regexp.MustCompile(`'((?:[^']|'')*)'|NULL`)
+	for _, part := range re.FindAllString(paramText, -1) {
+		if part == "NULL" {
+			parameters = append(parameters, null.NewString("", false))
+		} else {
+			parameters = append(parameters, null.StringFrom(strings.Trim(part, "'")))
+		}
+	}
+	return parameters
 }

--- a/logs/querysample/querysample.go
+++ b/logs/querysample/querysample.go
@@ -55,7 +55,7 @@ func transformExplainJSONToQuerySample(logLine state.LogLine, explainText string
 }
 
 var autoExplainTextWithQueryParametersRegexp = regexp.MustCompile(`^Query Text: ([\s\S]+)\r?\n\s*Query Parameters: (.+)\r?\n\s*([\s\S]+)`)
-var autoExplainTextWithCostsRegexp = regexp.MustCompile(`^Query Text: ([\s\S]+?)\r?\n\s*([\S ]+  \(cost=\d+\.\d{2}\.\.\d+\.\d{2} rows=\d+ width=\d+\)[\s\S]+)`)
+var autoExplainTextWithCostsRegexp = regexp.MustCompile(`^Query Text: ([\s\S]+?)\r?\n\s*([\S ]+  \(cost=\d+\.\d+\.\.\d+\.\d+ rows=\d+ width=\d+\)[\s\S]+)`)
 
 func transformExplainTextToQuerySample(logLine state.LogLine, explainText string, queryRuntimeMs float64) (state.PostgresQuerySample, error) {
 	querySample := state.PostgresQuerySample{

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -313,7 +313,7 @@ func postprocessAndSendLogs(ctx context.Context, server *state.Server, globalCol
 		for idx, sample := range transientLogState.QuerySamples {
 			// Ensure we always normalize the query text (when sample normalization is on), even if EXPLAIN errors out
 			sample.Query = util.NormalizeQuery(sample.Query, "unparseable", -1)
-			for pIdx, _ := range sample.Parameters {
+			for pIdx := range sample.Parameters {
 				sample.Parameters[pIdx] = null.StringFrom("<removed>")
 			}
 			if sample.ExplainOutputText != "" {
@@ -321,6 +321,8 @@ func postprocessAndSendLogs(ctx context.Context, server *state.Server, globalCol
 				sample.ExplainError = "EXPLAIN normalize failed: auto_explain format is not JSON - not supported (discarding EXPLAIN)"
 			}
 			if sample.ExplainOutputJSON != nil {
+				// force removing parameters
+				sample.ExplainOutputJSON.QueryParameters = ""
 				sample.ExplainOutputJSON, err = querysample.NormalizeExplainJSON(sample.ExplainOutputJSON)
 				if err != nil {
 					sample.ExplainOutputJSON = nil

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -321,7 +321,7 @@ func postprocessAndSendLogs(ctx context.Context, server *state.Server, globalCol
 				sample.ExplainError = "EXPLAIN normalize failed: auto_explain format is not JSON - not supported (discarding EXPLAIN)"
 			}
 			if sample.ExplainOutputJSON != nil {
-				// force removing parameters
+				// remove parameters as part of normalization
 				sample.ExplainOutputJSON.QueryParameters = ""
 				sample.ExplainOutputJSON, err = querysample.NormalizeExplainJSON(sample.ExplainOutputJSON)
 				if err != nil {

--- a/state/postgres_query_sample.go
+++ b/state/postgres_query_sample.go
@@ -33,6 +33,7 @@ type ExplainPlanContainer struct {
 	QueryText       string                `json:"Query Text,omitempty"`
 	Settings        *map[string]string    `json:"Settings,omitempty"`
 	Triggers        *[]ExplainPlanTrigger `json:"Triggers,omitempty"`
+	QueryParameters string                `json:"Query Parameters,omitempty"`
 }
 
 type PostgresQuerySample struct {


### PR DESCRIPTION
Starting from Postgres 16, auto_explain outputs the query parameters (bind parameters), used for prepared statements.
With this PR, the collector supports to extract these parameters and send them within query samples, with both JSON and TEXT format.

This PR also improves new lines support with text format. Previously, the text format is not parsing a query text and an EXPLAIN output well, and if the query text contains new lines, it was simply failing to extract them correctly.

With this PR, first we try to match the text format auto_explain with a newly introduced "Query Parameters:", which makes our life easier to actually separate a query text and an EXPLAIN output.
If that doesn't go well, we try to match with the cost output:
https://github.com/postgres/postgres/blob/4d93bbd4e0d414a33521f62d6249ac88486c866f/src/backend/commands/explain.c#L1815
While the most of auto_explain should have the cost output (it's turned on by default), you can also turn it off. In that case, use the existing logic as a fallback.
This way, most of the users should see the improved support even if text format + query text new lines are used.