### PR TITLE
Improve query runner error handling

### DIFF
--- a/runner/query_run.go
+++ b/runner/query_run.go
@@ -84,31 +84,25 @@ func run(ctx context.Context, server *state.Server, collectionOpts state.Collect
 
 		// We don't include QueryMarkerSQL so query runs are reported separately in pganalyze
 		comment := fmt.Sprintf("/* pganalyze:no-alert,pganalyze-query-run:%d */ ", query.Id)
-		prefix := ""
 		result := ""
-		if query.Type == pganalyze_collector.QueryRunType_EXPLAIN {
-			prefix = "EXPLAIN (ANALYZE, VERBOSE, BUFFERS, FORMAT JSON) "
-		}
 
 		if query.Type == pganalyze_collector.QueryRunType_EXPLAIN {
-			// Rollback any changes the query may perform
-			db.ExecContext(ctx, postgres.QueryMarkerSQL+"BEGIN READ ONLY")
-
-			err = db.QueryRowContext(ctx, comment+prefix+query.QueryText).Scan(&result)
+			sql := "BEGIN; EXPLAIN (ANALYZE, VERBOSE, BUFFERS, FORMAT JSON) " + comment + query.QueryText + "; ROLLBACK"
+			err = db.QueryRowContext(ctx, sql).Scan(&result)
 			firstErr = err
 
 			// Run EXPLAIN ANALYZE a second time to get a warm cache result
-			err = db.QueryRowContext(ctx, comment+prefix+query.QueryText).Scan(&result)
+			err = db.QueryRowContext(ctx, sql).Scan(&result)
 
-			// If the first run failed, run once more to get a warm cache result
+			// If the first run failed and the second run succeeded, run once more to get a warm cache result
 			if err == nil && firstErr != nil {
-				err = db.QueryRowContext(ctx, comment+prefix+query.QueryText).Scan(&result)
+				err = db.QueryRowContext(ctx, sql).Scan(&result)
 			}
 
-			// If the EXPLAIN ANALYZE timed out, capture a regular EXPLAIN instead
+			// If it timed out, capture a non-ANALYZE EXPLAIN instead
 			if err != nil && strings.Contains(err.Error(), "statement timeout") {
-				prefix = "EXPLAIN (VERBOSE, FORMAT JSON) "
-				err = db.QueryRowContext(ctx, comment+prefix+query.QueryText).Scan(&result)
+				sql = "BEGIN; EXPLAIN (VERBOSE, FORMAT JSON) " + comment + query.QueryText + "; ROLLBACK"
+				err = db.QueryRowContext(ctx, sql).Scan(&result)
 			}
 		} else {
 			err = errors.New("Unhandled query run type")

--- a/state/state.go
+++ b/state/state.go
@@ -317,6 +317,7 @@ func MakeServer(config config.ServerConfig, testRun bool) *Server {
 		ActivityStateMutex:    &sync.Mutex{},
 		CollectionStatusMutex: &sync.Mutex{},
 		SnapshotStream:        make(chan []byte),
+		QueryRuns:             make(map[int64]*QueryRun),
 		QueryRunsMutex:        &sync.Mutex{},
 		LogParseMutex:         &sync.RWMutex{},
 	}


### PR DESCRIPTION
This PR updates the query runner to submit the first error it sees, to avoid reporting an unhelpful `current transaction is aborted` error back to the server. `BEGIN READ ONLY` was a late addition to #628, so this wasn't caught in manual testing.

This also fixes an error I saw while testing this, where `server.QueryRuns` is nil:
```
panic: assignment to entry in nil map

goroutine 99 [running]:
runner.connect.func3()
    runner/websocket.go:150 +0x4ac
created by runner.connect in goroutine 64
    runner/websocket.go:113 +0xa44