### PR TITLE
Reuse existing database connections

### DIFF
--- a/input/full.go
+++ b/input/full.go
@@ -71,7 +71,7 @@ func CollectFull(ctx context.Context, server *state.Server, connection *sql.DB, 
 		logger.PrintError("Error collecting pg_stat_statements: %s", err)
 		var e *pq.Error
 		if errors.As(err, &e) && e.Code == "55000" && globalCollectionOpts.TestRun { // object_not_in_prerequisite_state
-			shared_preload_libraries, _ := postgres.GetPostgresSetting(ctx, "shared_preload_libraries", server, globalCollectionOpts, logger)
+			shared_preload_libraries, _ := postgres.GetPostgresSetting(ctx, connection, "shared_preload_libraries", server, globalCollectionOpts, logger)
 			logger.PrintInfo("HINT - Current shared_preload_libraries setting: '%s'. Your Postgres server may need to be restarted for changes to take effect.", shared_preload_libraries)
 			server.SelfTest.HintCollectionAspect(state.CollectionAspectPgStatStatements, "Current shared_preload_libraries setting: '%s'. Your Postgres server may need to be restarted for changes to take effect.", shared_preload_libraries)
 		}

--- a/input/postgres/helpers.go
+++ b/input/postgres/helpers.go
@@ -72,13 +72,9 @@ SELECT setting
 	FROM pg_settings
  WHERE name = '%s'`
 
-func GetPostgresSetting(ctx context.Context, settingName string, server *state.Server, globalCollectionOpts state.CollectionOpts, prefixedLogger *util.Logger) (string, error) {
+func GetPostgresSetting(ctx context.Context, db *sql.DB, settingName string, server *state.Server, globalCollectionOpts state.CollectionOpts, prefixedLogger *util.Logger) (string, error) {
 	var value string
-
-	db, err := EstablishConnection(ctx, server, prefixedLogger, globalCollectionOpts, "")
-	if err != nil {
-		return "", fmt.Errorf("Could not connect to database to retrieve \"%s\": %s", settingName, err)
-	}
+	var err error
 
 	err = db.QueryRow(QueryMarkerSQL + fmt.Sprintf(settingValueSQL, settingName)).Scan(&value)
 	db.Close()

--- a/input/system/selfhosted/logs.go
+++ b/input/system/selfhosted/logs.go
@@ -3,6 +3,7 @@ package selfhosted
 import (
 	"bufio"
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -39,15 +40,10 @@ SELECT setting
 	FROM pg_settings
  WHERE name = '%s'`
 
-func getPostgresSetting(ctx context.Context, settingName string, server *state.Server, globalCollectionOpts state.CollectionOpts, prefixedLogger *util.Logger) (string, error) {
+func getPostgresSetting(ctx context.Context, db *sql.DB, settingName string, server *state.Server, globalCollectionOpts state.CollectionOpts, prefixedLogger *util.Logger) (string, error) {
 	var value string
 
-	db, err := postgres.EstablishConnection(ctx, server, prefixedLogger, globalCollectionOpts, "")
-	if err != nil {
-		return "", fmt.Errorf("Could not connect to database to retrieve \"%s\": %s", settingName, err)
-	}
-
-	err = db.QueryRowContext(ctx, postgres.QueryMarkerSQL+fmt.Sprintf(settingValueSQL, settingName)).Scan(&value)
+	err := db.QueryRowContext(ctx, postgres.QueryMarkerSQL+fmt.Sprintf(settingValueSQL, settingName)).Scan(&value)
 	db.Close()
 	if err != nil {
 		return "", fmt.Errorf("Could not read \"%s\" setting: %s", settingName, err)
@@ -66,7 +62,13 @@ func DiscoverLogLocation(ctx context.Context, servers []*state.Server, globalCol
 			prefixedLogger.PrintWarning("WARNING - Database hostname is not localhost - Log Insights requires the collector to run on the database server directly for self-hosted systems")
 		}
 
-		logDestination, err := getPostgresSetting(ctx, "log_destination", server, globalCollectionOpts, prefixedLogger)
+		db, err := postgres.EstablishConnection(ctx, server, prefixedLogger, globalCollectionOpts, "")
+		if err != nil {
+			prefixedLogger.PrintError("Could not connect to database: %s", err)
+			continue
+		}
+
+		logDestination, err := getPostgresSetting(ctx, db, "log_destination", server, globalCollectionOpts, prefixedLogger)
 		if err != nil {
 			prefixedLogger.PrintError("ERROR - %s", err)
 			continue
@@ -80,7 +82,7 @@ func DiscoverLogLocation(ctx context.Context, servers []*state.Server, globalCol
 			continue
 		}
 
-		loggingCollector, err := getPostgresSetting(ctx, "logging_collector", server, globalCollectionOpts, prefixedLogger)
+		loggingCollector, err := getPostgresSetting(ctx, db, "logging_collector", server, globalCollectionOpts, prefixedLogger)
 		if err != nil {
 			prefixedLogger.PrintError("ERROR - %s", err)
 			continue
@@ -100,7 +102,7 @@ func DiscoverLogLocation(ctx context.Context, servers []*state.Server, globalCol
 		}
 
 		if loggingCollector == "on" {
-			logDirectory, err := getPostgresSetting(ctx, "log_directory", server, globalCollectionOpts, prefixedLogger)
+			logDirectory, err := getPostgresSetting(ctx, db, "log_directory", server, globalCollectionOpts, prefixedLogger)
 			if err != nil {
 				prefixedLogger.PrintError("ERROR - Could not retrieve log_directory setting from Postgres: %s", err)
 				continue

--- a/runner/activity.go
+++ b/runner/activity.go
@@ -68,7 +68,7 @@ func processActivityForServer(ctx context.Context, server *state.Server, globalC
 		defer connection.Close()
 	}
 
-	trackActivityQuerySize, err := postgres.GetPostgresSetting(ctx, "track_activity_query_size", server, globalCollectionOpts, logger)
+	trackActivityQuerySize, err := postgres.GetPostgresSetting(ctx, connection, "track_activity_query_size", server, globalCollectionOpts, logger)
 	if err != nil {
 		activity.TrackActivityQuerySize = -1
 	} else {

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -380,7 +380,13 @@ func TestLogsForAllServers(ctx context.Context, servers []*state.Server, globalC
 			continue
 		}
 
-		logLinePrefix, err := postgres.GetPostgresSetting(ctx, "log_line_prefix", server, globalCollectionOpts, prefixedLogger)
+		db, err := postgres.EstablishConnection(ctx, server, prefixedLogger, globalCollectionOpts, "")
+		if err != nil {
+			prefixedLogger.PrintError("Could not connect to database: %s", err)
+			continue
+		}
+
+		logLinePrefix, err := postgres.GetPostgresSetting(ctx, db, "log_line_prefix", server, globalCollectionOpts, prefixedLogger)
 		if err != nil {
 			prefixedLogger.PrintError("ERROR - Could not check log_line_prefix for server: %s", err)
 			hasFailedServers = true


### PR DESCRIPTION
- Update `postgres.GetPostgresSetting` to accept a database connection as an argumentf
- Update `runner/full.go` to use a single database connection while collecting a full snapshot