### PR TITLE
Fix hang for --discover-log-location flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -225,6 +225,8 @@ func run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 
 	if globalCollectionOpts.DiscoverLogLocation {
 		selfhosted.DiscoverLogLocation(ctx, servers, globalCollectionOpts, logger)
+		testRunSuccess = make(chan bool, 1)
+		testRunSuccess <- true
 		return
 	}
 


### PR DESCRIPTION
This was missed in #384.
