### PR TITLE
Add --force-record mode for testing snapshots

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,6 +66,7 @@ func main() {
 	var reloadRun bool
 	var noReload bool
 	var benchmark bool
+	var forceRecord bool
 
 	logFlags := log.LstdFlags
 	logger := &util.Logger{}
@@ -111,6 +112,7 @@ func main() {
 	flag.StringVar(&stateFilename, "statefile", defaultStateFile, "Specify alternative path for state file")
 	flag.StringVar(&pidFilename, "pidfile", "", "Specifies a path that a pidfile should be written to (default is no pidfile being written)")
 	flag.BoolVar(&benchmark, "benchmark", false, "Runs collector in benchmark mode (skip submitting the statistics to the server)")
+	flag.BoolVar(&forceRecord, "force-record", false, "When used with --test, sends snapshots like a normal one so that it will be processed on the server side (for testing and debugging)")
 	flag.Parse()
 
 	// Automatically reload the configuration after a successful test run.
@@ -178,6 +180,7 @@ func main() {
 		WriteStateUpdate:                 (!dryRun && !dryRunLogs && !testRun) || forceStateUpdate,
 		ForceEmptyGrant:                  dryRun || dryRunLogs || testRunLogs || benchmark,
 		OutputAsJson:                     !benchmark,
+		ForceRecord:                      forceRecord,
 	}
 
 	if reloadRun && !testRun {

--- a/runner/websocket.go
+++ b/runner/websocket.go
@@ -74,7 +74,7 @@ func connect(ctx context.Context, server *state.Server, globalCollectionOpts sta
 	headers["Pganalyze-System-Id-Fallback"] = []string{server.Config.SystemIDFallback}
 	headers["Pganalyze-System-Type-Fallback"] = []string{server.Config.SystemTypeFallback}
 	headers["Pganalyze-System-Scope-Fallback"] = []string{server.Config.SystemScopeFallback}
-	if globalCollectionOpts.TestRun {
+	if globalCollectionOpts.TestRun && !globalCollectionOpts.ForceRecord {
 		headers["Pganalyze-Test-Run"] = []string{"true"}
 	}
 	headers["User-Agent"] = []string{util.CollectorNameAndVersion}

--- a/state/state.go
+++ b/state/state.go
@@ -231,6 +231,7 @@ type CollectionOpts struct {
 	ForceEmptyGrant  bool
 
 	OutputAsJson bool
+	ForceRecord  bool
 }
 
 type Grant struct {


### PR DESCRIPTION
Unsure this is a good solution, but it is a solution, so let's start discussion from here. Any feedback from how we should implement this to the name of the flag is welcome.

During the development, we have a problem that we can only send and process full snapshots every 10 minutes. This is problematic when we want to have a better feedback loop, especially implementing new stats to record and trying out the integration test locally.

With this change, we can run the test like `./pganalyze-collector --test --force-record`, then snapshots created for the test will send out like a normal one, will be processed on the server side like a normal one.
Currently, with all test mode, we add a special header to the websocket request, and the server side will simply disregard these snapshots, therefore we can't use `--test` for the integration test.