### PR TITLE
Reduce memory usage when processing pg_stat_statements

### DIFF
--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -221,7 +221,8 @@ func GetStatements(ctx context.Context, server *state.Server, logger *util.Logge
 	}
 	defer rows.Close()
 
-	statementTexts := make(map[state.PostgresStatementKey]string)
+	statements := make(state.PostgresStatementMap)
+	statementTextsByFp := make(state.PostgresStatementTextMap)
 	statementStats := make(state.PostgresStatementStatsMap)
 
 	for rows.Next() {
@@ -247,7 +248,13 @@ func GetStatements(ctx context.Context, server *state.Server, logger *util.Logge
 		}
 
 		if showtext {
-			statementTexts[key] = receivedQuery.String
+			select {
+			// Since normalizing can take time, explicitly check for cancellations
+			case <-ctx.Done():
+				return nil, nil, nil, ctx.Err()
+			default:
+				fingerprintAndNormalize(key, receivedQuery.String, server, &statements, &statementTextsByFp)
+			}
 		}
 		if ignoreIOTiming(postgresVersion, receivedQuery) {
 			stats.BlkReadTime = 0
@@ -261,40 +268,6 @@ func GetStatements(ctx context.Context, server *state.Server, logger *util.Logge
 	}
 
 	server.SelfTest.MarkCollectionAspectOk(state.CollectionAspectPgStatStatements)
-
-	statements := make(state.PostgresStatementMap)
-	statementTextsByFp := make(state.PostgresStatementTextMap)
-	if showtext {
-		collectorQueryFingerprint := util.FingerprintText(util.QueryTextCollector)
-		insufficientPrivsQueryFingerprint := util.FingerprintText(util.QueryTextInsufficientPrivs)
-
-		for key, text := range statementTexts {
-			select {
-			// Since fingerprinting/normalizing can take time, explicitly check for cancellations
-			case <-ctx.Done():
-				return nil, nil, nil, ctx.Err()
-			default:
-				if insufficientPrivilege(text) {
-					statements[key] = state.PostgresStatement{
-						InsufficientPrivilege: true,
-						Fingerprint:           insufficientPrivsQueryFingerprint,
-					}
-				} else if collectorStatement(text) {
-					statements[key] = state.PostgresStatement{
-						Collector:   true,
-						Fingerprint: collectorQueryFingerprint,
-					}
-				} else {
-					fp := util.FingerprintQuery(text, server.Config.FilterQueryText, -1)
-					statements[key] = state.PostgresStatement{Fingerprint: fp}
-					_, ok := statementTextsByFp[fp]
-					if !ok {
-						statementTextsByFp[fp] = util.NormalizeQuery(text, server.Config.FilterQueryText, -1)
-					}
-				}
-			}
-		}
-	}
 
 	return statements, statementTextsByFp, statementStats, nil
 }
@@ -318,4 +291,28 @@ func ignoreIOTiming(postgresVersion state.PostgresVersion, receivedQuery null.St
 	}
 
 	return false
+}
+
+var collectorQueryFingerprint = util.FingerprintText(util.QueryTextCollector)
+var insufficientPrivsQueryFingerprint = util.FingerprintText(util.QueryTextInsufficientPrivs)
+
+func fingerprintAndNormalize(key state.PostgresStatementKey, text string, server *state.Server, statements *state.PostgresStatementMap, statementTextsByFp *state.PostgresStatementTextMap) {
+	if insufficientPrivilege(text) {
+		(*statements)[key] = state.PostgresStatement{
+			InsufficientPrivilege: true,
+			Fingerprint:           insufficientPrivsQueryFingerprint,
+		}
+	} else if collectorStatement(text) {
+		(*statements)[key] = state.PostgresStatement{
+			Collector:   true,
+			Fingerprint: collectorQueryFingerprint,
+		}
+	} else {
+		fp := util.FingerprintQuery(text, server.Config.FilterQueryText, -1)
+		(*statements)[key] = state.PostgresStatement{Fingerprint: fp}
+		_, ok := (*statementTextsByFp)[fp]
+		if !ok {
+			(*statementTextsByFp)[fp] = util.NormalizeQuery(text, server.Config.FilterQueryText, -1)
+		}
+	}
 }


