### PR TITLE
Fix flaky transform_test.go

### DIFF
--- a/output/transform/transform_test.go
+++ b/output/transform/transform_test.go
@@ -156,9 +156,9 @@ type OriginalPlanRef struct {
 // and similar fields sorted into a single canonical order.
 func makeCanonical(snapshot pganalyze_collector.FullSnapshot) {
 	// ensure query references occur in a consistent order
-	queryRefs := make([]*OriginalQueryRef, len(snapshot.QueryReferences))
+	queryRefs := make([]OriginalQueryRef, len(snapshot.QueryReferences))
 	for i, qRef := range snapshot.QueryReferences {
-		queryRefs[i] = &OriginalQueryRef{
+		queryRefs[i] = OriginalQueryRef{
 			Original:    qRef,
 			OriginalIdx: int32(i),
 		}

--- a/output/transform/transform_test.go
+++ b/output/transform/transform_test.go
@@ -227,6 +227,10 @@ func makeCanonical(snapshot pganalyze_collector.FullSnapshot) {
 	// ensure plan references occur in a consistent order
 	planRefs := make([]OriginalPlanRef, len(snapshot.QueryPlanReferences))
 	for i, planRef := range snapshot.QueryPlanReferences {
+		newQueryIdx := slices.IndexFunc(queryRefs, func(item OriginalQueryRef) bool {
+			return item.OriginalIdx == planRef.QueryIdx
+		})
+		planRef.QueryIdx = int32(newQueryIdx)
 		planRefs[i] = OriginalPlanRef{
 			Original:    planRef,
 			OriginalIdx: int32(i),


### PR DESCRIPTION
Since snapshots include query references and query plan references,
and since those can be orderered nondeterministically, the test can
fail if the snapshot is built with fields in an unexpected order.

The existing test tries to account for that by enumerating all
possible combinations, but this is very difficult to maintain, and
very difficult to scale to additional fields with this pattern.

Instead, rewrite snapshots to a canonical format to ensure comparisons
are stable. We can't just sort the array fields before serializing the
snapshot for comparison, since QueryReferences and similar items are
referenced by an index into their array. To work around that, we sort
the QueryReferences (tracking their original index), and rewrite all
entries that reference them to reference their new index instead.

See discussion in #630 [1].

[1]: https://github.com/pganalyze/collector/pull/630#issuecomment-2495113567
