### PR TITLE
Update logo for Deploy to Heroku button

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Heroku Monitoring
 
 When monitoring a Heroku Postgres database, it is recommended you deploy the collector as its own app inside your Heroku account.
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/pganalyze/collector)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://www.heroku.com/deploy?template=https://github.com/pganalyze/collector)
 
 Follow the instructions in the pganalyze documentation to add your databases to the collector.
 

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "pganalyze collector",
   "description": "Helper for pganalyze to collect PostgreSQL monitoring data from Heroku apps",
   "repository": "https://github.com/pganalyze/collector",
-  "logo": "http://static-assets.pganalyze.com/logo_square_120px.png",
+  "logo": "https://static-assets.pganalyze.com/pganalyze_logo_bimi.svg",
   "keywords": ["postgresql", "monitoring"],
   "env": {
     "PGA_API_KEY": {


### PR DESCRIPTION
Just noticed that it's using the old logo. Let's update to the new one.

Old
![](http://static-assets.pganalyze.com/logo_square_120px.png)

New
![](https://static-assets.pganalyze.com/pganalyze_logo_bimi.svg)

Also adding www to heroku.com as it first redirects www.heroku.com and we can skip that redirect by nicely adding www.