### PR TITLE
Azure Metrics: fix getFirstMetricValue to return the first value

### DIFF
--- a/input/system/azure/system.go
+++ b/input/system/azure/system.go
@@ -286,6 +286,7 @@ func getFirstMetricValue(metric *azquery.Metric) (metricValue *azquery.MetricVal
 	for _, timeSeriesElement := range metric.TimeSeries {
 		for _, mValue := range timeSeriesElement.Data {
 			metricValue = mValue
+			return
 		}
 	}
 	return

--- a/input/system/azure/system.go
+++ b/input/system/azure/system.go
@@ -283,8 +283,8 @@ func GetSystemState(ctx context.Context, server *state.Server, logger *util.Logg
 
 // getFirstMetricValue gets the first data from the time series metric and returns the value
 func getFirstMetricValue(metric *azquery.Metric) (metricValue *azquery.MetricValue) {
-        if len(metric.TimeSeries) == 0 || len(metric.TimeSeries[0].timeSeriesElement.Data) == 0 {
-                return
-        }
-        return metric.TimeSeries[0].timeSeriesElement.Data[0]
+	if len(metric.TimeSeries) == 0 || len(metric.TimeSeries[0].Data) == 0 {
+		return
+	}
+	return metric.TimeSeries[0].Data[0]
 }

--- a/input/system/azure/system.go
+++ b/input/system/azure/system.go
@@ -283,11 +283,8 @@ func GetSystemState(ctx context.Context, server *state.Server, logger *util.Logg
 
 // getFirstMetricValue gets the first data from the time series metric and returns the value
 func getFirstMetricValue(metric *azquery.Metric) (metricValue *azquery.MetricValue) {
-	for _, timeSeriesElement := range metric.TimeSeries {
-		for _, mValue := range timeSeriesElement.Data {
-			metricValue = mValue
-			return
-		}
-	}
-	return
+        if len(metric.TimeSeries) == 0 || len(metric.TimeSeries[0].timeSeriesElement.Data) == 0 {
+                return
+        }
+        return metric.TimeSeries[0].timeSeriesElement.Data[0]
 }


### PR DESCRIPTION
Spotted by Maciek in https://github.com/pganalyze/collector/pull/591/files#r1866387023

This function was previously returning the last value instead of the first value. This fix changes it and returns the value as soon as reading it.

Tested with the staging Azure database and it didn't break things.