### PR TITLE
Update MemoryLimit to MemoryMax in systemd config

### DIFF
--- a/contrib/systemd/pganalyze-collector.service
+++ b/contrib/systemd/pganalyze-collector.service
@@ -9,7 +9,7 @@ User=pganalyze
 ProtectSystem=full
 ProtectHome=true
 CapabilityBoundingSet=CAP_SYS_PTRACE CAP_DAC_READ_SEARCH CAP_DAC_OVERRIDE
-MemoryLimit=1024M
+MemoryMax=1024M
 Restart=always
 
 [Install]


### PR DESCRIPTION
See docs in https://www.freedesktop.org/software/systemd/man/latest/systemd.resource-control.html#MemoryMax=bytes (and the note about MemoryLimit at the end).

Given usage patterns for the collector MemoryMax makes more sense than MemoryHigh here.

MemoryMax was added in systemd 231 in 2016: it should be available on all our supported platforms.