### PR TITLE
Add MAX_BUFFER_CACHE_MONITORING_GB configuration variable

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -342,6 +342,9 @@ func getDefaultConfig() *ServerConfig {
 	if skipIfReplica := os.Getenv("SKIP_IF_REPLICA"); skipIfReplica != "" {
 		config.SkipIfReplica = parseConfigBool(skipIfReplica)
 	}
+	if maxBufferCacheMonitoringGB := os.Getenv("MAX_BUFFER_CACHE_MONITORING_GB"); maxBufferCacheMonitoringGB != "" {
+		config.MaxBufferCacheMonitoringGB, _ = strconv.Atoi(maxBufferCacheMonitoringGB)
+	}
 	if filterLogSecret := os.Getenv("FILTER_LOG_SECRET"); filterLogSecret != "" {
 		config.FilterLogSecret = filterLogSecret
 	} else {


### PR DESCRIPTION
This adds the equivalent of the ini-style setting "max_buffer_cache_monitoring_gb" for the environment-based settings, which was missed when the setting was first added.