### PR TITLE
Improve Azure log handling to support Flexible Server and Cosmos DB better

### DIFF
--- a/input/system/azure/logs.go
+++ b/input/system/azure/logs.go
@@ -253,7 +253,7 @@ func GetServerNameFromRecord(in AzurePostgresLogRecord) string {
 func ParseRecordToLogLines(in AzurePostgresLogRecord, parser state.LogParser) ([]state.LogLine, error) {
 	logLineContent := in.Properties.Message
 
-	if in.IsSingleServer() { // Single Server
+	if in.IsSingleServer() {
 		// Adjust Azure-modified log messages to be standard Postgres log messages
 		if strings.HasPrefix(logLineContent, "connection received:") {
 			logLineContent = connectionReceivedRegexp.ReplaceAllString(logLineContent, "$1")
@@ -267,7 +267,7 @@ func ParseRecordToLogLines(in AzurePostgresLogRecord, parser state.LogParser) ([
 		// Add prefix and error level, which are separated from the content on
 		// Single Server (but our parser expects them together)
 		logLineContent = fmt.Sprintf("%s%s:  %s", in.Properties.Prefix, in.Properties.ErrorLevel, logLineContent)
-	} else if in.IsCosmosDB() { // Cosmos DB
+	} else if in.IsCosmosDB() {
 		prefix, content, ok := parser.GetPrefixAndContent(logLineContent)
 		if ok {
 			// Cosmos DB doesn't output the log level after the log_line_prefix and before the content

--- a/input/system/azure/logs.go
+++ b/input/system/azure/logs.go
@@ -274,6 +274,8 @@ func ParseRecordToLogLines(in AzurePostgresLogRecord, parser state.LogParser) ([
 			// Manually adding it between them so the parser can parse the log line
 			logLineContent = fmt.Sprintf("%s%s:  %s", prefix, in.Properties.ErrorLevel, content)
 		}
+	} else {
+		// Flexible Server: no tweak needed
 	}
 	logLine, ok := parser.ParseLine(logLineContent)
 	if !ok {

--- a/input/system/azure/logs_test.go
+++ b/input/system/azure/logs_test.go
@@ -114,6 +114,71 @@ var parseRecordTests = []parseRecordTestpair{
 		"pganalyze-test",
 		nil,
 	},
+	{
+		`{
+			"LogicalServerName": "pganalyze-test",
+			"SubscriptionId": "",
+			"ResourceGroup": "",
+			"time": "2024-08-20T04:29:38.302Z",
+			"resourceId": "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/NETWORKWATCHERRG/PROVIDERS/MICROSOFT.DBFORPOSTGRESQL/FLEXIBLESERVERS/PGANALYZE-TEST",
+			"category": "PostgreSQLLogs",
+			"operationName": "LogEvent",
+			"properties": {
+				"prefix": "",
+				"message": "2024-08-20 04:12:31.701 UTC [1177] [user=[unknown],db=[unknown],app=[unknown]] LOG:  connection received: host=127.0.0.1 port=52498",
+				"detail": "",
+				"errorLevel": "LOG",
+				"domain": "",
+				"schemaName": "",
+				"tableName": "",
+				"columnName": "",
+				"datatypeName": ""
+			}
+		}`, []state.LogLine{
+			{
+				Content:    "connection received: host=127.0.0.1 port=52498",
+				LogLevel:   pganalyze_collector.LogLineInformation_LOG,
+				OccurredAt: time.Date(2024, time.August, 20, 4, 12, 31, 701*1000*1000, time.UTC),
+				BackendPid: 1177,
+			},
+		},
+		"pganalyze-test",
+		nil,
+	},
+	// Cosmos DB examples
+	{
+		`{
+			"LogicalServerName": "",
+			"SubscriptionId": "",
+			"ResourceGroup": "",
+			"time": "2024-08-21T08:48:57.0145890Z",
+			"resourceId": "/SUBSCRIPTIONS/00000000-0000-0000-0000-000000000000/RESOURCEGROUPS/NETWORKWATCHERRG/PROVIDERS/MICROSOFT.DBFORPOSTGRESQL/SERVERGROUPSV2/PGANALYZE-TEST",
+			"category": "PostgreSQLLogs",
+			"operationName": "LogEvent",
+			"properties": {
+				"prefix": "",
+				"message": "2024-08-21 08:48:57.014 UTC [167373] [user=postgres,db=postgres,app=[unknown]] connection authorized: user=postgres database=postgres application_name=citus_azure-admin",
+				"detail": "",
+				"errorLevel": "LOG",
+				"domain": "",
+				"schemaName": "",
+				"tableName": "",
+				"columnName": "",
+				"datatypeName": ""
+			}
+		}`, []state.LogLine{
+			{
+				Content:    "connection authorized: user=postgres database=postgres application_name=citus_azure-admin",
+				LogLevel:   pganalyze_collector.LogLineInformation_LOG,
+				OccurredAt: time.Date(2024, time.August, 21, 8, 48, 57, 14*1000*1000, time.UTC),
+				BackendPid: 167373,
+				Username:   "postgres",
+				Database:   "postgres",
+			},
+		},
+		"pganalyze-test",
+		nil,
+	},
 	// Single Server examples
 	{
 		`{
@@ -280,7 +345,7 @@ var parseRecordTests = []parseRecordTestpair{
 func TestParseRecordToLogLines(t *testing.T) {
 	for i, pair := range parseRecordTests {
 		var prefix string
-		if i < 3 {
+		if i < 5 {
 			prefix = logs.LogPrefixCustom3
 		} else {
 			prefix = logs.LogPrefixAzure

--- a/state/state.go
+++ b/state/state.go
@@ -321,6 +321,7 @@ type LogParser interface {
 	GetOccurredAt(timePart string) time.Time
 	ParseLine(line string) (logLine LogLine, ok bool)
 	ValidatePrefix() error
+	GetPrefixAndContent(line string) (prefix string, content string, ok bool)
 }
 
 func (s *Server) SetLogIgnoreFlags(ignoreStatement bool, ignoreDuration bool) {


### PR DESCRIPTION
This PR fixes two things of Azure log handling (Log Insights):

1. Handle the case Flexible Server returns `LogicalServerName` in record
   * This bug was found in https://github.com/pganalyze/collector/pull/494#issuecomment-2297975788
   * Previously, it was assumed that it won't be returned with Flexible Server
   * Instead, use `resourceId`, which contains resource type, to identify if it's single server or not
2. Fix parse errors with Cosmos DB logs
   * Lukas mentioned that this was reported by the customer that the current logic doesn't work with Cosmos DB
   * Confirmed that it doesn't work due to how Cosmos DB doesn't add log level after the prefix
   * Applied some workaround as a fix (similar to Flexible Server but a bit more complex)

