### PR TITLE
Add error when pgss version is below 1.9 with Postgres 14+

### DIFF
--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -134,6 +134,11 @@ func GetStatements(ctx context.Context, server *state.Server, logger *util.Logge
 		foundExtMinorVersion = extMinorVersion
 	}
 
+	if postgresVersion.Numeric >= state.PostgresVersion14 && foundExtMinorVersion < 9 {
+		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectPgStatStatements, "extension version (1.%d) is too old, 1.9 or newer is required.", foundExtMinorVersion)
+		server.SelfTest.HintCollectionAspect(state.CollectionAspectPgStatStatements, "Update the extension by running `ALTER EXTENSION pg_stat_statements UPDATE`.")
+	}
+
 	if foundExtMinorVersion >= 8 {
 		totalTimeField = statementSQLTotalTimeFieldMinorVersion8
 	} else {


### PR DESCRIPTION
It would be ideal to show this warning in the UI, but we can start from showing it with test run.
With Postgres 14+, `toplevel` (provided by pg_stat_statements 1.9+) is going to be really important to collect proper stats. Otherwise, we will collect stats without `toplevel`, which can cause the same query to have two version (with or without toplevel), which can lead to the incorrect metrics like "queries per min".

For instance, query A has stats with toplevel true and false, and true one has 100,000 calls and false one has 10 calls. Let's say the collector run will pick up the 10 calls for the query A and the following collector run will pick up 100,000 calls for it, which will result the diff to be almost 100k, making the "queries per min" to be 100k even though it's not true. It is important that the Postgres 14+ to have pgss 1.9+ to avoid this.