### PR TITLE
Collect column stats using helper on Postgres < 17 despite warning

### DIFF
--- a/input/postgres/schema.go
+++ b/input/postgres/schema.go
@@ -150,7 +150,7 @@ func collectSchemaData(ctx context.Context, collectionOpts state.CollectionOpts,
 			ps.SchemaStats[databaseOid].IndexStats[k] = v
 		}
 
-		newColumnStats, err := GetColumnStats(ctx, logger, db, collectionOpts, systemType, dbName, server)
+		newColumnStats, err := GetColumnStats(ctx, logger, db, collectionOpts, systemType, dbName, server, ts.Version)
 		if err != nil {
 			return ps, ts, fmt.Errorf("error collecting column statistics: %s", err)
 		}


### PR DESCRIPTION
Followup to #610, this makes it so we only fall back to querying `pg_stats` directly on Postgres 17 and older, since the old function definition will still work until the database server is upgraded.