### PR TITLE
Allow monitoring non-Heroku databases on Heroku

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -828,7 +828,7 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 			return conf, fmt.Errorf("Configuration contains no valid servers, please edit %s and reload the collector", filename)
 		}
 	} else {
-		if os.Getenv("PGA_API_KEY") != "" && (os.Getenv("DB_NAME") != "" || os.Getenv("DB_URL") != "") {
+		if os.Getenv("PGA_API_KEY") != "" && (os.Getenv("DB_URL") != "" || os.Getenv("DB_HOST") != "" || os.Getenv("DB_PORT") != "" || os.Getenv("DB_NAME") != "" || os.Getenv("DB_USERNAME") != "" || os.Getenv("DB_PASSWORD") != "") {
 			config := getDefaultConfig()
 			config, err = preprocessConfig(config)
 			if err != nil {

--- a/config/read.go
+++ b/config/read.go
@@ -828,7 +828,15 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 			return conf, fmt.Errorf("Configuration contains no valid servers, please edit %s and reload the collector", filename)
 		}
 	} else {
-		if util.IsHeroku() {
+		if os.Getenv("PGA_API_KEY") != "" && (os.Getenv("DB_NAME") != "" || os.Getenv("DB_URL") != "") {
+			config := getDefaultConfig()
+			config, err = preprocessConfig(config)
+			if err != nil {
+				return conf, err
+			}
+			config.SystemID, config.SystemType, config.SystemScope, config.SystemIDFallback, config.SystemTypeFallback, config.SystemScopeFallback = identifySystem(*config)
+			conf.Servers = append(conf.Servers, *config)
+		} else if util.IsHeroku() {
 			for _, kv := range os.Environ() {
 				parts := strings.SplitN(kv, "=", 2)
 				parsedKey := parts[0]
@@ -861,14 +869,6 @@ func Read(logger *util.Logger, filename string) (Config, error) {
 				}
 				conf.Servers = append(conf.Servers, *config)
 			}
-		} else if os.Getenv("PGA_API_KEY") != "" {
-			config := getDefaultConfig()
-			config, err = preprocessConfig(config)
-			if err != nil {
-				return conf, err
-			}
-			config.SystemID, config.SystemType, config.SystemScope, config.SystemIDFallback, config.SystemTypeFallback, config.SystemScopeFallback = identifySystem(*config)
-			conf.Servers = append(conf.Servers, *config)
 		} else {
 			if os.Getenv("API_KEY") != "" {
 				logger.PrintInfo("Environment variable API_KEY was found, but not PGA_API_KEY. Please double check the variable name")


### PR DESCRIPTION
Currently, we assume that a Heroku-deployed collector will always
monitor Heroku databases specified through Heroku env config
(`HEROKU_POSTGRES_..._URL` values). It's possible to work around this
with `CONFIG_CONTENTS`, but can be an awkward workflow.

Allow monitoring databases deployed elsewhere by checking for
pganalyze-specific env vars first.
