### PR TITLE
Shut down WebSocket after write error

### DIFF
--- a/runner/websocket.go
+++ b/runner/websocket.go
@@ -90,20 +90,14 @@ func connect(ctx context.Context, server *state.Server, globalCollectionOpts sta
 		for {
 			select {
 			case <-connCtx.Done():
-				socket := server.WebSocket.Swap(nil)
-				if socket != nil {
-					err = socket.Close()
-					if err != nil {
-						logger.PrintWarning("Error closing websocket: %s", err)
-					}
-				}
+				closeConnection(server, logger)
 				return
 			case snapshot := <-server.SnapshotStream:
 				logger.PrintVerbose("Uploading snapshot to websocket")
 				err = conn.WriteMessage(websocket.BinaryMessage, snapshot)
 				if err != nil {
 					logger.PrintError("Error uploading snapshot: %s", err)
-					cancelConn()
+					closeConnection(server, logger)
 					return
 				}
 			}
@@ -157,4 +151,14 @@ func connect(ctx context.Context, server *state.Server, globalCollectionOpts sta
 			}
 		}
 	}()
+}
+
+func closeConnection(server *state.Server, logger *util.Logger) {
+	socket := server.WebSocket.Swap(nil)
+	if socket != nil {
+		err := socket.Close()
+		if err != nil {
+			logger.PrintWarning("Error closing websocket: %s", err)
+		}
+	}
 }


### PR DESCRIPTION
If the WebSocket encounters an error when writing data to the connection, the previous implementation called `cancelConn` but that wouldn't actually shut down the connection because it then `return`ed, shutting down the goroutine that would be listening for that cancel event.

In that case `server.WebSocket.Swap(nil)` would never be called, so the collector would continue trying to submit snapshots to the dead websocket connection.

This PR resolves that by moving the cleanup code to a separate function so it can be called directly when a write error occurs.