### PR TITLE
Build more regular expressions at boot time

### DIFF
--- a/logs/querysample/querysample.go
+++ b/logs/querysample/querysample.go
@@ -117,13 +117,14 @@ func TransformLogMinDurationStatementToQuerySample(logLine state.LogLine, queryT
 	return sample, true
 }
 
+// Regular expression to find all values in single quotes or NULL
+// Query Parameters example: $1 = 'foo', $2 = '123', $3 = NULL, $4 = 'bo”o'
+var valueRegexp = regexp.MustCompile(`(?:(NULL)|'((?:[^']|'')*)')`)
+
 func findQueryParameters(paramText string) []null.String {
 	// Handle Query Parameters (available from Postgres 16+)
 	var parameters []null.String
-	// Regular expression to find all values in single quotes or NULL
-	// Query Parameters example: $1 = 'foo', $2 = '123', $3 = NULL, $4 = 'bo''o'
-	re := regexp.MustCompile(`(?:(NULL)|'((?:[^']|'')*)')`)
-	for _, part := range re.FindAllString(paramText, -1) {
+	for _, part := range valueRegexp.FindAllString(paramText, -1) {
 		if part == "NULL" {
 			parameters = append(parameters, null.NewString("", false))
 		} else {

--- a/util/clean_http_error.go
+++ b/util/clean_http_error.go
@@ -6,10 +6,11 @@ import (
 	"regexp"
 )
 
+var regex = regexp.MustCompile("(?i): (get|post|patch) ")
+
 // Removes duplicate URLs added by retryablehttp
 func CleanHTTPError(error error) error {
 	message := fmt.Sprintf("%v", error)
-	regex := regexp.MustCompile("(?i): (get|post|patch) ")
 	array := regex.Split(message, -1)
 	return errors.New(array[len(array)-1])
 }


### PR DESCRIPTION
For support ticket 5773, I noticed that some places in the code we compile regular expressions at runtime for regular expressions that don't change. This PR fixes that, which should reduce CPU/memory usage.