### PR TITLE
PII Filtering: Correctly redact CONTEXT lines for auto_explain, if present

### DIFF
--- a/logs/analyze.go
+++ b/logs/analyze.go
@@ -1153,6 +1153,11 @@ var otherContextPatterns = []match{
 		regexp:   regexp.MustCompile(`^JSON data, line (\d+): (.+)`),
 		secrets:  []state.LogSecretKind{0, state.TableDataLogSecret},
 	},
+	{
+		prefixes: []string{"portal \"", "unnamed portal "},
+		regexp:   regexp.MustCompile(`(?:(?:unnamed portal|portal \"(.+)\") with parameters: |, )\$\d+ = (?:(NULL)|'((?:[^']|'')*)')`),
+		secrets:  []state.LogSecretKind{0, state.StatementParameterLogSecret, state.StatementParameterLogSecret},
+	},
 }
 
 var autoVacuumIndexRegexp = regexp.MustCompile(`index "(.+?)": pages: (\d+) in total, (\d+) newly deleted, (\d+) currently deleted, (\d+) reusable,?\s*`)
@@ -2170,7 +2175,7 @@ func matchOtherContextLogLine(logLine state.LogLine) state.LogLine {
 		return logLine
 	}
 	for _, match := range otherContextPatterns {
-		logLine, parts := matchLogLine(logLine, match)
+		logLine, parts := matchLogLineAll(logLine, match)
 		if parts != nil {
 			return logLine
 		}

--- a/logs/replace.go
+++ b/logs/replace.go
@@ -18,7 +18,7 @@ func ReplaceSecrets(logLines []state.LogLine, filterLogSecret []state.LogSecretK
 		}
 	}
 	for idx, logLine := range logLines {
-		if filterUnidentified && logLines[idx].Classification == 0 && logLines[idx].ParentUUID == uuid.Nil {
+		if filterUnidentified && (!logLine.ReviewedForSecrets || (logLine.Classification == 0 && logLines[idx].ParentUUID == uuid.Nil)) {
 			logLines[idx].Content = replacement + "\n"
 		} else {
 			sort.Slice(logLine.SecretMarkers, func(i, j int) bool {

--- a/logs/replace_test.go
+++ b/logs/replace_test.go
@@ -30,9 +30,19 @@ var replaceTests = []replaceTestpair{
 		output:          "duration: 1242.570 ms  statement: [redacted]\n",
 	},
 	{
+		filterLogSecret: "statement_text",
+		input:           "2018-03-11 20:00:02 UTC:1.1.1.1(2):a@b:[3]:LOG:  duration: 2007.111 ms  plan:\n{\"Query Text\": \"SELECT pg_sleep($1)\", \"Query Parameters\": \"$1 = '2'\", \"Plan\": { } }\n",
+		output:          "duration: 2007.111 ms  plan:\n[redacted]\n",
+	},
+	{
 		filterLogSecret: "statement_parameter",
 		input:           "2018-03-11 20:00:02 UTC:1.1.1.1(2):a@b:[3]:LOG:  duration: 4079.697 ms  execute <unnamed>: \nSELECT * FROM x WHERE y = $1 LIMIT $2\n2018-03-11 20:00:02 UTC:1.1.1.1(2):a@b:[3]:DETAIL:  parameters: $1 = 'long string', $2 = '1', $3 = 'long string'\n",
 		output:          "duration: 4079.697 ms  execute <unnamed>: \nSELECT * FROM x WHERE y = $1 LIMIT $2\nparameters: $1 = '[redacted]', $2 = '[redacted]', $3 = '[redacted]'\n",
+	},
+	{
+		filterLogSecret: "statement_parameter",
+		input:           "2018-03-11 20:00:02 UTC:1.1.1.1(2):a@b:[3]:LOG:  duration: 2007.111 ms  plan:\n{\"Query Text\": \"SELECT * FROM x WHERE y = $1 LIMIT $2\", \"Plan\": { } }\n2018-03-11 20:00:02 UTC:1.1.1.1(2):a@b:[3]:CONTEXT: unnamed portal with parameters: $1 = 'long string', $2 = '1', $3 = 'long string'\n",
+		output:          "duration: 2007.111 ms  plan:\n{\"Query Text\": \"SELECT * FROM x WHERE y = $1 LIMIT $2\", \"Plan\": { } }\nunnamed portal with parameters: $1 = '[redacted]', $2 = '[redacted]', $3 = '[redacted]'\n",
 	},
 	{
 		filterLogSecret: "none",

--- a/logs/replace_test.go
+++ b/logs/replace_test.go
@@ -45,6 +45,11 @@ var replaceTests = []replaceTestpair{
 		output:          "division by zero\n[redacted]\n",
 	},
 	{
+		filterLogSecret: "statement_parameter, unidentified",
+		input:           "2018-03-11 20:00:02 UTC:1.1.1.1(2):a@b:[3]:LOG:  duration: 2007.111 ms  plan:\n{\"Query Text\": \"SELECT * FROM x WHERE y = $1 LIMIT $2\", \"Plan\": { } }\n2018-03-11 20:00:02 UTC:1.1.1.1(2):a@b:[3]:CONTEXT: some new context we do not know with a secret\n",
+		output:          "duration: 2007.111 ms  plan:\n{\"Query Text\": \"SELECT * FROM x WHERE y = $1 LIMIT $2\", \"Plan\": { } }\n[redacted]\n",
+	},
+	{
 		filterLogSecret: "statement_text, statement_parameter, unidentified",
 		input:           "2018-03-11 20:00:02 UTC:1.1.1.1(2):a@b:[3]:LOG:  duration: 4079.697 ms  execute <unnamed>: \nSELECT * FROM x WHERE y = $1 LIMIT $2\n2018-03-11 20:00:02 UTC:1.1.1.1(2):a@b:[3]:DETAIL:  parameters: $1 = 'long string', $2 = '1'\n",
 		output:          "duration: 4079.697 ms  execute <unnamed>: \n[redacted]\nparameters: $1 = '[redacted]', $2 = '[redacted]'\n",


### PR DESCRIPTION
See individual commits. These can be present on certain Postgres versions, and were not being filtered correctly.