### PR TITLE
Resolve data directory symlinks

### DIFF
--- a/helper/main.go
+++ b/helper/main.go
@@ -49,7 +49,7 @@ func getStatus(dataDirectory string) {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 	} else {
 		status.DataDirectory = dataDirectory
-		if dataDirectory == "" {
+		if status.DataDirectory == "" {
 			status.DataDirectory = os.Getenv("PGDATA")
 		}
 

--- a/helper/main.go
+++ b/helper/main.go
@@ -55,10 +55,12 @@ func getStatus(dataDirectory string) {
 		}
 
 		if status.DataDirectory == "" {
-			status.DataDirectory, err = filepath.EvalSymlinks("/proc/" + strconv.Itoa(status.PostmasterPid) + "/cwd")
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to resolve data directory path: %s\n", err)
-			}
+			status.DataDirectory = "/proc/" + strconv.Itoa(status.PostmasterPid) + "/cwd"
+		}
+
+		status.DataDirectory, err = filepath.EvalSymlinks(status.DataDirectory)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to resolve data directory path: %s\n", err)
 		}
 
 		xlogDirectoryName := "pg_wal"

--- a/helper/main.go
+++ b/helper/main.go
@@ -48,9 +48,8 @@ func getStatus(dataDirectory string) {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 	} else {
-		if dataDirectory != "" {
-			status.DataDirectory = dataDirectory
-		} else {
+		status.DataDirectory = dataDirectory
+		if dataDirectory == "" {
 			status.DataDirectory = os.Getenv("PGDATA")
 		}
 


### PR DESCRIPTION
Resolve symlinks when finding the Postgres data directory

We currently do not resolve symlinks when looking up $PGDATA from the
environment or the `data_directory` GUC setting. This can misattribute
storage costs to the wrong partition.

Always follow symlinks in the helper that resolves the data directory.
