### PR TITLE
Fix expected result set of transform test

### DIFF
--- a/output/transform/transform_test.go
+++ b/output/transform/transform_test.go
@@ -48,7 +48,7 @@ func TestStatements(t *testing.T) {
 	actual := transform.StateToSnapshot(newState, diffState, transientState)
 	actualJSON, _ := json.Marshal(actual)
 
-	// Query: 0, 1, Plan: 0, 1
+	// Query: 0, 1, Plan: 0, 1 (w/ QueryIdx 1)
 	expected := pganalyze_collector.FullSnapshot{
 		Config:             &pganalyze_collector.CollectorConfig{},
 		CollectorStatistic: &pganalyze_collector.CollectorStatistic{},
@@ -134,7 +134,7 @@ func TestStatements(t *testing.T) {
 	}
 	expectedJSON, _ := json.Marshal(expected)
 
-	// Query: 1, 0, Plan: 0, 1
+	// Query: 1, 0, Plan: 0, 1 (w/ QueryIdx 0)
 	var expectedAlt pganalyze_collector.FullSnapshot
 	json.Unmarshal(expectedJSON, &expectedAlt)
 	expectedAlt.QueryReferences = []*pganalyze_collector.QueryReference{
@@ -171,16 +171,26 @@ func TestStatements(t *testing.T) {
 			Calls:    1,
 		},
 	}
-	expectedJSONAlt, _ := json.Marshal(expectedAlt)
-
-	// Query: 1, 0, Plan: 1, 0
 	expectedAlt.QueryPlanReferences = []*pganalyze_collector.QueryPlanReference{
 		&pganalyze_collector.QueryPlanReference{
-			QueryIdx:       1,
+			QueryIdx:       0,
+			OriginalPlanId: 111,
+		},
+		&pganalyze_collector.QueryPlanReference{
+			QueryIdx:       0,
+			OriginalPlanId: 222,
+		},
+	}
+	expectedJSONAlt, _ := json.Marshal(expectedAlt)
+
+	// Query: 1, 0, Plan: 1, 0 (w/ QueryIdx 0)
+	expectedAlt.QueryPlanReferences = []*pganalyze_collector.QueryPlanReference{
+		&pganalyze_collector.QueryPlanReference{
+			QueryIdx:       0,
 			OriginalPlanId: 222,
 		},
 		&pganalyze_collector.QueryPlanReference{
-			QueryIdx:       1,
+			QueryIdx:       0,
 			OriginalPlanId: 111,
 		},
 	}
@@ -208,7 +218,7 @@ func TestStatements(t *testing.T) {
 	}
 	expectedJSONAlt2, _ := json.Marshal(expectedAlt)
 
-	// Query: 0, 1, Plan: 1, 0
+	// Query: 0, 1, Plan: 1, 0 (w/ QueryIdx 1)
 	expectedAlt.QueryReferences = []*pganalyze_collector.QueryReference{
 		&pganalyze_collector.QueryReference{
 			DatabaseIdx: 0,
@@ -241,6 +251,16 @@ func TestStatements(t *testing.T) {
 		&pganalyze_collector.QueryStatistic{
 			QueryIdx: 1,
 			Calls:    13,
+		},
+	}
+	expectedAlt.QueryPlanReferences = []*pganalyze_collector.QueryPlanReference{
+		&pganalyze_collector.QueryPlanReference{
+			QueryIdx:       1,
+			OriginalPlanId: 222,
+		},
+		&pganalyze_collector.QueryPlanReference{
+			QueryIdx:       1,
+			OriginalPlanId: 111,
 		},
 	}
 	expectedJSONAlt3, _ := json.Marshal(expectedAlt)


### PR DESCRIPTION
The test was having the wrong expected result set, so I updated it. Without this fix, test was consistently failing (e.g. if I run test 10 times, it guaranteed to fail a few times), but with this fix, I ran test 50 times and it was working fine (I also triple checked the logic).

https://github.com/pganalyze/collector/pull/630#issuecomment-2495113567

I agree with others that the current testing logic is not ideal and also very hard to maintain. I thought about removing this completely, but it's a nice test to have and it was still fixable for now (as it had a clear bug) so I went forward and fixed it. We shouldn't expand this test any further and if we want to add something, we should reconsider how we do the test.
I'm not so sure if the sorting works, this test is passing input to the blackbox (`transform.StateToSnapshot`) and we don't know in which combination the blackbox is going to return the result with.