### PR TITLE
Added ability to use raw envrionment variables maps in deployment

### DIFF
--- a/contrib/helm/pganalyze-collector/README.md
+++ b/contrib/helm/pganalyze-collector/README.md
@@ -1,6 +1,6 @@
 # pganalyze-collector
 
-![Version: 0.56.0](https://img.shields.io/badge/Version-0.56.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.56.0](https://img.shields.io/badge/AppVersion-v0.56.0-informational?style=flat-square)
+![Version: 0.63.0](https://img.shields.io/badge/Version-0.63.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.63.0](https://img.shields.io/badge/AppVersion-v0.63.0-informational?style=flat-square)
 
 pganalyze statistics collector
 
@@ -19,6 +19,7 @@ pganalyze statistics collector
 | configMap.name | string | `""` | The name of the config map to load environment variables from. If not set and create is true, a name is generated using the fullname template |
 | configMap.values | object | `{}` | Values to initialize the ConfigMap with. Only applicable if create is true |
 | extraEnv | object | `{}` | Environment variables to be passed to the container Config settings can be defined here, or can be defined via configMap + secret |
+| extraEnvRaw | list | `[]` | Environment variables to be passed to the container Config settings can be defined in raw form, for use with externally maintained env value sources (configMapKeyRef, fieldRef, resourceFieldRef, secretKeyRef) |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | Overrides the image pull policy. |
 | image.repository | string | `"quay.io/pganalyze/collector"` |  |

--- a/contrib/helm/pganalyze-collector/templates/deployment.yaml
+++ b/contrib/helm/pganalyze-collector/templates/deployment.yaml
@@ -44,11 +44,16 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- with .Values.extraEnv }}
+          {{- if or .Values.extraEnvRaw .Values.extraEnv }}
           env:
+            {{- with .Values.extraEnv }}
             {{- range $key, $value := . }}
             - name: {{ $key }}
               value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.extraEnvRaw }}
+              {{- toYaml .Values.extraEnvRaw | nindent 12 }}
             {{- end }}
           {{- end }}
           {{- $configMapName := (include "pganalyze-collector.configMapName" .) -}}

--- a/contrib/helm/pganalyze-collector/values.yaml
+++ b/contrib/helm/pganalyze-collector/values.yaml
@@ -28,7 +28,7 @@ extraEnvRaw: []
   #   valueFrom:
   #     secretKeyRef:
   #       name: pganalyze
-  #       key: api-key        
+  #       key: api-key
 
 configMap:
   # -- Specifies whether a config map should be created.

--- a/contrib/helm/pganalyze-collector/values.yaml
+++ b/contrib/helm/pganalyze-collector/values.yaml
@@ -21,6 +21,15 @@ extraEnv: {}
 #   DB_ALL_NAMES: true (monitor all databases on the server)
 #   DB_USERNAME: your_monitoring_user
 
+# -- Environment variables to be passed to the container
+# Config settings can be defined in raw form, for use with externally maintained env value sources (configMapKeyRef, fieldRef, resourceFieldRef, secretKeyRef)
+extraEnvRaw: []
+  # - name: PGA_API_KEY
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: pganalyze
+  #       key: api-key        
+
 configMap:
   # -- Specifies whether a config map should be created.
   # The config map can be used to set runtime environment variables


### PR DESCRIPTION
Hello, Internally we use external secret sources,
This PR adds the Ability for the environment variables to reference k8s objects that are per-defined under the pganalyze target namespace by cluster operators.

This solves an issue where a secret that does not conform to either existing methods:

- `extraEnv`: simple `key: value` strings
- `configMap` or `secret`: injection by using `envFrom` restricts the data fields conform to target environment variable names

By allowing helm operator to specify raw elements of the `env` spec of a container, it allows for additional options that are not currently covered.

I do not know how you do versioning for same appVersion patching of the chart-side only changes,
I see that most chart releases correspond to app releases, I ran `helm-docs` which is the only section in CONTRIBUTING.md that seems relevant for this type of PR

Edits: typo, versioning note