### PR TITLE
Log Insights: Use more specific log parsing regexp

### DIFF
--- a/logs/parse.go
+++ b/logs/parse.go
@@ -58,7 +58,7 @@ type PrefixEscape struct {
 var EscapeMatchers = map[rune]PrefixEscape{
 	// Application name
 	'a': {
-		Regexp: `.+?`,
+		Regexp: `.{1,63}?`,
 		ApplyValue: func(value string, logLine *state.LogLine, parser *LogParser) {
 			if value == "[unknown]" {
 				return
@@ -69,7 +69,7 @@ var EscapeMatchers = map[rune]PrefixEscape{
 	},
 	// User name
 	'u': {
-		Regexp: `.+?`,
+		Regexp: `.{1,63}?`,
 		ApplyValue: func(value string, logLine *state.LogLine, parser *LogParser) {
 			if value == "[unknown]" {
 				return
@@ -80,7 +80,7 @@ var EscapeMatchers = map[rune]PrefixEscape{
 	},
 	// Database name
 	'd': {
-		Regexp: `.+?`,
+		Regexp: `.{1,63}?`,
 		ApplyValue: func(value string, logLine *state.LogLine, parser *LogParser) {
 			if value == "[unknown]" {
 				return


### PR DESCRIPTION
Our existing log parsing regular expressions may lead to ambiguity in
parsing log line prefixes for some log lines.

Ensure we only look for identifiers (role name, application_name, and
database name) up to the default identifier length limit (63 bytes) to
reduce ambiguities.
