### PR TITLE
Handle the database / user being empty

### DIFF
--- a/logs/parse.go
+++ b/logs/parse.go
@@ -69,7 +69,7 @@ var EscapeMatchers = map[rune]PrefixEscape{
 	},
 	// User name
 	'u': {
-		Regexp: `.*?`,
+		Regexp: `.+?`,
 		ApplyValue: func(value string, logLine *state.LogLine, parser *LogParser) {
 			if value == "[unknown]" {
 				return
@@ -80,7 +80,7 @@ var EscapeMatchers = map[rune]PrefixEscape{
 	},
 	// Database name
 	'd': {
-		Regexp: `.*?`,
+		Regexp: `.+?`,
 		ApplyValue: func(value string, logLine *state.LogLine, parser *LogParser) {
 			if value == "[unknown]" {
 				return

--- a/logs/parse.go
+++ b/logs/parse.go
@@ -69,7 +69,7 @@ var EscapeMatchers = map[rune]PrefixEscape{
 	},
 	// User name
 	'u': {
-		Regexp: `.+?`,
+		Regexp: `[^ ].+?`,
 		ApplyValue: func(value string, logLine *state.LogLine, parser *LogParser) {
 			if value == "[unknown]" {
 				return
@@ -80,7 +80,7 @@ var EscapeMatchers = map[rune]PrefixEscape{
 	},
 	// Database name
 	'd': {
-		Regexp: `.+?`,
+		Regexp: `[^ ].+?`,
 		ApplyValue: func(value string, logLine *state.LogLine, parser *LogParser) {
 			if value == "[unknown]" {
 				return

--- a/logs/parse.go
+++ b/logs/parse.go
@@ -69,7 +69,7 @@ var EscapeMatchers = map[rune]PrefixEscape{
 	},
 	// User name
 	'u': {
-		Regexp: `[^ ].+?`,
+		Regexp: `(?:[^ ]|[^ ]{2,})?`,
 		ApplyValue: func(value string, logLine *state.LogLine, parser *LogParser) {
 			if value == "[unknown]" {
 				return
@@ -80,7 +80,7 @@ var EscapeMatchers = map[rune]PrefixEscape{
 	},
 	// Database name
 	'd': {
-		Regexp: `[^ ].+?`,
+		Regexp: `(?:[^ ]|[^ ]{2,})?`,
 		ApplyValue: func(value string, logLine *state.LogLine, parser *LogParser) {
 			if value == "[unknown]" {
 				return

--- a/logs/parse.go
+++ b/logs/parse.go
@@ -69,7 +69,7 @@ var EscapeMatchers = map[rune]PrefixEscape{
 	},
 	// User name
 	'u': {
-		Regexp: `(?:[^ ]|[^ ]{2,})?`,
+		Regexp: `.*?`,
 		ApplyValue: func(value string, logLine *state.LogLine, parser *LogParser) {
 			if value == "[unknown]" {
 				return
@@ -80,7 +80,7 @@ var EscapeMatchers = map[rune]PrefixEscape{
 	},
 	// Database name
 	'd': {
-		Regexp: `(?:[^ ]|[^ ]{2,})?`,
+		Regexp: `.*?`,
 		ApplyValue: func(value string, logLine *state.LogLine, parser *LogParser) {
 			if value == "[unknown]" {
 				return

--- a/logs/parse.go
+++ b/logs/parse.go
@@ -195,7 +195,7 @@ type LogParser struct {
 
 func NewLogParser(prefix string, tz *time.Location, isSyslog bool) *LogParser {
 	prefixRegexp, prefixElements := parsePrefix(prefix)
-	lineRegexp := regexp.MustCompile("(?ms)^" + prefixRegexp + `(\w+):\s+(.*\n?)$`)
+	lineRegexp := regexp.MustCompile("(?ms)^" + prefixRegexp + `(DEBUG|INFO|NOTICE|WARNING|ERROR|LOG|FATAL|PANIC|DETAIL|HINT|CONTEXT|STATEMENT|QUERY):\s+(.*\n?)$`)
 	lineRegexpWithoutLogLevel := regexp.MustCompile("(?ms)^" + prefixRegexp + `(.*\n?)$`)
 	return &LogParser{
 		prefix:   prefix,

--- a/logs/parse_test.go
+++ b/logs/parse_test.go
@@ -458,6 +458,32 @@ var parseTests = []parseTestpair{
 		},
 		true,
 	},
+	// Custom 11 format
+	{
+		logs.LogPrefixCustom11,
+		"pid=8284,user=[unknown],db=[unknown],app=[unknown],client=[local] LOG: connection received: host=[local]",
+		nil,
+		state.LogLine{
+			BackendPid: 8284,
+			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
+			Content:    "connection received: host=[local]",
+		},
+		true,
+	},
+	{
+		// Updating this to reflect that we can now capture the unusual application
+		// name (previously Application was omitted in the expected output struct)
+		logs.LogPrefixCustom11,
+		"pid=8284,user=[unknown],db=[unknown],app=why would you[] name your application this,client=[local] LOG: connection received: host=[local]",
+		nil,
+		state.LogLine{
+			Application: "why would you[] name your application this",
+			BackendPid:  8284,
+			LogLevel:    pganalyze_collector.LogLineInformation_LOG,
+			Content:     "connection received: host=[local]",
+		},
+		true,
+	},
 	// Custom 12 format
 	{
 		logs.LogPrefixCustom12,

--- a/logs/parse_test.go
+++ b/logs/parse_test.go
@@ -445,42 +445,16 @@ var parseTests = []parseTestpair{
 	{
 		logs.LogPrefixCustom10,
 		// Database and user are empty
-		"2020-09-04 16:03:11.375 UTC [417880]: [1-1] db=,user= LOG:  pganalyze-collector-identify: myserver",
+		"2024-10-04 06:38:28.808 UTC [2569017]: [1-1] db=,user= LOG: automatic vacuum of table \"some_database.some_schema.some_table\": index scans: 0\npages: 0 removed, 14 remain, 0 skipped due to pins, 0 skipped frozen\ntuples: 0 removed, 107 remain, 94 are dead but not yet removable, oldest xmin: 17243830\nindex scan not needed: 0 pages from table (0.00% of total) had 0 dead item identifiers removed\nI/O timings: read: 0.000 ms, write: 0.000 ms\navg read rate: 0.000 MB/s, avg write rate: 0.000 MB/s\nbuffer usage: 52 hits, 0 misses, 0 dirtied\nWAL usage: 0 records, 0 full page images, 0 bytes\nsystem usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s",
 		nil,
 		state.LogLine{
-			OccurredAt:    time.Date(2020, time.September, 4, 16, 3, 11, 375*1000*1000, time.UTC),
+			OccurredAt:    time.Date(2024, time.October, 4, 6, 38, 28, 808*1000*1000, time.UTC),
 			Username:      "",
 			Database:      "",
-			BackendPid:    417880,
+			BackendPid:    2569017,
 			LogLineNumber: 1,
 			LogLevel:      pganalyze_collector.LogLineInformation_LOG,
-			Content:       "pganalyze-collector-identify: myserver",
-		},
-		true,
-	},
-	// Custom 11 format
-	{
-		logs.LogPrefixCustom11,
-		"pid=8284,user=[unknown],db=[unknown],app=[unknown],client=[local] LOG: connection received: host=[local]",
-		nil,
-		state.LogLine{
-			BackendPid: 8284,
-			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
-			Content:    "connection received: host=[local]",
-		},
-		true,
-	},
-	{
-		// Updating this to reflect that we can now capture the unusual application
-		// name (previously Application was omitted in the expected output struct)
-		logs.LogPrefixCustom11,
-		"pid=8284,user=[unknown],db=[unknown],app=why would you[] name your application this,client=[local] LOG: connection received: host=[local]",
-		nil,
-		state.LogLine{
-			Application: "why would you[] name your application this",
-			BackendPid:  8284,
-			LogLevel:    pganalyze_collector.LogLineInformation_LOG,
-			Content:     "connection received: host=[local]",
+			Content:       "automatic vacuum of table \"some_database.some_schema.some_table\": index scans: 0\npages: 0 removed, 14 remain, 0 skipped due to pins, 0 skipped frozen\ntuples: 0 removed, 107 remain, 94 are dead but not yet removable, oldest xmin: 17243830\nindex scan not needed: 0 pages from table (0.00% of total) had 0 dead item identifiers removed\nI/O timings: read: 0.000 ms, write: 0.000 ms\navg read rate: 0.000 MB/s, avg write rate: 0.000 MB/s\nbuffer usage: 52 hits, 0 misses, 0 dirtied\nWAL usage: 0 records, 0 full page images, 0 bytes\nsystem usage: CPU: user: 0.00 s, system: 0.00 s, elapsed: 0.00 s",
 		},
 		true,
 	},

--- a/logs/parse_test.go
+++ b/logs/parse_test.go
@@ -442,6 +442,22 @@ var parseTests = []parseTestpair{
 		},
 		true,
 	},
+	{
+		logs.LogPrefixCustom10,
+		// Database and user are empty
+		"2020-09-04 16:03:11.375 UTC [417880]: [1-1] db=,user= LOG:  pganalyze-collector-identify: myserver",
+		nil,
+		state.LogLine{
+			OccurredAt:    time.Date(2020, time.September, 4, 16, 3, 11, 375*1000*1000, time.UTC),
+			Username:      "",
+			Database:      "",
+			BackendPid:    417880,
+			LogLineNumber: 1,
+			LogLevel:      pganalyze_collector.LogLineInformation_LOG,
+			Content:       "pganalyze-collector-identify: myserver",
+		},
+		true,
+	},
 	// Custom 11 format
 	{
 		logs.LogPrefixCustom11,


### PR DESCRIPTION
Raised as part of open case (5773) with support regarding a memory leak. Will link PR in ticket. 

It is possible for the username and the database to be empty for some log messages. For example with CloudSQL the vacuum analysis logs are output as

> 2024-10-04 06:38:28.316 UTC [2569017]: [1-1] db=,user= LOG:  automatic vacuum of table \\\"database_name.pg_catalog.pg_database\\\": etc

This previously caused a bug where these lines were being treated as incomplete, resulting in a memory leak as "the rest" of the line was awaited (to stitch together logs that appear over multiple lines).

The ultimate result of this is that vacuum logs on CloudSQL never make it to PgAnalyze and therefore are not available in log insights or used as part of the vacuum advisor.

This commit fixes this by changing the regex matching for username and database to match anything that is not a single space, rather than just anything.