### PR TITLE
Redact utility statements by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/fatih/color v1.16.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.1
-	github.com/pganalyze/pg_query_go/v5 v5.1.0
+	github.com/pganalyze/pg_query_go/v5 v5.1.1-0.20240806162031-502d8d478511
 	github.com/prometheus/procfs v0.7.3
 	go.opentelemetry.io/otel v1.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/fatih/color v1.16.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.1
-	github.com/pganalyze/pg_query_go/v5 v5.1.1-0.20240806162031-502d8d478511
+	github.com/pganalyze/pg_query_go/v5 v5.1.1-0.20240829182208-c3a818d346a9
 	github.com/prometheus/procfs v0.7.3
 	go.opentelemetry.io/otel v1.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/ogier/pflag v0.0.0-20160129220114-45c278ab3607 h1:db+rES1EpSjP45xOU3h
 github.com/ogier/pflag v0.0.0-20160129220114-45c278ab3607/go.mod h1:zkFki7tvTa0tafRvTBIZTvzYyAu6kQhPZFnshFFPE+g=
 github.com/papertrail/go-tail v0.0.0-20180509224916-973c153b0431 h1:i1egM7gz4bPxLCIwBJOkpk6TqHpjTnL4dE1xdN/4dcs=
 github.com/papertrail/go-tail v0.0.0-20180509224916-973c153b0431/go.mod h1:dMID0RaS2a5rhpOjC4RsAKitU6WGgkFBZnPVffL69b8=
-github.com/pganalyze/pg_query_go/v5 v5.1.1-0.20240806162031-502d8d478511 h1:HWM/uR3ajSgm7RHcdqZdid+kuEgO2cLkpNE4ScXBPIA=
-github.com/pganalyze/pg_query_go/v5 v5.1.1-0.20240806162031-502d8d478511/go.mod h1:FsglvxidZsVN+Ltw3Ai6nTgPVcK2BPukH3jCDEqc1Ug=
+github.com/pganalyze/pg_query_go/v5 v5.1.1-0.20240829182208-c3a818d346a9 h1:9aymnVwCh0j7i+Myb1x3g+Xm1JtAk4TrTAyqBwCWhN8=
+github.com/pganalyze/pg_query_go/v5 v5.1.1-0.20240829182208-c3a818d346a9/go.mod h1:FsglvxidZsVN+Ltw3Ai6nTgPVcK2BPukH3jCDEqc1Ug=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/ogier/pflag v0.0.0-20160129220114-45c278ab3607 h1:db+rES1EpSjP45xOU3h
 github.com/ogier/pflag v0.0.0-20160129220114-45c278ab3607/go.mod h1:zkFki7tvTa0tafRvTBIZTvzYyAu6kQhPZFnshFFPE+g=
 github.com/papertrail/go-tail v0.0.0-20180509224916-973c153b0431 h1:i1egM7gz4bPxLCIwBJOkpk6TqHpjTnL4dE1xdN/4dcs=
 github.com/papertrail/go-tail v0.0.0-20180509224916-973c153b0431/go.mod h1:dMID0RaS2a5rhpOjC4RsAKitU6WGgkFBZnPVffL69b8=
