### PR TITLE
Avoid trying to parse log lines when parser is not initialized

### DIFF
--- a/input/system/azure/logs.go
+++ b/input/system/azure/logs.go
@@ -338,6 +338,9 @@ func setupLogTransformer(ctx context.Context, wg *sync.WaitGroup, servers []*sta
 					continue
 				}
 				parser := server.GetLogParser()
+				if parser == nil {
+					continue
+				}
 				logLines, err := ParseRecordToLogLines(in, parser)
 				if err != nil {
 					logger.PrintError("%s", err)

--- a/input/system/google_cloudsql/logs.go
+++ b/input/system/google_cloudsql/logs.go
@@ -206,12 +206,16 @@ func setupLogTransformer(ctx context.Context, wg *sync.WaitGroup, servers []*sta
 					continue
 				}
 
+				parser := server.GetLogParser()
+				if parser == nil {
+					continue
+				}
 				// We ignore failures here since we want the per-backend stitching logic
 				// that runs later on (and any other parsing errors will just be ignored).
 				// Note that we need to restore the original trailing newlines since
 				// AnalyzeStreamInGroups expects them and they are not present in the GCP
 				// log stream.
-				logLine, _ := server.GetLogParser().ParseLine(in.Content + "\n")
+				logLine, _ := parser.ParseLine(in.Content + "\n")
 				logLine.OccurredAt = in.OccurredAt
 
 				// Ignore loglines which are outside our time window

--- a/input/system/selfhosted/logs.go
+++ b/input/system/selfhosted/logs.go
@@ -405,6 +405,9 @@ func setupLogTransformer(ctx context.Context, wg *sync.WaitGroup, server *state.
 					return
 				}
 				logParser := server.GetLogParser()
+				if logParser == nil {
+					continue
+				}
 
 				// We ignore failures here since we want the per-backend stitching logic
 				// that runs later on (and any other parsing errors will just be ignored)

--- a/logs/parse.go
+++ b/logs/parse.go
@@ -512,6 +512,9 @@ func ParseAndAnalyzeBuffer(logStream LineReader, linesNewerThan time.Time, serve
 	var logLines []state.LogLine
 	var currentByteStart int64 = 0
 	parser := server.GetLogParser()
+	if parser == nil {
+		return []state.LogLine{}, []state.PostgresQuerySample{}
+	}
 
 	for {
 		line, err := logStream.ReadString('\n')

--- a/runner/run.go
+++ b/runner/run.go
@@ -334,9 +334,13 @@ func checkOneInitialCollectionStatus(ctx context.Context, server *state.Server, 
 
 	logs.SyncLogParser(server, settings)
 	parser := server.GetLogParser()
-	prefixErr := parser.ValidatePrefix()
-	if prefixErr != nil {
-		logger.PrintWarning("Checking log_line_prefix: %s", prefixErr)
+	if parser == nil {
+		logger.PrintWarning("Could not initialize log parser for server")
+	} else {
+		prefixErr := parser.ValidatePrefix()
+		if prefixErr != nil {
+			logger.PrintWarning("Checking log_line_prefix: %s", prefixErr)
+		}
 	}
 
 	server.CollectionStatusMutex.Lock()


### PR DESCRIPTION
Currently, the collector log processing code assumes that the log
parser has always been initialized by the time we receive log messages
to process.  This is generally true, but it can be false if the
collector failed to connect to the database (to fetch log_line_prefix
to initialize the parser). That can lead to confusing errors (that
are not relevant to the root cause of the connection problem).

Skip attempting to process log lines when the log parser is not yet
initialized.
