### PR TITLE
Exclude unused pages from buffer cache monitoring

### DIFF
--- a/input/postgres/buffer_cache.go
+++ b/input/postgres/buffer_cache.go
@@ -28,6 +28,7 @@ WHERE name = 'shared_buffers'
 const bufferCacheSQL string = `
 SELECT reldatabase, relfilenode, count(*) * current_setting('block_size')::int
 FROM %s.pg_buffercache
+WHERE reldatabase IS NOT NULL -- filters out unused pages
 GROUP BY 1, 2
 `
 


### PR DESCRIPTION
Followup to #633. As mentioned in the [documentation](https://www.postgresql.org/docs/current/pgbuffercache.html):
>There is one row for each buffer in the shared cache. Unused buffers are shown with all fields null except bufferid. Shared system catalogs are shown as belonging to database zero.

The null values cause a type conversion error:
```
Scan error on column index 0, name "reldatabase": converting NULL to uint64 is unsupported
```

We might want to track them in the future, but for now this PR excludes them to work around the issue.