### PR TITLE
Rename cron scheduler

### DIFF
--- a/runner/run.go
+++ b/runner/run.go
@@ -266,11 +266,12 @@ func Run(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.Col
 		}, logger, "activity snapshot of all servers")
 	}
 
-	scheduler.OneMinute.ScheduleSecondary(ctx, func(ctx context.Context) {
+	// Query stats are captured every minute, except for minute 10 when full snapshot collection takes over
+	scheduler.OneMinute.ScheduleSecondary(ctx, scheduler.TenMinute, func(ctx context.Context) {
 		wg.Add(1)
 		GatherQueryStatsFromAllServers(ctx, servers, globalCollectionOpts, logger)
 		wg.Done()
-	}, logger, "high frequency query statistics of all servers", scheduler.TenMinute)
+	}, logger, "high frequency query statistics of all servers")
 
 	SetupWebsocketForAllServers(ctx, servers, globalCollectionOpts, logger)
 	SetupQueryRunnerForAllServers(ctx, servers, globalCollectionOpts, logger)

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -8,6 +8,36 @@ import (
 	"github.com/pganalyze/collector/util"
 )
 
+type Scheduler struct {
+	TenSecond Group
+	OneMinute Group
+	TenMinute Group
+}
+
+func GetScheduler() (scheduler Scheduler, err error) {
+	tenSecondInterval, err := cronexpr.Parse("*/10 * * * * * *")
+	if err != nil {
+		return
+	}
+
+	oneMinuteInterval, err := cronexpr.Parse("0 * * * * * *")
+	if err != nil {
+		return
+	}
+
+	tenMinuteInterval, err := cronexpr.Parse("0 */10 * * * * *")
+	if err != nil {
+		return
+	}
+
+	scheduler = Scheduler{
+		TenSecond: Group{interval: tenSecondInterval},
+		OneMinute: Group{interval: oneMinuteInterval},
+		TenMinute: Group{interval: tenMinuteInterval},
+	}
+	return
+}
+
 type Group struct {
 	interval *cronexpr.Expression
 }
@@ -74,28 +104,3 @@ func (group Group) ScheduleSecondary(ctx context.Context, runner func(context.Co
 }
 
 const FullSnapshotsPerHour = 6
-
-func GetSchedulerGroups() (groups map[string]Group, err error) {
-	tenSecondInterval, err := cronexpr.Parse("*/10 * * * * * *")
-	if err != nil {
-		return
-	}
-
-	oneMinuteInterval, err := cronexpr.Parse("0 * * * * * *")
-	if err != nil {
-		return
-	}
-
-	tenMinuteInterval, err := cronexpr.Parse("0 */10 * * * * *")
-	if err != nil {
-		return
-	}
-
-	groups = make(map[string]Group)
-
-	groups["stats"] = Group{interval: tenMinuteInterval}
-	groups["activity"] = Group{interval: tenSecondInterval}
-	groups["query_stats"] = Group{interval: oneMinuteInterval}
-
-	return
-}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -9,9 +9,9 @@ import (
 )
 
 type Scheduler struct {
-	TenSecond Group
-	OneMinute Group
-	TenMinute Group
+	TenSecond Schedule
+	OneMinute Schedule
+	TenMinute Schedule
 }
 
 func GetScheduler() (scheduler Scheduler, err error) {
@@ -31,21 +31,21 @@ func GetScheduler() (scheduler Scheduler, err error) {
 	}
 
 	scheduler = Scheduler{
-		TenSecond: Group{interval: tenSecondInterval},
-		OneMinute: Group{interval: oneMinuteInterval},
-		TenMinute: Group{interval: tenMinuteInterval},
+		TenSecond: Schedule{interval: tenSecondInterval},
+		OneMinute: Schedule{interval: oneMinuteInterval},
+		TenMinute: Schedule{interval: tenMinuteInterval},
 	}
 	return
 }
 
-type Group struct {
+type Schedule struct {
 	interval *cronexpr.Expression
 }
 
-func (group Group) Schedule(ctx context.Context, runner func(context.Context), logger *util.Logger, logName string) {
+func (schedule Schedule) Schedule(ctx context.Context, runner func(context.Context), logger *util.Logger, logName string) {
 	go func() {
 		for {
-			nextExecutions := group.interval.NextN(time.Now(), 2)
+			nextExecutions := schedule.interval.NextN(time.Now(), 2)
 			delay := time.Until(nextExecutions[0])
 
 			logger.PrintVerbose("Scheduled next run for %s in %+v", logName, delay)
@@ -72,13 +72,13 @@ func (group Group) Schedule(ctx context.Context, runner func(context.Context), l
 }
 
 // ScheduleSecondary - Behaves almost like Schedule, but ignores the point in time
-// where the primary group also has a run (to avoid overlapping statistics)
-func (group Group) ScheduleSecondary(ctx context.Context, runner func(context.Context), logger *util.Logger, logName string, primaryGroup Group) {
+// where the primary schedule also has a run (to avoid overlapping statistics)
+func (schedule Schedule) ScheduleSecondary(ctx context.Context, primarySchedule Schedule, runner func(context.Context), logger *util.Logger, logName string) {
 	go func() {
 		for {
 			timeNow := time.Now()
-			delay := group.interval.Next(timeNow).Sub(timeNow)
-			delayPrimary := primaryGroup.interval.Next(timeNow).Sub(timeNow)
+			delay := schedule.interval.Next(timeNow).Sub(timeNow)
+			delayPrimary := primarySchedule.interval.Next(timeNow).Sub(timeNow)
 
 			// Make sure to not run more often than once a second - this can happen
 			// due to rounding errors in the interval logic
@@ -94,7 +94,7 @@ func (group Group) ScheduleSecondary(ctx context.Context, runner func(context.Co
 				return
 			case <-time.After(delay):
 				if int(delay.Seconds()) == int(delayPrimary.Seconds()) {
-					logger.PrintVerbose("Skipping run for %s since it overlaps with primary group time", logName)
+					logger.PrintVerbose("Skipping run for %s since it overlaps with primary schedule", logName)
 				} else {
 					runner(ctx)
 				}

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -6,14 +6,14 @@ import (
 )
 
 func TestScheduler(t *testing.T) {
-	groups, err := GetSchedulerGroups()
+	scheduler, err := GetScheduler()
 	if err != nil {
 		t.Errorf("Error: %v\n", err)
 	}
 
 	someTime := time.Date(2013, 1, 1, 0, 5, 0, 0, time.UTC)
 	expectedNextRun := time.Date(2013, 1, 1, 0, 10, 0, 0, time.UTC)
-	actualNextRun := groups["stats"].interval.Next(someTime)
+	actualNextRun := scheduler.TenMinute.interval.Next(someTime)
 
 	if expectedNextRun != actualNextRun {
 		t.Errorf("\nNext run:\n\texpected %s\n\tactual %s\n\n", expectedNextRun, actualNextRun)


### PR DESCRIPTION
This PR updates the scheduler code so that the individual schedules are named by their frequency instead of using a purpose-specific name like, so for example `activity` becomes `TenSecond`. This change is needed for new features; it wouldn't make sense to capture 1 minute system stats using a `query_stats` schedule.

Since there's no need for this to be a dynamic map of schedules, I've replaced it with a statically-typed `Scheduler` struct. Note: `GetScheduler` was moved to the top of the file since it's the entrypoint into the file.