### PR TITLE
Improve support for EDB Postgres Advanced Server (EPAS)

### DIFF
--- a/input/postgres/functions.go
+++ b/input/postgres/functions.go
@@ -62,7 +62,7 @@ func GetFunctions(ctx context.Context, logger *util.Logger, db *sql.DB, postgres
 	}
 
 	if postgresVersion.IsEPAS {
-		systemCatalogFilter = relationSQLepasSystemCatalogFilter
+		systemCatalogFilter = relationSQLEPASSystemCatalogFilter
 	} else {
 		systemCatalogFilter = relationSQLdefaultSystemCatalogFilter
 	}
@@ -130,7 +130,7 @@ func GetFunctionStats(ctx context.Context, db *sql.DB, postgresVersion state.Pos
 	var systemCatalogFilter string
 
 	if postgresVersion.IsEPAS {
-		systemCatalogFilter = relationSQLepasSystemCatalogFilter
+		systemCatalogFilter = relationSQLEPASSystemCatalogFilter
 	} else {
 		systemCatalogFilter = relationSQLdefaultSystemCatalogFilter
 	}

--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -80,7 +80,7 @@ SELECT c.oid,
        AND c.relkind IN ('r','v','m','p')
 			 AND c.relpersistence <> 't'
 			 AND c.oid NOT IN (SELECT pd.objid FROM pg_catalog.pg_depend pd WHERE pd.deptype = 'e' AND pd.classid = 'pg_catalog.pg_class'::regclass)
-			 AND n.nspname NOT IN ('pg_catalog','pg_toast','information_schema')
+			 AND %s
 			 AND ($1 = '' OR (n.nspname || '.' || c.relname) !~* $1)
  UNION ALL
 SELECT relid,
@@ -153,6 +153,7 @@ SELECT relid,
 
 func GetRelationStats(ctx context.Context, db *sql.DB, postgresVersion state.PostgresVersion, server *state.Server) (relStats state.PostgresRelationStatsMap, err error) {
 	var insertsSinceVacuumField string
+	var systemCatalogFilter string
 
 	if postgresVersion.Numeric >= state.PostgresVersion13 {
 		insertsSinceVacuumField = relationStatsSQLInsertsSinceVacuumFieldPg13
@@ -160,7 +161,13 @@ func GetRelationStats(ctx context.Context, db *sql.DB, postgresVersion state.Pos
 		insertsSinceVacuumField = relationStatsSQLInsertsSinceVacuumFieldDefault
 	}
 
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+fmt.Sprintf(relationStatsSQL, insertsSinceVacuumField))
+	if postgresVersion.IsEPAS {
+		systemCatalogFilter = relationSQLepasSystemCatalogFilter
+	} else {
+		systemCatalogFilter = relationSQLdefaultSystemCatalogFilter
+	}
+
+	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+fmt.Sprintf(relationStatsSQL, insertsSinceVacuumField, systemCatalogFilter))
 	if err != nil {
 		err = fmt.Errorf("RelationStats/Prepare: %s", err)
 		return

--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -162,7 +162,7 @@ func GetRelationStats(ctx context.Context, db *sql.DB, postgresVersion state.Pos
 	}
 
 	if postgresVersion.IsEPAS {
-		systemCatalogFilter = relationSQLepasSystemCatalogFilter
+		systemCatalogFilter = relationSQLEPASSystemCatalogFilter
 	} else {
 		systemCatalogFilter = relationSQLdefaultSystemCatalogFilter
 	}

--- a/input/postgres/relations.go
+++ b/input/postgres/relations.go
@@ -12,7 +12,7 @@ import (
 )
 
 const relationSQLdefaultSystemCatalogFilter = "n.nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema')"
-const relationSQLepasSystemCatalogFilter = "n.nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema', 'sys') AND n.nspparent <> 'sys'::regnamespace"
+const relationSQLEPASSystemCatalogFilter = "n.nspname NOT IN ('pg_catalog', 'pg_toast', 'information_schema', 'sys') AND n.nspparent <> 'sys'::regnamespace"
 
 const relationsSQLOidField = "c.relhasoids AS relation_has_oids"
 const relationsSQLpg12OidField = "false AS relation_has_oids"
@@ -189,7 +189,7 @@ func GetRelations(ctx context.Context, db *sql.DB, postgresVersion state.Postgre
 
 	var systemCatalogFilter string
 	if postgresVersion.IsEPAS {
-		systemCatalogFilter = relationSQLepasSystemCatalogFilter
+		systemCatalogFilter = relationSQLEPASSystemCatalogFilter
 	} else {
 		systemCatalogFilter = relationSQLdefaultSystemCatalogFilter
 	}

--- a/input/postgres/schema.go
+++ b/input/postgres/schema.go
@@ -170,7 +170,7 @@ func collectSchemaData(ctx context.Context, collectionOpts state.CollectionOpts,
 	}
 
 	if collectionOpts.CollectPostgresFunctions {
-		newFunctions, err := GetFunctions(ctx, db, postgresVersion, databaseOid, server.Config.IgnoreSchemaRegexp)
+		newFunctions, err := GetFunctions(ctx, logger, db, postgresVersion, databaseOid, server.Config.IgnoreSchemaRegexp)
 		if err != nil {
 			return ps, ts, fmt.Errorf("error collecting stored procedure metadata: %s", err)
 		}

--- a/input/postgres/types.go
+++ b/input/postgres/types.go
@@ -40,7 +40,7 @@ SELECT t.oid,
 func GetTypes(ctx context.Context, db *sql.DB, postgresVersion state.PostgresVersion, currentDatabaseOid state.Oid) ([]state.PostgresType, error) {
 	var systemCatalogFilter string
 	if postgresVersion.IsEPAS {
-		systemCatalogFilter = relationSQLepasSystemCatalogFilter
+		systemCatalogFilter = relationSQLEPASSystemCatalogFilter
 	} else {
 		systemCatalogFilter = relationSQLdefaultSystemCatalogFilter
 	}

--- a/input/postgres/version.go
+++ b/input/postgres/version.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"strings"
 
 	"github.com/pganalyze/collector/state"
 	"github.com/pganalyze/collector/util"
@@ -14,6 +15,7 @@ func GetPostgresVersion(ctx context.Context, logger *util.Logger, db *sql.DB) (v
 	if err != nil {
 		return
 	}
+	version.IsEPAS = strings.Contains(version.Full, "EnterpriseDB Advanced Server")
 
 	err = db.QueryRowContext(ctx, QueryMarkerSQL+"SHOW server_version").Scan(&version.Short)
 	if err != nil {

--- a/state/postgres_version.go
+++ b/state/postgres_version.go
@@ -22,6 +22,7 @@ type PostgresVersion struct {
 	Numeric int    `json:"numeric"` // e.g. 90501
 
 	// For collector use only, to avoid calling functions that don't work
-	IsAwsAurora bool
-	IsCitus     bool
+	IsAwsAurora bool // Amazon Aurora
+	IsCitus     bool // Citus extension (e.g. with Azure CosmosDB for PostgreSQL)
+	IsEPAS      bool // EnterpriseDB Advanced Server
 }


### PR DESCRIPTION
Previously the collector would emit system catalogs that are only existing on EPAS ("sys" schema and child schemas), causing unnecessary schema information to show in the pganalyze dashboard.

Here we fix this by introducing EPAS-specific filtering of system catalogs, and share the system catalog filter logic across all files that use it.

Further, EPAS allows function signatures to be re-used between functions and procedures (presumably this was allowed before upstream Postgres added CREATE PROCEDURE), like this:

```
BEGIN;
CREATE FUNCTION test() RETURNS void AS $$
BEGIN
    RAISE NOTICE 'test function';
END;
$$ LANGUAGE plpgsql;
CREATE PROCEDURE test() AS $$
BEGIN
    RAISE NOTICE 'test procedure';
END;
$$ LANGUAGE plpgsql;
COMMIT;
 
SELECT prokind, pronamespace, pg_catalog.pg_get_function_arguments(pp.oid), pg_catalog.pg_get_function_result(pp.oid) FROM pg_proc pp WHERE proname = 'test';

 prokind | pronamespace | pg_get_function_arguments | pg_get_function_result 
---------+--------------+---------------------------+------------------------
 f       |         2200 |                           | integer
 p       |         2200 |                           | 
(2 rows)
```

The same SQL causes an error on regular Postgres. Unfortunately this unexpected duplication causes a server-side error with pganalyze due to a unique constraint violation.

Whilst we could track this properly on the server side, since this is an edge case and there are no intents to support this in upstream Postgres (see note on https://www.postgresql.org/docs/current/sql-createprocedure.html), ignore duplicate functions/procedures that have the same signature for now, but only if we're on EPAS (to avoid overhead on regular Postgres).