### PR TITLE
Handle repeated query run requests from server

### DIFF
--- a/runner/websocket.go
+++ b/runner/websocket.go
@@ -141,11 +141,13 @@ func connect(ctx context.Context, server *state.Server, globalCollectionOpts sta
 				q := message.GetQueryRun()
 				logger.PrintVerbose("Query run %d received: %s", q.Id, q.QueryText)
 				server.QueryRunsMutex.Lock()
-				server.QueryRuns[q.Id] = &state.QueryRun{
-					Id:           q.Id,
-					Type:         q.Type,
-					DatabaseName: q.DatabaseName,
-					QueryText:    q.QueryText,
+				if _, exists := server.QueryRuns[q.Id]; !exists {
+					server.QueryRuns[q.Id] = &state.QueryRun{
+						Id:           q.Id,
+						Type:         q.Type,
+						DatabaseName: q.DatabaseName,
+						QueryText:    q.QueryText,
+					}
 				}
 				server.QueryRunsMutex.Unlock()
 			}


### PR DESCRIPTION
The server repeatedly sends query runs that haven't started yet, but that can lead to a race condition where the server sends the query run again after it's already started but before it's completed. In that case, the websocket handler would erase the state that's already been stored (specifically `StartedAt`). This PR resolves that by only adding the query run if it's new.