### PR TITLE
GH Actions: Pin QEMU action binfmt to qemu-v7.0.0-28

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,8 @@ jobs:
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Build packages
       run: |

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
         platforms: arm64
 
     - name: Build packages


### PR DESCRIPTION
Newer versions cause segmentation fault issues, see https://github.com/docker/setup-qemu-action/issues/198