### PR TITLE
Packages repo sync: Use sleep instead of /sbin/init

### DIFF
--- a/packages/repo/Makefile
+++ b/packages/repo/Makefile
@@ -31,7 +31,7 @@ update_rpm:
 		-e REPO_GPG_KEY=$(REPO_GPG_KEY) \
 		-e RPM_PACKAGE_X86_64=$(RPM_PACKAGE_X86_64) \
 		-e RPM_PACKAGE_ARM64=$(RPM_PACKAGE_ARM64) \
-		pga-collector-repo /sbin/init
+		pga-collector-repo sleep 600
 	keybase pgp export --unencrypted -s -q $(REPO_GPG_KEY) | $(DOCKER_CMD) exec -i pga-collector-repo gpg --allow-secret-key-import --import
 	$(DOCKER_CMD) exec -i pga-collector-repo /root/sync_rpm.sh
 	$(call docker_clean)


### PR DESCRIPTION
RPM base packages have changed and no longer contain an init system by default. Since we mainly care about having a process running to then issue exec commands under, we can use a sleep here instead to avoid failure.