### PR TITLE
Drop special-casing of syslog format

### DIFF
--- a/input/system/azure/logs_test.go
+++ b/input/system/azure/logs_test.go
@@ -350,7 +350,7 @@ func TestParseRecordToLogLines(t *testing.T) {
 		} else {
 			prefix = logs.LogPrefixAzure
 		}
-		parser := logs.NewLogParser(prefix, nil, false)
+		parser := logs.NewLogParser(prefix, nil)
 
 		var record azure.AzurePostgresLogRecord
 		err := json.Unmarshal([]byte(pair.recordIn), &record)

--- a/input/system/heroku/logs.go
+++ b/input/system/heroku/logs.go
@@ -118,7 +118,7 @@ func processSystemMetrics(ctx context.Context, timestamp time.Time, content []by
 	}
 }
 
-var HerokuLogParser = logs.NewLogParser(logs.LogPrefixHeroku2, nil, false)
+var HerokuLogParser = logs.NewLogParser(logs.LogPrefixHeroku2, nil)
 
 func logStreamItemToLogLine(ctx context.Context, item HttpSyslogMessage, servers []*state.Server, sourceToServer map[string]*state.Server, now time.Time, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (map[string]*state.Server, *state.LogLine, string) {
 	timestamp, err := time.Parse(time.RFC3339, item.HeaderTimestamp)

--- a/logs/parse_test.go
+++ b/logs/parse_test.go
@@ -29,45 +29,6 @@ func mustTimeLocation(tzStr string) *time.Location {
 var BSTTimeLocation = mustTimeLocation("Europe/London")
 
 var parseTests = []parseTestpair{
-	// rsyslog format
-	{
-		"",
-		"Feb  1 21:48:31 ip-172-31-14-41 postgres[9076]: [3-1] LOG:  database system is ready to accept connections",
-		nil,
-		state.LogLine{
-			OccurredAt: time.Date(time.Now().Year(), time.February, 1, 21, 48, 31, 0, time.UTC),
-			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
-			BackendPid: 9076,
-			Content:    "database system is ready to accept connections",
-		},
-		true,
-	},
-	{
-		"",
-		"Feb  1 21:48:31 ip-172-31-14-41 postgres[9076]: [3-2] #011 something",
-		nil,
-		state.LogLine{
-			OccurredAt: time.Date(time.Now().Year(), time.February, 1, 21, 48, 31, 0, time.UTC),
-			LogLevel:   pganalyze_collector.LogLineInformation_UNKNOWN,
-			BackendPid: 9076,
-			Content:    "\t something",
-		},
-		false,
-	},
-	{
-		"",
-		"Feb  1 21:48:31 ip-172-31-14-41 postgres[123]: [8-1] [user=postgres,db=postgres,app=[unknown]] LOG: connection received: host=[local]",
-		nil,
-		state.LogLine{
-			OccurredAt: time.Date(time.Now().Year(), time.February, 1, 21, 48, 31, 0, time.UTC),
-			LogLevel:   pganalyze_collector.LogLineInformation_LOG,
-			BackendPid: 123,
-			Username:   "postgres",
-			Database:   "postgres",
-			Content:    "connection received: host=[local]",
-		},
-		true,
-	},
 	// Amazon RDS format
 	{
 		logs.LogPrefixAmazonRds,
@@ -658,11 +619,7 @@ var parseTests = []parseTestpair{
 
 func TestLogParser(t *testing.T) {
 	for _, pair := range parseTests {
-		// Syslog format has a separate, fixed prefix, so the prefix argument is
-		// ignored by the parser in that case. We use an empty string to indicate
-		// that this is a syslog test case.
-		isSyslog := pair.prefixIn == ""
-		parser := logs.NewLogParser(pair.prefixIn, pair.lineInTz, isSyslog)
+		parser := logs.NewLogParser(pair.prefixIn, pair.lineInTz)
 		l, lOk := parser.ParseLine(pair.lineIn)
 
 		cfg := pretty.CompareConfig

--- a/logs/replace_test.go
+++ b/logs/replace_test.go
@@ -70,7 +70,7 @@ func TestReplaceSecrets(t *testing.T) {
 	for _, pair := range replaceTests {
 		reader := bufio.NewReader(strings.NewReader(pair.input))
 		server := state.MakeServer(config.ServerConfig{}, false)
-		server.LogParser = logs.NewLogParser(logs.LogPrefixAmazonRds, nil, false)
+		server.LogParser = logs.NewLogParser(logs.LogPrefixAmazonRds, nil)
 		logLines, _ := logs.ParseAndAnalyzeBuffer(reader, time.Time{}, server)
 		logs.ReplaceSecrets(logLines, state.ParseFilterLogSecret(pair.filterLogSecret))
 

--- a/main.go
+++ b/main.go
@@ -214,7 +214,7 @@ func main() {
 			fmt.Println("ERROR: must specify log_line_prefix used to generate logfile with --analyze-logfile-prefix")
 			return
 		}
-		server.LogParser = logs.NewLogParser(analyzeLogfilePrefix, tz, false)
+		server.LogParser = logs.NewLogParser(analyzeLogfilePrefix, tz)
 
 		logLines, samples := logs.ParseAndAnalyzeBuffer(logReader, time.Time{}, server)
 		logs.PrintDebugInfo(logLines, samples)

--- a/state/state.go
+++ b/state/state.go
@@ -343,7 +343,7 @@ const (
 )
 
 type LogParser interface {
-	Matches(prefix string, tz *time.Location, isSyslog bool) bool
+	Matches(prefix string, tz *time.Location) bool
 	GetOccurredAt(timePart string) time.Time
 	ParseLine(line string) (logLine LogLine, ok bool)
 	ValidatePrefix() error


### PR DESCRIPTION
This was a bug introduced in #494. The code here was intended to pass
syslog-format messages to the old parsing code, but the old parsing
code did not actually use this code path for syslog. All the
syslog-specific processing is actually in
input/system/selfhosted/syslog_handler.go, and then the messages are
handed off to the parser. They will be matched against log_line_prefix
like any other log line.

Before #494 this worked fine, because #145 introduced a couple of
log_line_prefix options that could be used with this format.

The RsyslogRegexp was actually introduced in
73712dd996be4485b49ef79df5e5533131020ac9 (before our workflow used
pull requests consistently), and appears to have been intended to tail
log files in an older syslog format (the obsolete RFC3164, versus the
RFC5424 we currently support).

Drop mistaken delegating of syslog message handling to obsolete
parsing mechanism. Also drop this mechanism: it was broken by #494
anyway, and given it's a legacy format (RFC5424 came out in 2009),
there's no reason to believe it's still in use.

TODO:
 - [ ] ~add CI test coverage~ (see below)
   - one of the reasons this bug occurred in the first place is our
     lack of tests around this; I'm looking into adding an integration
     test coverage