### PR TITLE
Use groupadd instead of addgroup

### DIFF
--- a/packages/src/rpm-systemd/post.sh
+++ b/packages/src/rpm-systemd/post.sh
@@ -8,7 +8,7 @@ if ! getent passwd pganalyze > /dev/null; then
 fi
 
 if ! getent group pganalyze > /dev/null; then
-  addgroup --system --quiet pganalyze
+  groupadd --system pganalyze
   usermod -g pganalyze pganalyze
 fi
 


### PR DESCRIPTION
The latter seems to no longer be available on Amazon Linux 2023. Since
addgroup is just a convenience wrapper around groupadd and we are only
using its basic functionality, we can switch to using groupadd
directly.
