### PR TITLE
Error out on incomplete config sections

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -782,15 +782,11 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 			}
 
 			// Ensure we have no duplicate identifiers within one collector
-			skip := false
 			for _, server := range conf.Servers {
 				if config.Identifier == server.Identifier {
-					skip = true
+					logger.PrintError("Skipping config section %s, detected as duplicate. Note: To monitor multiple databases on the same server, db_name accepts a comma-separated list.", config.SectionName)
+					continue
 				}
-			}
-			if skip {
-				logger.PrintError("Skipping config section %s, detected as duplicate. Note: To monitor multiple databases on the same server, db_name accepts a comma-separated list.", config.SectionName)
-				continue
 			}
 
 			conf.Servers = append(conf.Servers, *config)

--- a/config/read.go
+++ b/config/read.go
@@ -766,8 +766,16 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 				return conf, err
 			}
 
+			if config.DbURL != "" {
+				_, err := url.Parse(config.DbURL)
+				if err != nil {
+					logger.PrintError("Could not parse db_url in section %s; check URL format and note that any special characters must be percent-encoded", config.SectionName)
+				}
+			}
+
 			if config.GetDbName() == "" {
-				return conf, fmt.Errorf("No connection info found for section %s; see https://pganalyze.com/docs/collector/settings", sectionName)
+				logger.PrintError("No connection info found for section %s; see https://pganalyze.com/docs/collector/settings", sectionName)
+				continue
 			}
 
 			config.SectionName = sectionName
@@ -786,13 +794,6 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 				if config.Identifier == server.Identifier {
 					logger.PrintError("Skipping config section %s, detected as duplicate. Note: To monitor multiple databases on the same server, db_name accepts a comma-separated list.", config.SectionName)
 					continue
-				}
-			}
-
-			if config.DbURL != "" {
-				_, err := url.Parse(config.DbURL)
-				if err != nil {
-					return conf, fmt.Errorf("Could not parse db_url in section %s; check URL format and note that any special characters must be percent-encoded", config.SectionName)
 				}
 			}
 

--- a/config/read.go
+++ b/config/read.go
@@ -800,7 +800,7 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 		}
 
 		if len(conf.Servers) == 0 {
-			return conf, fmt.Errorf("Configuration file is empty, please edit %s and reload the collector", filename)
+			return conf, fmt.Errorf("Configuration contains no valid servers, please edit %s and reload the collector", filename)
 		}
 	} else {
 		if util.IsHeroku() {

--- a/config/read.go
+++ b/config/read.go
@@ -749,8 +749,8 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 		sections := configFile.Sections()
 		for _, section := range sections {
 			sectionName := section.Name()
-			if sectionName == "pganalyze" || sectionName == "DEFAULT" {
-				// we already handled this above
+			if sectionName == "pganalyze" || sectionName == ini.DefaultSection {
+				// we already handled the pganalyze section above, and we don't use the default section
 				continue
 			}
 			config := &ServerConfig{}

--- a/config/read.go
+++ b/config/read.go
@@ -749,7 +749,7 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 		sections := configFile.Sections()
 		for _, section := range sections {
 			sectionName := section.Name()
-			if sectionName == "pganalyze" || sectionName == "" {
+			if sectionName == "pganalyze" || sectionName == "DEFAULT" {
 				// we already handled this above
 				continue
 			}

--- a/config/read.go
+++ b/config/read.go
@@ -789,15 +789,14 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 				}
 			}
 
-			conf.Servers = append(conf.Servers, *config)
-
 			if config.DbURL != "" {
 				_, err := url.Parse(config.DbURL)
 				if err != nil {
-					prefixedLogger := logger.WithPrefix(config.SectionName)
-					prefixedLogger.PrintError("Could not parse db_url; check URL format and note that any special characters must be percent-encoded")
+					return conf, fmt.Errorf("Could not parse db_url in section %s; check URL format and note that any special characters must be percent-encoded", config.SectionName)
 				}
 			}
+
+			conf.Servers = append(conf.Servers, *config)
 		}
 
 		if len(conf.Servers) == 0 {


### PR DESCRIPTION
A customer ran into this because they specified some configuration settings in uppercase (`DB_NAME`). We currently silently skip incomplete sections, which is pretty confusing.

Separately, I considered parsing config keys in a case-insensitive manner, but since some but not all of our environment variable keys are identical to our config file keys, I thought this would be more confusing than a clear error. I'm open to revisiting that decision.