### PR TITLE
Fix --analyze-logfile flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -316,7 +316,7 @@ func main() {
 	flag.BoolVar(&dryRunLogs, "dry-run-logs", false, "Print JSON data for log snapshot (without actually sending) and exit afterwards")
 	flag.StringVar(&analyzeLogfile, "analyze-logfile", "", "Analyzes the content of the given log file and returns debug output about it")
 	flag.StringVar(&analyzeLogfilePrefix, "analyze-logfile-prefix", "", "The log_line_prefix to use with --analyze-logfile")
-	flag.StringVar(&analyzeLogfileTz, "analyze-logfile-tz", "", "The timezone to use with --analyze-logfile (default UTC)")
+	flag.StringVar(&analyzeLogfileTz, "analyze-logfile-tz", "", "The log_timezone to use with --analyze-logfile (default: UTC)")
 	flag.StringVar(&analyzeDebugClassifications, "analyze-debug-classifications", "", "When used with --analyze-logfile, print detailed information about given classifications (can be comma-separated list of integer classifications, or keyword 'all')")
 	flag.StringVar(&filterLogFile, "filter-logfile", "", "Test command that filters all known secrets in the logfile according to the filter-log-secret option")
 	flag.StringVar(&filterLogSecret, "filter-log-secret", "all", "Sets the type of secrets filtered by the filter-logfile test command (default: all)")

--- a/main.go
+++ b/main.go
@@ -269,6 +269,8 @@ func main() {
 	var dryRun bool
 	var dryRunLogs bool
 	var analyzeLogfile string
+	var analyzeLogfilePrefix string
+	var analyzeLogfileTz string
 	var analyzeDebugClassifications string
 	var filterLogFile string
 	var filterLogSecret string
@@ -313,6 +315,8 @@ func main() {
 	flag.BoolVar(&dryRun, "dry-run", false, "Print JSON data that would get sent to web service (without actually sending) and exit afterwards")
 	flag.BoolVar(&dryRunLogs, "dry-run-logs", false, "Print JSON data for log snapshot (without actually sending) and exit afterwards")
 	flag.StringVar(&analyzeLogfile, "analyze-logfile", "", "Analyzes the content of the given log file and returns debug output about it")
+	flag.StringVar(&analyzeLogfilePrefix, "analyze-logfile-prefix", "", "The log_line_prefix to use with --analyze-logfile")
+	flag.StringVar(&analyzeLogfileTz, "analyze-logfile-tz", "", "The timezone to use with --analyze-logfile (default UTC)")
 	flag.StringVar(&analyzeDebugClassifications, "analyze-debug-classifications", "", "When used with --analyze-logfile, print detailed information about given classifications (can be comma-separated list of integer classifications, or keyword 'all')")
 	flag.StringVar(&filterLogFile, "filter-logfile", "", "Test command that filters all known secrets in the logfile according to the filter-log-secret option")
 	flag.StringVar(&filterLogSecret, "filter-log-secret", "all", "Sets the type of secrets filtered by the filter-logfile test command (default: all)")
@@ -427,7 +431,19 @@ func main() {
 		content := string(contentBytes)
 		reader := strings.NewReader(content)
 		logReader := logs.NewMaybeHerokuLogReader(reader)
-		logLines, samples := logs.ParseAndAnalyzeBuffer(logReader, time.Time{}, state.MakeServer(config.ServerConfig{}, false))
+		server := state.MakeServer(config.ServerConfig{}, false)
+		tz, err := time.LoadLocation(analyzeLogfileTz)
+		if err != nil {
+			fmt.Printf("ERROR: could not read time zone: %s\n", err)
+			return
+		}
+		if analyzeLogfilePrefix == "" {
+			fmt.Println("ERROR: must specify log_line_prefix used to generate logfile with --analyze-logfile-prefix")
+			return
+		}
+		server.LogParser = logs.NewLogParser(analyzeLogfilePrefix, tz, false)
+
+		logLines, samples := logs.ParseAndAnalyzeBuffer(logReader, time.Time{}, server)
 		logs.PrintDebugInfo(content, logLines, samples)
 		if analyzeDebugClassifications != "" {
 			classifications := strings.Split(analyzeDebugClassifications, ",")


### PR DESCRIPTION
In #494, I missed updating the --analyze-logfile flag. The flag is
intended to analyze a logfile "offline", which does not work with the
new mechanism, since that relies on being able to read the server's
log_timezone and log_line_prefix.

This adds additional flags to pass that information to the
--analyze-logfile path. The timezone defaults to UTC; the prefix is
required.