### PR DESCRIPTION
Currently when processing `pg_stat_statements` data we collect all query texts into memory, then discard them in favor of pg_query's normalized version. This PR reduces memory pressure by immediately normalizing each query text instead of collecting them into a map.

Using the below benchmark, this PR reduces memory usage from 16 MB to 14 MB.

```sh
go test -bench=. -benchmem

# Before
BenchmarkPgStatStatements-10               7     143591024 ns/op    16130617 B/op     178235 allocs/op
# After
BenchmarkPgStatStatements-10               8     145522057 ns/op    14261621 B/op     177960 allocs/op
```

<details><summary>Benchmark:</summary>

```go
package main

import (
    "testing"
    "context"
    "log"
    "os"
    "github.com/pganalyze/collector/input/postgres"
    "github.com/pganalyze/collector/state"
    "github.com/pganalyze/collector/config"
    "github.com/pganalyze/collector/util"
)

func BenchmarkPgStatStatements(b *testing.B) {
    ctx := context.TODO()
    logger := &util.Logger{}
    logger.Destination = log.New(os.Stderr, "", log.LstdFlags)
    cfg := *config.GetDefaultConfig()
    cfg.DbURL = "postgresql://pgaweb@127.0.0.1:5432/pgaweb"
    cfg.DbName = "pgaweb_test"
    server := state.MakeServer(cfg, true)
    collectionOpts := state.CollectionOpts{}
    db, err := postgres.EstablishConnection(ctx, server, logger, collectionOpts, "pgaweb_test")
    if err != nil {
        panic(err)
    }
    version, err := postgres.GetPostgresVersion(ctx, logger, db)
    if err != nil {
        panic(err)
    }
    for i := 0; i < b.N; i++ {
        _, _, _, err := postgres.GetStatements(ctx, server, logger, db, collectionOpts, version, true, "self_hosted")
        if err != nil {
            panic(err)
        }
    }
}
```

</details>

What's surprising is that my local database only has 2 MB of log text to start with, so what's using the rest of the memory? Checking `pprof`, it seems the database connection is using a surprising amount of memory to `recvMessage` and `textDecode`.

```
go test -bench=. -benchmem -memprofile memprofile.out -cpuprofile profile.out
go tool pprof memprofile.out
top

      flat  flat%   sum%        cum   cum%
   76.55MB 36.89% 36.89%   198.18MB 95.51%  github.com/pganalyze/collector/input/postgres.GetStatements
   50.04MB 24.12% 61.01%    50.04MB 24.12%  github.com/lib/pq.textDecode
   37.07MB 17.87% 78.88%    37.07MB 17.87%  github.com/lib/pq.(*conn).recvMessage
   26.01MB 12.54% 91.41%    31.02MB 14.95%  github.com/pganalyze/collector/input/postgres.fingerprintAndNormalize
    5.01MB  2.41% 93.83%     5.01MB  2.41%  github.com/pganalyze/pg_query_go/v5/parser._Cfunc_GoString (inline)
       2MB  0.96% 94.79%        2MB  0.96%  github.com/aws/aws-sdk-go/aws/endpoints.init
       2MB  0.96% 95.76%        2MB  0.96%  github.com/lib/pq.binaryDecode
    1.53MB  0.74% 96.49%     1.53MB  0.74%  regexp/syntax.(*compiler).inst
    1.50MB  0.72% 97.22%     1.50MB  0.72%  database/sql.asString
    1.16MB  0.56% 97.77%     1.16MB  0.56%  runtime/pprof.StartCPUProfile
```

It's worth noting that:
- The `pprof` output shows higher numbers because that's a sum of every iteration of the benchmark.
- In both cases, these are sums of all allocations. I'd hope that this PR has a greater reduction in peak memory usage by not collecting all query texts into a map, making it possible to do incremental garbage collection.
