### PR TITLE
Fix stats handling in partition merging when some relations are locked

### DIFF
--- a/output/transform/merge_partition_sizes.go
+++ b/output/transform/merge_partition_sizes.go
@@ -12,11 +12,17 @@ import (
 //
 // TODO: recursively build up stats when nested partitioning is used
 func mergePartitionSizes(s snapshot.FullSnapshot, newState state.PersistedState, ts state.TransientState, databaseOidToIdx OidToIdx) snapshot.FullSnapshot {
+	relIdxToStatsIdx := make(map[int32]int, len(s.RelationStatistics))
+	for idx, stat := range s.RelationStatistics {
+		relIdxToStatsIdx[stat.RelationIdx] = idx
+	}
+
 	for idx, rel := range s.RelationInformations {
 		if !rel.HasParentRelation || rel.PartitionBoundary == "" {
 			continue
 		}
-		stat := s.RelationStatistics[idx]
+		statIdx := relIdxToStatsIdx[int32(idx)]
+		stat := s.RelationStatistics[statIdx]
 		parent := s.RelationStatistics[rel.ParentRelationIdx]
 		parent.NTupIns += stat.NTupIns
 		parent.NTupUpd += stat.NTupUpd

--- a/output/transform/merge_partition_sizes.go
+++ b/output/transform/merge_partition_sizes.go
@@ -21,7 +21,11 @@ func mergePartitionSizes(s snapshot.FullSnapshot, newState state.PersistedState,
 		if !rel.HasParentRelation || rel.PartitionBoundary == "" {
 			continue
 		}
-		statIdx := relIdxToStatsIdx[int32(idx)]
+		statIdx, ok := relIdxToStatsIdx[int32(idx)]
+		if !ok {
+			continue
+		}
+
 		stat := s.RelationStatistics[statIdx]
 		parent := s.RelationStatistics[rel.ParentRelationIdx]
 		parent.NTupIns += stat.NTupIns


### PR DESCRIPTION
When some relations are locked, we add them to the
RelationInformations array, but do not add their stats to the
RelationStatistics array. This can cause problems because
mergePartitionSizes assumes that the arrays are parallel.

Update mergePartitionSizes to reference relations by the RelationIdx
field in RelationStatistic, which avoids this issue.