-github.com/pganalyze/pg_query_go/v5 v5.1.0 h1:MlxQqHZnvA3cbRQYyIrjxEjzo560P6MyTgtlaf3pmXg=
-github.com/pganalyze/pg_query_go/v5 v5.1.0/go.mod h1:FsglvxidZsVN+Ltw3Ai6nTgPVcK2BPukH3jCDEqc1Ug=
+github.com/pganalyze/pg_query_go/v5 v5.1.1-0.20240806162031-502d8d478511 h1:HWM/uR3ajSgm7RHcdqZdid+kuEgO2cLkpNE4ScXBPIA=
+github.com/pganalyze/pg_query_go/v5 v5.1.1-0.20240806162031-502d8d478511/go.mod h1:FsglvxidZsVN+Ltw3Ai6nTgPVcK2BPukH3jCDEqc1Ug=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/logs/analyze.go
+++ b/logs/analyze.go
@@ -2280,7 +2280,7 @@ func markUtilitySecret(line *state.LogLine) {
 		if m.Kind == state.StatementTextLogSecret {
 			query := line.Content[m.ByteStart:m.ByteEnd]
 			normalized, err := pg_query.NormalizeUtility(query)
-			if err == nil && len(query) != len(normalized) {
+			if err == nil && query != normalized {
 				line.SecretMarkers = append(line.SecretMarkers, state.LogSecretMarker{
 					ByteStart: m.ByteStart,
 					ByteEnd:   m.ByteEnd,

--- a/logs/analyze.go
+++ b/logs/analyze.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pganalyze/collector/logs/util"
 	"github.com/pganalyze/collector/output/pganalyze_collector"
 	"github.com/pganalyze/collector/state"
+	pg_query "github.com/pganalyze/pg_query_go/v5"
 )
 
 type match struct {
@@ -2246,6 +2247,9 @@ func AnalyzeBackendLogLines(logLines []state.LogLine) (logLinesOut []state.LogLi
 
 		logLine, statementLine, detailLine, contextLine, hintLine, samples = classifyAndSetDetails(logLine, statementLine, detailLine, contextLine, hintLine, samples)
 
+		markUtilitySecret(&logLine)
+		markUtilitySecret(&statementLine)
+
 		if statementLineIdx != 0 {
 			logLines[statementLineIdx] = statementLine
 		}
@@ -2269,4 +2273,21 @@ func AnalyzeBackendLogLines(logLines []state.LogLine) (logLinesOut []state.LogLi
 	}
 
 	return
+}
+
+func markUtilitySecret(line *state.LogLine) {
+	for _, m := range line.SecretMarkers {
+		if m.Kind == state.StatementTextLogSecret {
+			query := line.Content[m.ByteStart:m.ByteEnd]
+			normalized, err := pg_query.NormalizeUtility(query)
+			if err == nil && len(query) != len(normalized) {
+				line.SecretMarkers = append(line.SecretMarkers, state.LogSecretMarker{
+					ByteStart: m.ByteStart,
+					ByteEnd:   m.ByteEnd,
+					Kind:      state.CredentialLogSecret,
+				})
+				return
+			}
+		}
+	}
 }

--- a/logs/analyze_test.go
+++ b/logs/analyze_test.go
@@ -155,6 +155,34 @@ var tests = []testpair{
 		}},
 		nil,
 	},
+	{
+		[]state.LogLine{{
+			Content:  "duration: 3205.800 ms  execute a2: CREATE ROLE postgres PASSWORD 'xyz'\n",
+			LogLevel: pganalyze_collector.LogLineInformation_LOG,
+		}},
+		[]state.LogLine{{
+			Query:              "CREATE ROLE postgres PASSWORD 'xyz'",
+			LogLevel:           pganalyze_collector.LogLineInformation_LOG,
+			Classification:     pganalyze_collector.LogLineInformation_STATEMENT_DURATION,
+			ReviewedForSecrets: true,
+			SecretMarkers: []state.LogSecretMarker{
+				{
+					ByteStart: 35,
+					ByteEnd:   70,
+					Kind:      state.StatementTextLogSecret,
+				},
+				{
+					ByteStart: 35,
+					ByteEnd:   70,
+					Kind:      state.CredentialLogSecret,
+				},
+			},
+		}},
+		[]state.PostgresQuerySample{{
+			Query:     "CREATE ROLE postgres PASSWORD 'xyz'",
+			RuntimeMs: 3205.8,
+		}},
+	},
 	// Statement log
 	{
 		[]state.LogLine{{

--- a/vendor/github.com/pganalyze/pg_query_go/v5/CHANGELOG.md
+++ b/vendor/github.com/pganalyze/pg_query_go/v5/CHANGELOG.md
@@ -10,8 +10,6 @@
 * Update to libpg_query 16-5.1.0
   - Add support for running on Windows
   - Add support for compiling on 32-bit systems
-* Treewalker: Allow passing a block with a single argument to walk!
-* PgQuery::Node: Add inner and inner= helpers to get/set inner object
 
 
 ## 5.0.0     2023-12-23

--- a/vendor/github.com/pganalyze/pg_query_go/v5/Makefile
+++ b/vendor/github.com/pganalyze/pg_query_go/v5/Makefile
@@ -16,7 +16,7 @@ benchmark:
 
 # --- Below only needed for releasing new versions
 
-LIB_PG_QUERY_TAG = 16-5.1.0
+LIB_PG_QUERY_TAG = c492b8f6fa54811fb194b6964055bb7d480f8c91
 
 root_dir := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 LIB_TMPDIR = $(root_dir)/tmp

--- a/vendor/github.com/pganalyze/pg_query_go/v5/Makefile
+++ b/vendor/github.com/pganalyze/pg_query_go/v5/Makefile
@@ -16,7 +16,7 @@ benchmark:
 
 # --- Below only needed for releasing new versions
 
-LIB_PG_QUERY_TAG = c492b8f6fa54811fb194b6964055bb7d480f8c91
+LIB_PG_QUERY_TAG = 43bad3cbcd1a70a30494b64f464c3f60579884ed
 
 root_dir := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 LIB_TMPDIR = $(root_dir)/tmp
@@ -31,7 +31,7 @@ $(LIBDIRGZ):
 	mkdir -p $(LIB_TMPDIR)
 	curl -o $(LIBDIRGZ) https://codeload.github.com/pganalyze/libpg_query/tar.gz/$(LIB_PG_QUERY_TAG)
 
-update_source: $(LIBDIR)
+update_source: clean $(LIBDIR)
 	rm -f parser/*.{c,h}
 	rm -fr parser/include
 	# Reduce everything down to one directory

--- a/vendor/github.com/pganalyze/pg_query_go/v5/README.md
+++ b/vendor/github.com/pganalyze/pg_query_go/v5/README.md
@@ -59,7 +59,7 @@ func main() {
 Running will output the query's parse tree as JSON:
 
 ```json
-{"version":150001,"stmts":[{"stmt":{"SelectStmt":{"targetList":[{"ResTarget":{"val":{"A_Const":{"ival":{"ival":1},"location":7}},"location":7}}],"limitOption":"LIMIT_OPTION_DEFAULT","op":"SETOP_NONE"}}}]}
+{"version":160001,"stmts":[{"stmt":{"SelectStmt":{"targetList":[{"ResTarget":{"val":{"A_Const":{"ival":{"ival":1},"location":7}},"location":7}}],"limitOption":"LIMIT_OPTION_DEFAULT","op":"SETOP_NONE"}}}]}
 ```
 
 ### Parsing a query into Go structs

--- a/vendor/github.com/pganalyze/pg_query_go/v5/parser/include/pg_query.h
+++ b/vendor/github.com/pganalyze/pg_query_go/v5/parser/include/pg_query.h
@@ -96,6 +96,7 @@ extern "C" {
 #endif
 
 PgQueryNormalizeResult pg_query_normalize(const char* input);
+PgQueryNormalizeResult pg_query_normalize_utility(const char* input);
 PgQueryScanResult pg_query_scan(const char* input);
 PgQueryParseResult pg_query_parse(const char* input);
 PgQueryParseResult pg_query_parse_opts(const char* input, int parser_options);

--- a/vendor/github.com/pganalyze/pg_query_go/v5/parser/parser.go
+++ b/vendor/github.com/pganalyze/pg_query_go/v5/parser/parser.go
@@ -175,6 +175,24 @@ func Normalize(input string) (result string, err error) {
 	return
 }
 
+// Normalize the passed utility statement to replace constant values with ? characters
+func NormalizeUtility(input string) (result string, err error) {
+	inputC := C.CString(input)
+	defer C.free(unsafe.Pointer(inputC))
+
+	resultC := C.pg_query_normalize_utility(inputC)
+	defer C.pg_query_free_normalize_result(resultC)
+
+	if resultC.error != nil {
+		err = newPgQueryError(resultC.error)
+		return
+	}
+
+	result = C.GoString(resultC.normalized_query)
+
+	return
+}
+
 func SplitWithScanner(input string, trimSpace bool) (result []string, err error) {
 	inputC := C.CString(input)
 	defer C.free(unsafe.Pointer(inputC))

--- a/vendor/github.com/pganalyze/pg_query_go/v5/parser/pg_query_normalize.c
+++ b/vendor/github.com/pganalyze/pg_query_go/v5/parser/pg_query_normalize.c
@@ -48,6 +48,9 @@ typedef struct pgssConstLocations
 	int *param_refs;
 	int param_refs_buf_size;
 	int param_refs_count;
+
+	/* Should only utility statements be normalized? Set by pg_query_normalize_utility */
+	bool normalize_utility_only;
 } pgssConstLocations;
 
 /*
@@ -398,8 +401,10 @@ static bool const_record_walker(Node *node, pgssConstLocations *jstate)
 		case T_RawStmt:
 			return const_record_walker((Node *) ((RawStmt *) node)->stmt, jstate);
 		case T_VariableSetStmt:
+			if (jstate->normalize_utility_only) return false;
 			return const_record_walker((Node *) ((VariableSetStmt *) node)->args, jstate);
 		case T_CopyStmt:
+			if (jstate->normalize_utility_only) return false;
 			return const_record_walker((Node *) ((CopyStmt *) node)->query, jstate);
 		case T_ExplainStmt:
 			return const_record_walker((Node *) ((ExplainStmt *) node)->query, jstate);
@@ -408,10 +413,13 @@ static bool const_record_walker(Node *node, pgssConstLocations *jstate)
 		case T_AlterRoleStmt:
 			return const_record_walker((Node *) ((AlterRoleStmt *) node)->options, jstate);
 		case T_DeclareCursorStmt:
+			if (jstate->normalize_utility_only) return false;
 			return const_record_walker((Node *) ((DeclareCursorStmt *) node)->query, jstate);
 		case T_CreateFunctionStmt:
+			if (jstate->normalize_utility_only) return false;
 			return const_record_walker((Node *) ((CreateFunctionStmt *) node)->options, jstate);
 		case T_DoStmt:
+			if (jstate->normalize_utility_only) return false;
 			return const_record_walker((Node *) ((DoStmt *) node)->args, jstate);
 		case T_CreateSubscriptionStmt:
 			record_matching_string(jstate, ((CreateSubscriptionStmt *) node)->conninfo);
@@ -428,6 +436,7 @@ static bool const_record_walker(Node *node, pgssConstLocations *jstate)
 			return false;
 		case T_SelectStmt:
 			{
+				if (jstate->normalize_utility_only) return false;
 				SelectStmt *stmt = (SelectStmt *) node;
 				ListCell *lc;
 				List *fp_and_param_refs_list = NIL;
@@ -540,6 +549,26 @@ static bool const_record_walker(Node *node, pgssConstLocations *jstate)
 
 				return false;
 			}
+		case T_MergeStmt:
+			{
+				if (jstate->normalize_utility_only) return false;
+				return raw_expression_tree_walker(node, const_record_walker, (void*) jstate);
+			}
+		case T_InsertStmt:
+			{
+				if (jstate->normalize_utility_only) return false;
+				return raw_expression_tree_walker(node, const_record_walker, (void*) jstate);
+			}
+		case T_UpdateStmt:
+			{
+				if (jstate->normalize_utility_only) return false;
+				return raw_expression_tree_walker(node, const_record_walker, (void*) jstate);
+			}
+		case T_DeleteStmt:
+			{
+				if (jstate->normalize_utility_only) return false;
+				return raw_expression_tree_walker(node, const_record_walker, (void*) jstate);
+			}
 		default:
 			{
 				PG_TRY();
@@ -558,7 +587,7 @@ static bool const_record_walker(Node *node, pgssConstLocations *jstate)
 	return false;
 }
 
-PgQueryNormalizeResult pg_query_normalize(const char* input)
+PgQueryNormalizeResult pg_query_normalize_ext(const char* input, bool normalize_utility_only)
 {
 	MemoryContext ctx = NULL;
 	PgQueryNormalizeResult result = {0};
@@ -588,6 +617,7 @@ PgQueryNormalizeResult pg_query_normalize(const char* input)
 		jstate.param_refs = NULL;
 		jstate.param_refs_buf_size = 0;
 		jstate.param_refs_count = 0;
+		jstate.normalize_utility_only = normalize_utility_only;
 
 		/* Walk tree and record const locations */
 		const_record_walker((Node *) tree, &jstate);
@@ -619,6 +649,17 @@ PgQueryNormalizeResult pg_query_normalize(const char* input)
 	pg_query_exit_memory_context(ctx);
 
 	return result;
+}
+
+PgQueryNormalizeResult pg_query_normalize(const char* input)
+{
+	return pg_query_normalize_ext(input, false);
+}
+
+
+PgQueryNormalizeResult pg_query_normalize_utility(const char* input)
+{
+	return pg_query_normalize_ext(input, true);
 }
 
 void pg_query_free_normalize_result(PgQueryNormalizeResult result)

--- a/vendor/github.com/pganalyze/pg_query_go/v5/parser/pg_query_scan.c
+++ b/vendor/github.com/pganalyze/pg_query_go/v5/parser/pg_query_scan.c
@@ -93,7 +93,7 @@ PgQueryScanResult pg_query_scan(const char* input)
       output_tokens[i] = malloc(sizeof(PgQuery__ScanToken));
       pg_query__scan_token__init(output_tokens[i]);
       output_tokens[i]->start = yylloc;
-      if (tok == SCONST || tok == BCONST || tok == XCONST || tok == IDENT || tok == C_COMMENT) {
+      if (tok == SCONST || tok == USCONST || tok == BCONST || tok == XCONST || tok == IDENT || tok == UIDENT || tok == C_COMMENT) {
         output_tokens[i]->end = yyextra.yyllocend;
       } else {
         output_tokens[i]->end = yylloc + ((struct yyguts_t*) yyscanner)->yyleng_r;

--- a/vendor/github.com/pganalyze/pg_query_go/v5/pg_query.go
+++ b/vendor/github.com/pganalyze/pg_query_go/v5/pg_query.go
@@ -57,6 +57,11 @@ func Normalize(input string) (result string, err error) {
 	return parser.Normalize(input)
 }
 
+// Normalize the passed utility statement to replace constant values with $n parameter references
+func NormalizeUtility(input string) (result string, err error) {
+	return parser.NormalizeUtility(input)
+}
+
 // Fingerprint - Fingerprint the passed SQL statement to a hex string
 func Fingerprint(input string) (result string, err error) {
 	return parser.FingerprintToHexStr(input)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -311,7 +311,7 @@ github.com/ogier/pflag
 # github.com/papertrail/go-tail v0.0.0-20180509224916-973c153b0431
 ## explicit
 github.com/papertrail/go-tail/follower
-# github.com/pganalyze/pg_query_go/v5 v5.1.0
+# github.com/pganalyze/pg_query_go/v5 v5.1.1-0.20240806162031-502d8d478511
 ## explicit; go 1.14
 github.com/pganalyze/pg_query_go/v5
 github.com/pganalyze/pg_query_go/v5/parser

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -311,7 +311,7 @@ github.com/ogier/pflag
 # github.com/papertrail/go-tail v0.0.0-20180509224916-973c153b0431
 ## explicit
 github.com/papertrail/go-tail/follower
-# github.com/pganalyze/pg_query_go/v5 v5.1.1-0.20240806162031-502d8d478511
+# github.com/pganalyze/pg_query_go/v5 v5.1.1-0.20240829182208-c3a818d346a9
 ## explicit; go 1.14
 github.com/pganalyze/pg_query_go/v5
 github.com/pganalyze/pg_query_go/v5/parser


### PR DESCRIPTION
Utility statements can include database secrets, so this PR classifies utility statements under `filter_log_secret = credential` (which is enabled by default as of #556), so they're redacted from the logs.

Depends on https://github.com/pganalyze/pg_query_go/pull/116