### PR TITLE
Drop supported log_line_prefix check in test

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -175,7 +175,6 @@ type ServerConfig struct {
 	// Configure the collector's log parsing mechanism. Can be either 'legacy' (to
 	// use the old mechanism), or 'auto' (a new mechanism that can support an
 	// arbitrary log_line_prefix).
-	// TODO: analyze and mention (hopefully beneficial) performance impact
 	LogLinePrefix string `init:"db_log_line_prefix"`
 
 	// Specifies a table pattern to ignore - no statistics will be collected for

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -388,7 +388,7 @@ func TestLogsForAllServers(ctx context.Context, servers []*state.Server, globalC
 		} else if server.Config.SystemType == "heroku" && logLinePrefix == logs.LogPrefixHerokuHobbyTier {
 			prefixedLogger.PrintWarning("WARNING - Detected log_line_prefix indicates Heroku Postgres Hobby tier, which has no log output support")
 			continue
-		} else if !logs.IsSupportedPrefix(logLinePrefix) {
+		} else if server.Config.LogLinePrefix == "legacy" && !logs.IsSupportedPrefix(logLinePrefix) {
 			prefixedLogger.PrintError("ERROR - Unsupported log_line_prefix setting: '%s'", logLinePrefix)
 			prefixedLogger.PrintInfo("HINT - You can find a list of supported settings in the pganalyze documentation: https://pganalyze.com/docs/log-insights/setup/self-managed/troubleshooting")
 			hasFailedServers = true


### PR DESCRIPTION
- Avoid log_line_prefix check in log test in new mode
- Drop obsolete TODO
