### PR TITLE
Fix over-eager PII filtering

### DIFF
--- a/logs/replace.go
+++ b/logs/replace.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"sort"
 
+	"github.com/google/uuid"
 	"github.com/pganalyze/collector/state"
 )
 
@@ -17,7 +18,7 @@ func ReplaceSecrets(logLines []state.LogLine, filterLogSecret []state.LogSecretK
 		}
 	}
 	for idx, logLine := range logLines {
-		if filterUnidentified && logLines[idx].Classification == 0 {
+		if filterUnidentified && logLines[idx].Classification == 0 && logLines[idx].ParentUUID == uuid.Nil {
 			logLines[idx].Content = replacement + "\n"
 		} else {
 			sort.Slice(logLine.SecretMarkers, func(i, j int) bool {

--- a/logs/replace_test.go
+++ b/logs/replace_test.go
@@ -47,7 +47,7 @@ var replaceTests = []replaceTestpair{
 	{
 		filterLogSecret: "statement_text, statement_parameter, unidentified",
 		input:           "2018-03-11 20:00:02 UTC:1.1.1.1(2):a@b:[3]:LOG:  duration: 4079.697 ms  execute <unnamed>: \nSELECT * FROM x WHERE y = $1 LIMIT $2\n2018-03-11 20:00:02 UTC:1.1.1.1(2):a@b:[3]:DETAIL:  parameters: $1 = 'long string', $2 = '1'\n",
-		output:          "duration: 4079.697 ms  execute <unnamed>: \n[redacted]\n[redacted]\n",
+		output:          "duration: 4079.697 ms  execute <unnamed>: \n[redacted]\nparameters: $1 = '[redacted]', $2 = '[redacted]'\n",
 	},
 }
 


### PR DESCRIPTION
In a25800b1a1e32c62dcc74587a2dbf7503e977211, we changed the way
redaction works for PII filtering. The change did not account for
detail log lines, leading to all log lines always being redacted.

Update the redaction mechanism to check for a parent log line.
