### PR TITLE
Update get_column_stats for Postgres 17

### DIFF
--- a/input/postgres/relation_column_stats.go
+++ b/input/postgres/relation_column_stats.go
@@ -46,7 +46,7 @@ func GetColumnStats(ctx context.Context, logger *util.Logger, db *sql.DB, global
 				server.SelfTest.HintDbCollectionAspect(dbName, state.CollectionAspectColumnStats, "Please set up"+
 					" the monitoring helper function pganalyze.get_column_stats (%s)"+
 					" or connect as superuser to get column statistics for all tables.", selftest.URLPrinter.Sprint("https://pganalyze.com/docs/install/troubleshooting/column_stats_helper"))
-				logger.PrintWarning("Limited access to table column statistics detected in database %s. Please set up"+
+				logger.PrintInfo("Warning: Limited access to table column statistics detected in database %s. Please set up"+
 					" the monitoring helper function pganalyze.get_column_stats (https://pganalyze.com/docs/install/troubleshooting/column_stats_helper)"+
 					" or connect as superuser, to get column statistics for all tables.", dbName)
 			}

--- a/input/postgres/superuser.go
+++ b/input/postgres/superuser.go
@@ -85,9 +85,9 @@ func connectedAsMonitoringRole(ctx context.Context, db *sql.DB) bool {
 
 const statsHelperSQL string = `
 SELECT 1 AS enabled
-	FROM pg_catalog.pg_proc p
-	JOIN pg_catalog.pg_namespace n ON (p.pronamespace = n.oid)
- WHERE n.nspname = 'pganalyze' AND p.proname = '%s'
+FROM pg_catalog.pg_proc p
+JOIN pg_catalog.pg_namespace n ON (p.pronamespace = n.oid)
+WHERE n.nspname = 'pganalyze' AND p.proname = '%s'
 `
 
 func StatsHelperExists(ctx context.Context, db *sql.DB, statsHelper string) bool {
@@ -99,4 +99,22 @@ func StatsHelperExists(ctx context.Context, db *sql.DB, statsHelper string) bool
 	}
 
 	return enabled
+}
+
+const statsHelperReturnTypeSQL string = `
+SELECT pg_catalog.format_type(prorettype, null)
+FROM pg_catalog.pg_proc p
+JOIN pg_catalog.pg_namespace n ON (p.pronamespace = n.oid)
+WHERE n.nspname = 'pganalyze' AND p.proname = '%s'
+`
+
+func StatsHelperReturnType(ctx context.Context, db *sql.DB, statsHelper string) string {
+	var source string
+
+	err := db.QueryRowContext(ctx, QueryMarkerSQL+fmt.Sprintf(statsHelperReturnTypeSQL, statsHelper)).Scan(&source)
+	if err != nil {
+		return ""
+	}
+
+	return source
 }

--- a/runner/generate_helper_sql.go
+++ b/runner/generate_helper_sql.go
@@ -13,11 +13,11 @@ import (
 
 var statsHelpers = []string{
 	// Column stats
-	`CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS SETOF pg_stats AS
-$$
-  /* pganalyze-collector */ SELECT schemaname, tablename, attname, inherited, null_frac, avg_width,
-    n_distinct, NULL::anyarray, most_common_freqs, NULL::anyarray, correlation, NULL::anyarray,
-    most_common_elem_freqs, elem_count_histogram
+	`CREATE OR REPLACE FUNCTION pganalyze.get_column_stats() RETURNS TABLE(
+  schemaname name, tablename name, attname name, inherited bool, null_frac real, avg_width int, n_distinct real, correlation real
+) AS $$
+  /* pganalyze-collector */
+  SELECT schemaname, tablename, attname, inherited, null_frac, avg_width, n_distinct, correlation
   FROM pg_catalog.pg_stats
   WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND tablename <> 'pg_subscription';
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`,


### PR DESCRIPTION
As documented on https://github.com/pganalyze/pganalyze-docs/pull/285, Postgres 17 added new columns to `pg_stats` which broke the `pganalyze.get_column_stats` helper function. This PR updates the function to `RETURNS TABLE` so any future additions won't break the function again.

But since that's a backwards-incompatable change requiring `DROP FUNCTION` instead of `CREATE OR REPLACE FUNCTION` this PR also adds an additional runtime check to explain the necessary steps to users.