### PR TITLE
Build ARM packages without QEMU emulation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
         name: pganalyze-collector-linux-arm64
         path: pganalyze-collector-linux-arm64
 
-  build_packages:
+  build_packages_x86_64:
     # Use older Ubuntu release to ensure availability of CGroupsv1 (which are necessary
     # currently to support older systemd on some of the test containers)
     runs-on: ubuntu-20.04
@@ -97,16 +97,43 @@ jobs:
       with:
         submodules: true
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
     - name: Build packages
       run: |
-        DOCKER_BUILDKIT=1 make -C packages build
+        make -C packages build_x86_64
 
     - name: Test packages
       run: |
-        DOCKER_BUILDKIT=1 make -C packages test
+        make -C packages test_x86_64
+
+    - name: Upload packages as artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: packages
+        path: |
+          packages/tmp/pganalyze-collector-*.x86_64.rpm
+          packages/tmp/pganalyze-collector_*_amd64.deb
+        if-no-files-found: error
+
+  build_packages_arm64:
+    runs-on: ubuntu-22.04-arm
+    permissions: {}
+    # ensure we don't release on create events for branches (only tags)
+    if: ${{ startsWith( github.ref, 'refs/tags' ) }}
+
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Build packages
+      run: |
+        make -C packages build_arm64
+
+    - name: Test packages
+      run: |
+        make -C packages test_arm64
 
     - name: Upload packages as artifacts
       uses: actions/upload-artifact@v4
@@ -114,8 +141,6 @@ jobs:
         name: packages
         path: |
           packages/tmp/pganalyze-collector-*.aarch64.rpm
-          packages/tmp/pganalyze-collector-*.x86_64.rpm
-          packages/tmp/pganalyze-collector_*_amd64.deb
           packages/tmp/pganalyze-collector_*_arm64.deb
         if-no-files-found: error
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,7 +170,7 @@ jobs:
         if-no-files-found: error
 
   release:
-    needs: [build, build_arm, build_packages, build_charts]
+    needs: [build, build_arm, build_packages_x86_64, build_packages_arm64, build_charts]
     runs-on: ubuntu-latest
     # ensure we don't release on create events for branches (only tags)
     if: ${{ startsWith( github.ref, 'refs/tags' ) }}

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -10,7 +10,7 @@ jobs:
   build_x86_64:
     # Use older Ubuntu release to ensure availability of CGroupsv1 (which are necessary
     # currently to support older systemd on some of the test containers)
-    runs-on: ubuntu-20.04-4-cores
+    runs-on: ubuntu-22.04-4-cores
     permissions: {}
 
     steps:

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build_x86_64:
     # Use older Ubuntu release to ensure availability of CGroupsv1 (which are necessary
     # currently to support older systemd on some of the test containers)
     runs-on: ubuntu-20.04-4-cores
@@ -20,15 +20,29 @@ jobs:
       with:
         submodules: true
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: arm64
-
     - name: Build packages
       run: |
-        GIT_VERSION=HEAD VERSION=0.0.0 make -C packages build
+        GIT_VERSION=HEAD VERSION=0.0.0 make -C packages build_x86_64
 
     - name: Test packages
       run: |
-        GIT_VERSION=HEAD VERSION=0.0.0 make -C packages test
+        GIT_VERSION=HEAD VERSION=0.0.0 make -C packages test_x86_64
+
+  build_arm64:
+    runs-on: ubuntu-22.04-arm
+    permissions: {}
+
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Build packages
+      run: |
+        GIT_VERSION=HEAD VERSION=0.0.0 make -C packages build_arm64
+
+    - name: Test packages
+      run: |
+        GIT_VERSION=HEAD VERSION=0.0.0 make -C packages test_arm64

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -29,7 +29,7 @@ jobs:
         GIT_VERSION=HEAD VERSION=0.0.0 make -C packages test_x86_64
 
   build_arm64:
-    runs-on: ubuntu-20.04-arm
+    runs-on: ubicloud-standard-2-arm
     permissions: {}
 
     steps:

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -10,7 +10,7 @@ jobs:
   build_x86_64:
     # Use older Ubuntu release to ensure availability of CGroupsv1 (which are necessary
     # currently to support older systemd on some of the test containers)
-    runs-on: ubuntu-22.04-4-cores
+    runs-on: ubuntu-20.04-4-cores
     permissions: {}
 
     steps:
@@ -29,7 +29,7 @@ jobs:
         GIT_VERSION=HEAD VERSION=0.0.0 make -C packages test_x86_64
 
   build_arm64:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-20.04-arm
     permissions: {}
 
     steps:

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -29,7 +29,7 @@ jobs:
         GIT_VERSION=HEAD VERSION=0.0.0 make -C packages test_x86_64
 
   build_arm64:
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-24.04-arm
     permissions: {}
 
     steps:

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -29,7 +29,7 @@ jobs:
         GIT_VERSION=HEAD VERSION=0.0.0 make -C packages test_x86_64
 
   build_arm64:
-    runs-on: ubicloud-standard-2-arm
+    runs-on: ubuntu-22.04-arm
     permissions: {}
 
     steps:

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -19,11 +19,21 @@ default: test repo
 setup:
 	mkdir -p $(TMP_DIR)
 
-build: setup
-	make -C src
+build_x86_64: setup
+	make -C src x86_64
 
-test: setup build
-	make -C test
+build_arm64: setup
+	make -C src arm64
+
+build: build_x86_64 build_arm64
+
+test_x86_64: setup build_x86_64
+	make -C test x86_64
+
+test_arm64: setup build_arm64
+	make -C test arm64
+
+test: test_x86_64 test_arm64
 
 # Assume the package build and test were run automatically, and use the artifacts from the GitHub release instead of rebuilding
 repo: setup

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -12,7 +12,7 @@ export DEB_PACKAGE_ARM64=$(NAME)_$(VERSION)_arm64.deb
 
 export TMP_DIR=$(shell pwd)/tmp
 
-.PHONY: default setup build test clean repo
+.PHONY: default setup build_x86_64 build_arm64 build test_x86_64 test_arm64 test clean repo
 
 default: test repo
 

--- a/packages/src/Makefile
+++ b/packages/src/Makefile
@@ -2,10 +2,13 @@
 
 BUILD_ARGS=--no-cache --build-arg VERSION=$(VERSION) --build-arg GIT_VERSION=$(GIT_VERSION)
 
-.PHONY: all
+.PHONY: all x86_64 arm64
 
-all: $(TMP_DIR)/$(RPM_PACKAGE_X86_64) $(TMP_DIR)/$(RPM_PACKAGE_ARM64) \
-$(TMP_DIR)/$(DEB_PACKAGE_X86_64) $(TMP_DIR)/$(DEB_PACKAGE_ARM64)
+all: x86_64 arm64
+
+x86_64: $(TMP_DIR)/$(RPM_PACKAGE_X86_64) $(TMP_DIR)/$(DEB_PACKAGE_X86_64)
+
+arm64: $(TMP_DIR)/$(RPM_PACKAGE_ARM64) $(TMP_DIR)/$(DEB_PACKAGE_ARM64)
 
 $(TMP_DIR)/$(RPM_PACKAGE_X86_64): Dockerfile.build.rpm-systemd
 	docker build --platform linux/amd64 $(BUILD_ARGS) -f Dockerfile.build.rpm-systemd -t pga-collector-build ../../

--- a/packages/src/Makefile
+++ b/packages/src/Makefile
@@ -1,6 +1,7 @@
 # Note: This requires variables that are set in the top-level packages Makefile
 
 BUILD_ARGS=--no-cache --build-arg VERSION=$(VERSION) --build-arg GIT_VERSION=$(GIT_VERSION)
+DOCKER_CMD=docker
 
 .PHONY: all x86_64 arm64
 
@@ -11,21 +12,21 @@ x86_64: $(TMP_DIR)/$(RPM_PACKAGE_X86_64) $(TMP_DIR)/$(DEB_PACKAGE_X86_64)
 arm64: $(TMP_DIR)/$(RPM_PACKAGE_ARM64) $(TMP_DIR)/$(DEB_PACKAGE_ARM64)
 
 $(TMP_DIR)/$(RPM_PACKAGE_X86_64): Dockerfile.build.rpm-systemd
-	docker build --platform linux/amd64 $(BUILD_ARGS) -f Dockerfile.build.rpm-systemd -t pga-collector-build ../../
-	docker run --platform linux/amd64 --rm -v $(TMP_DIR):/out pga-collector-build sh -c "cp /root/$(RPM_PACKAGE_X86_64) /out"
-	docker rmi pga-collector-build
+	$(DOCKER_CMD) build --platform linux/amd64 $(BUILD_ARGS) -f Dockerfile.build.rpm-systemd -t pga-collector-build ../../
+	$(DOCKER_CMD) run --platform linux/amd64 --rm -v $(TMP_DIR):/out pga-collector-build sh -c "cp /root/$(RPM_PACKAGE_X86_64) /out"
+	$(DOCKER_CMD) rmi pga-collector-build
 
 $(TMP_DIR)/$(RPM_PACKAGE_ARM64): Dockerfile.build.rpm-systemd
-	docker build --platform linux/arm64 $(BUILD_ARGS) -f Dockerfile.build.rpm-systemd -t pga-collector-build ../../
-	docker run --platform linux/arm64 --rm -v $(TMP_DIR):/out pga-collector-build sh -c "cp /root/$(RPM_PACKAGE_ARM64) /out"
-	docker rmi pga-collector-build
+	$(DOCKER_CMD) build --platform linux/arm64 $(BUILD_ARGS) -f Dockerfile.build.rpm-systemd -t pga-collector-build ../../
+	$(DOCKER_CMD) run --platform linux/arm64 --rm -v $(TMP_DIR):/out pga-collector-build sh -c "cp /root/$(RPM_PACKAGE_ARM64) /out"
+	$(DOCKER_CMD) rmi pga-collector-build
 
 $(TMP_DIR)/$(DEB_PACKAGE_X86_64): Dockerfile.build.deb-systemd
-	docker build --platform linux/amd64 $(BUILD_ARGS) -f Dockerfile.build.deb-systemd -t pga-collector-build ../../
-	docker run --platform linux/amd64 --rm -v $(TMP_DIR):/out pga-collector-build sh -c "cp /root/$(DEB_PACKAGE_X86_64) /out"
-	docker rmi pga-collector-build
+	$(DOCKER_CMD) build --platform linux/amd64 $(BUILD_ARGS) -f Dockerfile.build.deb-systemd -t pga-collector-build ../../
+	$(DOCKER_CMD) run --platform linux/amd64 --rm -v $(TMP_DIR):/out pga-collector-build sh -c "cp /root/$(DEB_PACKAGE_X86_64) /out"
+	$(DOCKER_CMD) rmi pga-collector-build
 
 $(TMP_DIR)/$(DEB_PACKAGE_ARM64): Dockerfile.build.deb-systemd
-	docker build --platform linux/arm64 $(BUILD_ARGS) -f Dockerfile.build.deb-systemd -t pga-collector-build ../../
-	docker run --platform linux/arm64 --rm -v $(TMP_DIR):/out pga-collector-build sh -c "cp /root/$(DEB_PACKAGE_ARM64) /out"
-	docker rmi pga-collector-build
+	$(DOCKER_CMD) build --platform linux/arm64 $(BUILD_ARGS) -f Dockerfile.build.deb-systemd -t pga-collector-build ../../
+	$(DOCKER_CMD) run --platform linux/arm64 --rm -v $(TMP_DIR):/out pga-collector-build sh -c "cp /root/$(DEB_PACKAGE_ARM64) /out"
+	$(DOCKER_CMD) rmi pga-collector-build

--- a/packages/test/Makefile
+++ b/packages/test/Makefile
@@ -13,8 +13,9 @@ docker_test_and_clean = $(DOCKER_CMD) exec pga-collector-test /root/systemd_test
 # /sbin/init not being present, see https://github.com/rocky-linux/sig-cloud-instance-images/issues/39
 # Note: The default list also excludes centos7 since it's EOL, we will drop the support near future
 DISTROS_X86_64=rhel8_x86_64 rockylinux8_x86_64 rhel9_x86_64 fedora36_x86_64 fedora37_x86_64 amazonlinux2_x86_64 amazonlinux2023_x86_64 ubuntu-focal_x86_64 ubuntu-jammy_x86_64 ubuntu-noble_x86_64 debian-bullseye_x86_64 debian-bookworm_x86_64
-#DISTROS_ARM64=rhel8_arm64 rockylinux8_arm64 rhel9_arm64 fedora36_arm64 fedora37_arm64 amazonlinux2_arm64 amazonlinux2023_arm64 ubuntu-focal_arm64 ubuntu-jammy_arm64 ubuntu-noble_arm64 debian-bullseye_arm64 debian-bookworm_arm64
-DISTROS_ARM64=amazonlinux2_arm64 rhel8_arm64 rockylinux8_arm64 rhel9_arm64 fedora36_arm64 fedora37_arm64 amazonlinux2023_arm64 ubuntu-focal_arm64 ubuntu-jammy_arm64 ubuntu-noble_arm64 debian-bullseye_arm64 debian-bookworm_arm64
+DISTROS_ARM64=rhel8_arm64 rockylinux8_arm64 rhel9_arm64 fedora36_arm64 fedora37_arm64 amazonlinux2_arm64 amazonlinux2023_arm64 ubuntu-focal_arm64 ubuntu-jammy_arm64 ubuntu-noble_arm64 debian-bullseye_arm64 debian-bookworm_arm64
+
+CGROUPS_V1 := $(shell test `stat -fc %T /sys/fs/cgroup/` = tmpfs && echo '1' 1>&2 2> /dev/null)
 
 .PHONY: all $(DISTROS_X86_64) $(DISTROS_ARM64)
 
@@ -174,27 +175,26 @@ amazonlinux2_x86_64: $(RPM_PACKAGE_X86_64)
 	echo "FROM amazonlinux:2" > Dockerfile.tmp
 	echo "RUN yum install -y procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
-	$(DOCKER_CMD) build --no-cache -f Dockerfile.tmp -t pga-collector-test .
-	$(DOCKER_CMD) run --name pga-collector-test --privileged=true -e container=docker -d pga-collector-test /sbin/init
-	$(DOCKER_CMD) top pga-collector-test
-	$(DOCKER_CMD) exec pga-collector-test bash -c "echo -n 'Waiting for systemd'; while \$$(sleep 1); do echo -n '.'; if (systemctl is-system-running 2> /dev/null || /bin/true) | grep -qE 'running|degraded'; then break; fi; done; echo ''"
-#	$(call docker_build_and_run,amd64)
+ifeq ($(CGROUPS_V1),1)
+	$(call docker_build_and_run,amd64)
 	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_X86_64))
 	$(call docker_test_and_clean)
+else
+	echo "Skipping Amazon Linux 2 test since host system uses cgroup v2"
+endif
 	rm Dockerfile.tmp
 
 amazonlinux2_arm64: $(RPM_PACKAGE_ARM64)
 	echo "FROM amazonlinux:2" > Dockerfile.tmp
 	echo "RUN yum install -y procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
-	$(DOCKER_CMD) build --no-cache -f Dockerfile.tmp -t pga-collector-test .
-	$(DOCKER_CMD) run --name pga-collector-test --privileged=true -e container=docker -d pga-collector-test /sbin/init
-	$(DOCKER_CMD) top pga-collector-test
-	$(DOCKER_CMD) exec pga-collector-test bash -c "echo -n 'Waiting for systemd'; while \$$(sleep 1); do echo -n '.'; if (systemctl is-system-running 2> /dev/null || /bin/true) | grep -qE 'running|degraded'; then break; fi; done; echo ''"
-# TODO: This is hanging on the first "docker run" step
-#	$(call docker_build_and_run,arm64)
+ifeq ($(CGROUPS_V1),1)
+	$(call docker_build_and_run,arm64)
 	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64))
 	$(call docker_test_and_clean)
+else
+	echo "Skipping Amazon Linux 2 test since host system uses cgroup v2"
+endif
 	rm Dockerfile.tmp
 
 amazonlinux2023_x86_64: $(RPM_PACKAGE_X86_64)

--- a/packages/test/Makefile
+++ b/packages/test/Makefile
@@ -180,9 +180,10 @@ amazonlinux2_arm64: $(RPM_PACKAGE_ARM64)
 	echo "FROM amazonlinux:2" > Dockerfile.tmp
 	echo "RUN yum install -y procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
-	$(call docker_build_and_run,arm64)
-	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64))
-	$(call docker_test_and_clean)
+# TODO: This is hanging on the first "docker run" step
+#	$(call docker_build_and_run,arm64)
+#	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64))
+#	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
 amazonlinux2023_x86_64: $(RPM_PACKAGE_X86_64)

--- a/packages/test/Makefile
+++ b/packages/test/Makefile
@@ -174,8 +174,8 @@ amazonlinux2_x86_64: $(RPM_PACKAGE_X86_64)
 	echo "FROM amazonlinux:2" > Dockerfile.tmp
 	echo "RUN yum install -y procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
-	$(DOCKER_CMD) build --no-cache --platform linux/amd64 -f Dockerfile.tmp -t pga-collector-test .
-	$(DOCKER_CMD) run --platform linux/amd64 --name pga-collector-test --privileged=true -e container=docker -d pga-collector-test /sbin/init
+	$(DOCKER_CMD) build --no-cache -f Dockerfile.tmp -t pga-collector-test .
+	$(DOCKER_CMD) run --name pga-collector-test --privileged=true -e container=docker -d pga-collector-test /sbin/init
 	$(DOCKER_CMD) top pga-collector-test
 	$(DOCKER_CMD) exec pga-collector-test bash -c "echo -n 'Waiting for systemd'; while \$$(sleep 1); do echo -n '.'; if (systemctl is-system-running 2> /dev/null || /bin/true) | grep -qE 'running|degraded'; then break; fi; done; echo ''"
 #	$(call docker_build_and_run,amd64)
@@ -187,14 +187,14 @@ amazonlinux2_arm64: $(RPM_PACKAGE_ARM64)
 	echo "FROM amazonlinux:2" > Dockerfile.tmp
 	echo "RUN yum install -y procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
-	$(DOCKER_CMD) build --no-cache --platform linux/arm64 -f Dockerfile.tmp -t pga-collector-test .
-	$(DOCKER_CMD) run --platform linux/arm64 --name pga-collector-test --privileged=true -e container=docker -d pga-collector-test /sbin/init
+	$(DOCKER_CMD) build --no-cache -f Dockerfile.tmp -t pga-collector-test .
+	$(DOCKER_CMD) run --name pga-collector-test --privileged=true -e container=docker -d pga-collector-test /sbin/init
 	$(DOCKER_CMD) top pga-collector-test
 	$(DOCKER_CMD) exec pga-collector-test bash -c "echo -n 'Waiting for systemd'; while \$$(sleep 1); do echo -n '.'; if (systemctl is-system-running 2> /dev/null || /bin/true) | grep -qE 'running|degraded'; then break; fi; done; echo ''"
 # TODO: This is hanging on the first "docker run" step
 #	$(call docker_build_and_run,arm64)
-#	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64))
-#	$(call docker_test_and_clean)
+	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64))
+	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
 amazonlinux2023_x86_64: $(RPM_PACKAGE_X86_64)

--- a/packages/test/Makefile
+++ b/packages/test/Makefile
@@ -174,9 +174,13 @@ amazonlinux2_x86_64: $(RPM_PACKAGE_X86_64)
 	echo "FROM amazonlinux:2" > Dockerfile.tmp
 	echo "RUN yum install -y procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
-	$(call docker_build_and_run,amd64)
-	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_X86_64))
-	$(call docker_test_and_clean)
+	$(DOCKER_CMD) build --no-cache --platform linux/amd64 -f Dockerfile.tmp -t pga-collector-test .
+	$(DOCKER_CMD) run --platform linux/amd64 --name pga-collector-test --privileged=true -e container=docker -d pga-collector-test /sbin/init
+	$(DOCKER_CMD) top pga-collector-test
+	$(DOCKER_CMD) exec pga-collector-test bash -c "echo -n 'Waiting for systemd'; while \$$(sleep 1); do echo -n '.'; if (systemctl is-system-running 2> /dev/null || /bin/true) | grep -qE 'running|degraded'; then break; fi; done; echo ''"
+#	$(call docker_build_and_run,amd64)
+#	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_X86_64))
+#	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
 amazonlinux2_arm64: $(RPM_PACKAGE_ARM64)
@@ -185,6 +189,7 @@ amazonlinux2_arm64: $(RPM_PACKAGE_ARM64)
 	echo "COPY . /root" >> Dockerfile.tmp
 	$(DOCKER_CMD) build --no-cache --platform linux/arm64 -f Dockerfile.tmp -t pga-collector-test .
 	$(DOCKER_CMD) run --platform linux/arm64 --name pga-collector-test --privileged=true -e container=docker -d pga-collector-test /sbin/init
+	$(DOCKER_CMD) top pga-collector-test
 	$(DOCKER_CMD) exec pga-collector-test bash -c "echo -n 'Waiting for systemd'; while \$$(sleep 1); do echo -n '.'; if (systemctl is-system-running 2> /dev/null || /bin/true) | grep -qE 'running|degraded'; then break; fi; done; echo ''"
 # TODO: This is hanging on the first "docker run" step
 #	$(call docker_build_and_run,arm64)

--- a/packages/test/Makefile
+++ b/packages/test/Makefile
@@ -1,11 +1,13 @@
 # Note: This requires variables that are set in the top-level packages Makefile
 
-docker_build_and_run = docker build --no-cache --platform linux/$(1) -f Dockerfile.tmp -t pga-collector-test . && \
-  docker run --platform linux/$(1) --name pga-collector-test --privileged=true -e container=docker -d pga-collector-test /sbin/init && \
-  docker exec pga-collector-test bash -c "echo -n 'Waiting for systemd'; while \$$(sleep 1); do echo -n '.'; if (systemctl is-system-running 2> /dev/null || /bin/true) | grep -qE 'running|degraded'; then break; fi; done; echo ''"
-docker_exec = docker exec pga-collector-test $(1)
-docker_test_and_clean = docker exec pga-collector-test /root/systemd_test.sh && \
-  docker kill pga-collector-test && docker rm pga-collector-test && docker rmi -f pga-collector-test
+DOCKER_CMD=docker
+
+docker_build_and_run = $(DOCKER_CMD) build --no-cache --platform linux/$(1) -f Dockerfile.tmp -t pga-collector-test . && \
+  $(DOCKER_CMD) run --platform linux/$(1) --name pga-collector-test --privileged=true -e container=docker -d pga-collector-test /sbin/init && \
+  $(DOCKER_CMD) exec pga-collector-test bash -c "echo -n 'Waiting for systemd'; while \$$(sleep 1); do echo -n '.'; if (systemctl is-system-running 2> /dev/null || /bin/true) | grep -qE 'running|degraded'; then break; fi; done; echo ''"
+docker_exec = $(DOCKER_CMD) exec pga-collector-test $(1)
+docker_test_and_clean = $(DOCKER_CMD) exec pga-collector-test /root/systemd_test.sh && \
+  $(DOCKER_CMD) kill pga-collector-test && $(DOCKER_CMD) rm pga-collector-test && $(DOCKER_CMD) rmi -f pga-collector-test
 
 # Note: The default list excludes rockylinux9 since there is an open issue with
 # /sbin/init not being present, see https://github.com/rocky-linux/sig-cloud-instance-images/issues/39
@@ -181,9 +183,9 @@ amazonlinux2_arm64: $(RPM_PACKAGE_ARM64)
 	echo "FROM amazonlinux:2" > Dockerfile.tmp
 	echo "RUN yum install -y procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
-	docker build --no-cache --platform linux/$(1) -f Dockerfile.tmp -t pga-collector-test .
-	docker run --platform linux/$(1) --name pga-collector-test --privileged=true -e container=docker -d pga-collector-test /sbin/init
-	docker exec pga-collector-test bash -c "echo -n 'Waiting for systemd'; while \$$(sleep 1); do echo -n '.'; if (systemctl is-system-running 2> /dev/null || /bin/true) | grep -qE 'running|degraded'; then break; fi; done; echo ''"
+	$(DOCKER_CMD) build --no-cache --platform linux/arm64 -f Dockerfile.tmp -t pga-collector-test .
+	$(DOCKER_CMD) run --platform linux/arm64 --name pga-collector-test --privileged=true -e container=docker -d pga-collector-test /sbin/init
+	$(DOCKER_CMD) exec pga-collector-test bash -c "echo -n 'Waiting for systemd'; while \$$(sleep 1); do echo -n '.'; if (systemctl is-system-running 2> /dev/null || /bin/true) | grep -qE 'running|degraded'; then break; fi; done; echo ''"
 # TODO: This is hanging on the first "docker run" step
 #	$(call docker_build_and_run,arm64)
 #	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64))

--- a/packages/test/Makefile
+++ b/packages/test/Makefile
@@ -179,8 +179,8 @@ amazonlinux2_x86_64: $(RPM_PACKAGE_X86_64)
 	$(DOCKER_CMD) top pga-collector-test
 	$(DOCKER_CMD) exec pga-collector-test bash -c "echo -n 'Waiting for systemd'; while \$$(sleep 1); do echo -n '.'; if (systemctl is-system-running 2> /dev/null || /bin/true) | grep -qE 'running|degraded'; then break; fi; done; echo ''"
 #	$(call docker_build_and_run,amd64)
-#	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_X86_64))
-#	$(call docker_test_and_clean)
+	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_X86_64))
+	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
 amazonlinux2_arm64: $(RPM_PACKAGE_ARM64)

--- a/packages/test/Makefile
+++ b/packages/test/Makefile
@@ -131,7 +131,7 @@ rockylinux9_arm64: $(RPM_PACKAGE_ARM64)
 	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
-fedora36_x86_64: $(RPM_PACKAGE_X86_64
+fedora36_x86_64: $(RPM_PACKAGE_X86_64)
 	echo "FROM fedora:36" > Dockerfile.tmp
 	echo "RUN dnf install -y procps systemd" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp

--- a/packages/test/Makefile
+++ b/packages/test/Makefile
@@ -11,7 +11,8 @@ docker_test_and_clean = docker exec pga-collector-test /root/systemd_test.sh && 
 # /sbin/init not being present, see https://github.com/rocky-linux/sig-cloud-instance-images/issues/39
 # Note: The default list also excludes centos7 since it's EOL, we will drop the support near future
 DISTROS_X86_64=rhel8_x86_64 rockylinux8_x86_64 rhel9_x86_64 fedora36_x86_64 fedora37_x86_64 amazonlinux2_x86_64 amazonlinux2023_x86_64 ubuntu-focal_x86_64 ubuntu-jammy_x86_64 ubuntu-noble_x86_64 debian-bullseye_x86_64 debian-bookworm_x86_64
-DISTROS_ARM64=rhel8_arm64 rockylinux8_arm64 rhel9_arm64 fedora36_arm64 fedora37_arm64 amazonlinux2_arm64 amazonlinux2023_arm64 ubuntu-focal_arm64 ubuntu-jammy_arm64 ubuntu-noble_arm64 debian-bullseye_arm64 debian-bookworm_arm64
+#DISTROS_ARM64=rhel8_arm64 rockylinux8_arm64 rhel9_arm64 fedora36_arm64 fedora37_arm64 amazonlinux2_arm64 amazonlinux2023_arm64 ubuntu-focal_arm64 ubuntu-jammy_arm64 ubuntu-noble_arm64 debian-bullseye_arm64 debian-bookworm_arm64
+DISTROS_ARM64=amazonlinux2_arm64 rhel8_arm64 rockylinux8_arm64 rhel9_arm64 fedora36_arm64 fedora37_arm64 amazonlinux2023_arm64 ubuntu-focal_arm64 ubuntu-jammy_arm64 ubuntu-noble_arm64 debian-bullseye_arm64 debian-bookworm_arm64
 
 .PHONY: all $(DISTROS_X86_64) $(DISTROS_ARM64)
 
@@ -180,6 +181,9 @@ amazonlinux2_arm64: $(RPM_PACKAGE_ARM64)
 	echo "FROM amazonlinux:2" > Dockerfile.tmp
 	echo "RUN yum install -y procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
+	docker build --no-cache --platform linux/$(1) -f Dockerfile.tmp -t pga-collector-test .
+	docker run --platform linux/$(1) --name pga-collector-test --privileged=true -e container=docker -d pga-collector-test /sbin/init
+	docker exec pga-collector-test bash -c "echo -n 'Waiting for systemd'; while \$$(sleep 1); do echo -n '.'; if (systemctl is-system-running 2> /dev/null || /bin/true) | grep -qE 'running|degraded'; then break; fi; done; echo ''"
 # TODO: This is hanging on the first "docker run" step
 #	$(call docker_build_and_run,arm64)
 #	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64))

--- a/packages/test/Makefile
+++ b/packages/test/Makefile
@@ -10,11 +10,16 @@ docker_test_and_clean = docker exec pga-collector-test /root/systemd_test.sh && 
 # Note: The default list excludes rockylinux9 since there is an open issue with
 # /sbin/init not being present, see https://github.com/rocky-linux/sig-cloud-instance-images/issues/39
 # Note: The default list also excludes centos7 since it's EOL, we will drop the support near future
-DISTROS=rhel8 rockylinux8 rhel9 fedora36 fedora37 amazonlinux2 amazonlinux2023 ubuntu-focal ubuntu-jammy ubuntu-noble debian-bullseye debian-bookworm
+DISTROS_X86_64=rhel8_x86_64 rockylinux8_x86_64 rhel9_x86_64 fedora36_x86_64 fedora37_x86_64 amazonlinux2_x86_64 amazonlinux2023_x86_64 ubuntu-focal_x86_64 ubuntu-jammy_x86_64 ubuntu-noble_x86_64 debian-bullseye_x86_64 debian-bookworm_x86_64
+DISTROS_ARM64=rhel8_arm64 rockylinux8_arm64 rhel9_arm64 fedora36_arm64 fedora37_arm64 amazonlinux2_arm64 amazonlinux2023_arm64 ubuntu-focal_arm64 ubuntu-jammy_arm64 ubuntu-noble_arm64 debian-bullseye_arm64 debian-bookworm_arm64
 
-.PHONY: all $(DISTROS)
+.PHONY: all $(DISTROS_X86_64) $(DISTROS_ARM64)
 
-all: $(DISTROS) clean
+all: $(DISTROS_X86_64) $(DISTROS_ARM64) clean
+
+x86_64: $(DISTROS_X86_64) clean_x86_64
+
+arm64: $(DISTROS_ARM64) clean_arm64
 
 $(RPM_PACKAGE_X86_64):
 	cp $(TMP_DIR)/$(RPM_PACKAGE_X86_64) .
@@ -28,120 +33,177 @@ $(DEB_PACKAGE_X86_64):
 $(DEB_PACKAGE_ARM64):
 	cp $(TMP_DIR)/$(DEB_PACKAGE_ARM64) .
 
-clean: $(RPM_PACKAGE_X86_64) $(RPM_PACKAGE_ARM64) $(DEB_PACKAGE_X86_64) $(DEB_PACKAGE_ARM64)
+clean_x86_64: $(RPM_PACKAGE_X86_64) $(DEB_PACKAGE_X86_64)
 	rm $(RPM_PACKAGE_X86_64)
-	rm $(RPM_PACKAGE_ARM64)
 	rm $(DEB_PACKAGE_X86_64)
+
+clean_arm64: $(RPM_PACKAGE_ARM64) $(DEB_PACKAGE_ARM64)
+	rm $(RPM_PACKAGE_ARM64)
 	rm $(DEB_PACKAGE_ARM64)
 
-centos7: $(RPM_PACKAGE_X86_64) $(RPM_PACKAGE_ARM64)
+clean: clean_x86_64 clean_arm64
+
+centos7_x86_64: $(RPM_PACKAGE_X86_64)
 	echo "FROM centos:7" > Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,amd64)
 	$(call docker_exec,/bin/bash -c "yum install -y --nogpgcheck /root/$(RPM_PACKAGE_X86_64)")
 	$(call docker_test_and_clean)
+	rm Dockerfile.tmp
+
+centos7_arm64: $(RPM_PACKAGE_ARM64)
+	echo "FROM centos:7" > Dockerfile.tmp
+	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,arm64)
 	$(call docker_exec,/bin/bash -c "yum install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64)")
 	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
-rhel8: $(RPM_PACKAGE_X86_64) $(RPM_PACKAGE_ARM64)
+rhel8_x86_64: $(RPM_PACKAGE_X86_64)
 	echo "FROM redhat/ubi8:latest" > Dockerfile.tmp
 	echo "RUN dnf install -y procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,amd64)
 	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_X86_64))
 	$(call docker_test_and_clean)
+	rm Dockerfile.tmp
+
+rhel8_arm64: $(RPM_PACKAGE_ARM64)
+	echo "FROM redhat/ubi8:latest" > Dockerfile.tmp
+	echo "RUN dnf install -y procps" >> Dockerfile.tmp
+	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,arm64)
 	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64))
 	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
-rockylinux8: $(RPM_PACKAGE_X86_64) $(RPM_PACKAGE_ARM64)
+rockylinux8_x86_64: $(RPM_PACKAGE_X86_64)
 	echo "FROM rockylinux:8" > Dockerfile.tmp
 	echo "RUN dnf install -y procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,amd64)
 	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_X86_64))
 	$(call docker_test_and_clean)
+	rm Dockerfile.tmp
+
+rockylinux8_arm64: $(RPM_PACKAGE_ARM64)
+	echo "FROM rockylinux:8" > Dockerfile.tmp
+	echo "RUN dnf install -y procps" >> Dockerfile.tmp
+	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,arm64)
 	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64))
 	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
-rhel9: $(RPM_PACKAGE_X86_64) $(RPM_PACKAGE_ARM64)
+rhel9_x86_64: $(RPM_PACKAGE_X86_64)
 	echo "FROM redhat/ubi9:latest" > Dockerfile.tmp
 	echo "RUN dnf install -y procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,amd64)
 	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_X86_64))
 	$(call docker_test_and_clean)
+	rm Dockerfile.tmp
+
+rhel9_arm64: $(RPM_PACKAGE_ARM64)
+	echo "FROM redhat/ubi9:latest" > Dockerfile.tmp
+	echo "RUN dnf install -y procps" >> Dockerfile.tmp
+	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,arm64)
 	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64))
 	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
-rockylinux9: $(RPM_PACKAGE_X86_64) $(RPM_PACKAGE_ARM64)
+rockylinux9_x86_64: $(RPM_PACKAGE_X86_64)
 	echo "FROM rockylinux:9" > Dockerfile.tmp
 	echo "RUN dnf install -y procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,amd64)
 	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_X86_64))
 	$(call docker_test_and_clean)
+	rm Dockerfile.tmp
+
+rockylinux9_arm64: $(RPM_PACKAGE_ARM64)
+	echo "FROM rockylinux:9" > Dockerfile.tmp
+	echo "RUN dnf install -y procps" >> Dockerfile.tmp
+	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,arm64)
 	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64))
 	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
-fedora36: $(RPM_PACKAGE_X86_64) $(RPM_PACKAGE_ARM64)
+fedora36_x86_64: $(RPM_PACKAGE_X86_64
 	echo "FROM fedora:36" > Dockerfile.tmp
 	echo "RUN dnf install -y procps systemd" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,amd64)
 	$(call docker_exec,dnf install -y --nogpgcheck /root/$(RPM_PACKAGE_X86_64))
 	$(call docker_test_and_clean)
+	rm Dockerfile.tmp
+
+fedora36_arm64: $(RPM_PACKAGE_ARM64)
+	echo "FROM fedora:36" > Dockerfile.tmp
+	echo "RUN dnf install -y procps systemd" >> Dockerfile.tmp
+	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,arm64)
 	$(call docker_exec,dnf install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64))
 	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
-fedora37: $(RPM_PACKAGE_X86_64) $(RPM_PACKAGE_ARM64)
+fedora37_x86_64: $(RPM_PACKAGE_X86_64)
 	echo "FROM fedora:37" > Dockerfile.tmp
 	echo "RUN dnf install -y procps systemd" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,amd64)
 	$(call docker_exec,dnf install -y --nogpgcheck /root/$(RPM_PACKAGE_X86_64))
 	$(call docker_test_and_clean)
+	rm Dockerfile.tmp
+
+fedora37_arm64: $(RPM_PACKAGE_ARM64)
+	echo "FROM fedora:37" > Dockerfile.tmp
+	echo "RUN dnf install -y procps systemd" >> Dockerfile.tmp
+	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,arm64)
 	$(call docker_exec,dnf install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64))
 	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
-amazonlinux2: $(RPM_PACKAGE_X86_64) $(RPM_PACKAGE_ARM64)
+amazonlinux2_x86_64: $(RPM_PACKAGE_X86_64)
 	echo "FROM amazonlinux:2" > Dockerfile.tmp
 	echo "RUN yum install -y procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,amd64)
 	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_X86_64))
 	$(call docker_test_and_clean)
+	rm Dockerfile.tmp
+
+amazonlinux2_arm64: $(RPM_PACKAGE_ARM64)
+	echo "FROM amazonlinux:2" > Dockerfile.tmp
+	echo "RUN yum install -y procps" >> Dockerfile.tmp
+	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,arm64)
 	$(call docker_exec,yum install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64))
 	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
-amazonlinux2023: $(RPM_PACKAGE_X86_64) $(RPM_PACKAGE_ARM64)
+amazonlinux2023_x86_64: $(RPM_PACKAGE_X86_64)
 	echo "FROM amazonlinux:2023" > Dockerfile.tmp
 	echo "RUN yum install -y procps systemd" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,amd64)
 	$(call docker_exec,dnf install -y --nogpgcheck /root/$(RPM_PACKAGE_X86_64))
 	$(call docker_test_and_clean)
+	rm Dockerfile.tmp
+
+amazonlinux2023_arm64: $(RPM_PACKAGE_ARM64)
+	echo "FROM amazonlinux:2023" > Dockerfile.tmp
+	echo "RUN yum install -y procps systemd" >> Dockerfile.tmp
+	echo "COPY . /root" >> Dockerfile.tmp
 	$(call docker_build_and_run,arm64)
 	$(call docker_exec,dnf install -y --nogpgcheck /root/$(RPM_PACKAGE_ARM64))
 	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
-ubuntu-focal: $(DEB_PACKAGE_X86_64) $(DEB_PACKAGE_ARM64)
+ubuntu-focal_x86_64: $(DEB_PACKAGE_X86_64)
 	echo "FROM ubuntu:focal" > Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
 	echo "RUN apt-get update" >> Dockerfile.tmp
@@ -150,12 +212,20 @@ ubuntu-focal: $(DEB_PACKAGE_X86_64) $(DEB_PACKAGE_ARM64)
 	$(call docker_build_and_run,amd64)
 	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_X86_64))
 	$(call docker_test_and_clean)
+	rm Dockerfile.tmp
+
+ubuntu-focal_arm64: $(DEB_PACKAGE_ARM64)
+	echo "FROM ubuntu:focal" > Dockerfile.tmp
+	echo "COPY . /root" >> Dockerfile.tmp
+	echo "RUN apt-get update" >> Dockerfile.tmp
+	echo "RUN apt-get install systemd-sysv -y" >> Dockerfile.tmp
+	echo "RUN rm /usr/sbin/policy-rc.d" >> Dockerfile.tmp
 	$(call docker_build_and_run,arm64)
 	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_ARM64))
 	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
-ubuntu-jammy: $(DEB_PACKAGE_X86_64) $(DEB_PACKAGE_ARM64)
+ubuntu-jammy_x86_64: $(DEB_PACKAGE_X86_64)
 	echo "FROM ubuntu:jammy" > Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
 	echo "RUN apt-get update" >> Dockerfile.tmp
@@ -164,6 +234,14 @@ ubuntu-jammy: $(DEB_PACKAGE_X86_64) $(DEB_PACKAGE_ARM64)
 	$(call docker_build_and_run,amd64)
 	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_X86_64))
 	$(call docker_test_and_clean)
+	rm Dockerfile.tmp
+
+ubuntu-jammy_arm64: $(DEB_PACKAGE_ARM64)
+	echo "FROM ubuntu:jammy" > Dockerfile.tmp
+	echo "COPY . /root" >> Dockerfile.tmp
+	echo "RUN apt-get update" >> Dockerfile.tmp
+	echo "RUN apt-get install systemd-sysv -y" >> Dockerfile.tmp
+	echo "RUN rm /usr/sbin/policy-rc.d" >> Dockerfile.tmp
 # Don't test ubuntu:jammy on arm64 for now, since for unknown reasons we're seeing the following error
 # in CI only, since GitHub Actions upgraded the Docker engine from 20.10.2 to 23.0.6:
 #   exec /bin/sh: exec format error
@@ -173,7 +251,7 @@ ubuntu-jammy: $(DEB_PACKAGE_X86_64) $(DEB_PACKAGE_ARM64)
 #	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
-ubuntu-noble: $(DEB_PACKAGE_X86_64) $(DEB_PACKAGE_ARM64)
+ubuntu-noble_x86_64: $(DEB_PACKAGE_X86_64)
 	echo "FROM ubuntu:noble" > Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
 	echo "RUN apt-get update" >> Dockerfile.tmp
@@ -182,6 +260,14 @@ ubuntu-noble: $(DEB_PACKAGE_X86_64) $(DEB_PACKAGE_ARM64)
 	$(call docker_build_and_run,amd64)
 	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_X86_64))
 	$(call docker_test_and_clean)
+	rm Dockerfile.tmp
+
+ubuntu-noble_arm64: $(DEB_PACKAGE_ARM64)
+	echo "FROM ubuntu:noble" > Dockerfile.tmp
+	echo "COPY . /root" >> Dockerfile.tmp
+	echo "RUN apt-get update" >> Dockerfile.tmp
+	echo "RUN apt-get install systemd-sysv -y" >> Dockerfile.tmp
+	echo "RUN rm /usr/sbin/policy-rc.d" >> Dockerfile.tmp
 # Don't test ubuntu:noble on arm64 for now, since for unknown reasons we're seeing the following error
 # in CI only, since GitHub Actions upgraded the Docker engine from 20.10.2 to 23.0.6:
 #   exec /bin/sh: exec format error
@@ -191,7 +277,7 @@ ubuntu-noble: $(DEB_PACKAGE_X86_64) $(DEB_PACKAGE_ARM64)
 #	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
-debian-bullseye: $(DEB_PACKAGE_X86_64) $(DEB_PACKAGE_ARM64)
+debian-bullseye_x86_64: $(DEB_PACKAGE_X86_64)
 	echo "FROM debian:bullseye" > Dockerfile.tmp
 	echo "RUN apt-get update -qq && apt-get install -y -q systemd-sysv procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
@@ -199,6 +285,13 @@ debian-bullseye: $(DEB_PACKAGE_X86_64) $(DEB_PACKAGE_ARM64)
 	$(call docker_build_and_run,amd64)
 	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_X86_64))
 	$(call docker_test_and_clean)
+	rm Dockerfile.tmp
+
+debian-bullseye_arm64: $(DEB_PACKAGE_ARM64)
+	echo "FROM debian:bullseye" > Dockerfile.tmp
+	echo "RUN apt-get update -qq && apt-get install -y -q systemd-sysv procps" >> Dockerfile.tmp
+	echo "COPY . /root" >> Dockerfile.tmp
+	echo "RUN rm /usr/sbin/policy-rc.d" >> Dockerfile.tmp
 # Don't test debian:bullseye on arm64 for now, since for unknown reasons we're seeing the following error
 # in CI only, since GitHub Actions upgraded the Docker engine from 20.10.2 to 23.0.6:
 #   exec /bin/sh: exec format error
@@ -208,7 +301,7 @@ debian-bullseye: $(DEB_PACKAGE_X86_64) $(DEB_PACKAGE_ARM64)
 #	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
-debian-bookworm: $(DEB_PACKAGE_X86_64) $(DEB_PACKAGE_ARM64)
+debian-bookworm_x86_64: $(DEB_PACKAGE_X86_64)
 	echo "FROM debian:bookworm" > Dockerfile.tmp
 	echo "RUN apt-get update -qq && apt-get install -y -q systemd-sysv procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
@@ -216,6 +309,13 @@ debian-bookworm: $(DEB_PACKAGE_X86_64) $(DEB_PACKAGE_ARM64)
 	$(call docker_build_and_run,amd64)
 	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_X86_64))
 	$(call docker_test_and_clean)
+	rm Dockerfile.tmp
+
+debian-bookworm_arm64: $(DEB_PACKAGE_ARM64)
+	echo "FROM debian:bookworm" > Dockerfile.tmp
+	echo "RUN apt-get update -qq && apt-get install -y -q systemd-sysv procps" >> Dockerfile.tmp
+	echo "COPY . /root" >> Dockerfile.tmp
+	echo "RUN rm /usr/sbin/policy-rc.d" >> Dockerfile.tmp
 # Don't test debian:bookworm on arm64 for now, since for unknown reasons we're seeing the following error
 # in CI only, since GitHub Actions upgraded the Docker engine from 20.10.2 to 23.0.6:
 #   exec /bin/sh: exec format error

--- a/packages/test/Makefile
+++ b/packages/test/Makefile
@@ -243,10 +243,6 @@ ubuntu-jammy_arm64: $(DEB_PACKAGE_ARM64)
 	echo "RUN apt-get update" >> Dockerfile.tmp
 	echo "RUN apt-get install systemd-sysv -y" >> Dockerfile.tmp
 	echo "RUN rm /usr/sbin/policy-rc.d" >> Dockerfile.tmp
-# Don't test ubuntu:jammy on arm64 for now, since for unknown reasons we're seeing the following error
-# in CI only, since GitHub Actions upgraded the Docker engine from 20.10.2 to 23.0.6:
-#   exec /bin/sh: exec format error
-#
 	$(call docker_build_and_run,arm64)
 	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_ARM64))
 	$(call docker_test_and_clean)
@@ -269,10 +265,6 @@ ubuntu-noble_arm64: $(DEB_PACKAGE_ARM64)
 	echo "RUN apt-get update" >> Dockerfile.tmp
 	echo "RUN apt-get install systemd-sysv -y" >> Dockerfile.tmp
 	echo "RUN rm /usr/sbin/policy-rc.d" >> Dockerfile.tmp
-# Don't test ubuntu:noble on arm64 for now, since for unknown reasons we're seeing the following error
-# in CI only, since GitHub Actions upgraded the Docker engine from 20.10.2 to 23.0.6:
-#   exec /bin/sh: exec format error
-#
 	$(call docker_build_and_run,arm64)
 	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_ARM64))
 	$(call docker_test_and_clean)
@@ -293,10 +285,6 @@ debian-bullseye_arm64: $(DEB_PACKAGE_ARM64)
 	echo "RUN apt-get update -qq && apt-get install -y -q systemd-sysv procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
 	echo "RUN rm /usr/sbin/policy-rc.d" >> Dockerfile.tmp
-# Don't test debian:bullseye on arm64 for now, since for unknown reasons we're seeing the following error
-# in CI only, since GitHub Actions upgraded the Docker engine from 20.10.2 to 23.0.6:
-#   exec /bin/sh: exec format error
-#
 	$(call docker_build_and_run,arm64)
 	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_ARM64))
 	$(call docker_test_and_clean)
@@ -317,10 +305,6 @@ debian-bookworm_arm64: $(DEB_PACKAGE_ARM64)
 	echo "RUN apt-get update -qq && apt-get install -y -q systemd-sysv procps" >> Dockerfile.tmp
 	echo "COPY . /root" >> Dockerfile.tmp
 	echo "RUN rm /usr/sbin/policy-rc.d" >> Dockerfile.tmp
-# Don't test debian:bookworm on arm64 for now, since for unknown reasons we're seeing the following error
-# in CI only, since GitHub Actions upgraded the Docker engine from 20.10.2 to 23.0.6:
-#   exec /bin/sh: exec format error
-#
 	$(call docker_build_and_run,arm64)
 	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_ARM64))
 	$(call docker_test_and_clean)

--- a/packages/test/Makefile
+++ b/packages/test/Makefile
@@ -247,9 +247,9 @@ ubuntu-jammy_arm64: $(DEB_PACKAGE_ARM64)
 # in CI only, since GitHub Actions upgraded the Docker engine from 20.10.2 to 23.0.6:
 #   exec /bin/sh: exec format error
 #
-#	$(call docker_build_and_run,arm64)
-#	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_ARM64))
-#	$(call docker_test_and_clean)
+	$(call docker_build_and_run,arm64)
+	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_ARM64))
+	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
 ubuntu-noble_x86_64: $(DEB_PACKAGE_X86_64)
@@ -273,9 +273,9 @@ ubuntu-noble_arm64: $(DEB_PACKAGE_ARM64)
 # in CI only, since GitHub Actions upgraded the Docker engine from 20.10.2 to 23.0.6:
 #   exec /bin/sh: exec format error
 #
-#	$(call docker_build_and_run,arm64)
-#	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_ARM64))
-#	$(call docker_test_and_clean)
+	$(call docker_build_and_run,arm64)
+	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_ARM64))
+	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
 debian-bullseye_x86_64: $(DEB_PACKAGE_X86_64)
@@ -297,9 +297,9 @@ debian-bullseye_arm64: $(DEB_PACKAGE_ARM64)
 # in CI only, since GitHub Actions upgraded the Docker engine from 20.10.2 to 23.0.6:
 #   exec /bin/sh: exec format error
 #
-#	$(call docker_build_and_run,arm64)
-#	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_ARM64))
-#	$(call docker_test_and_clean)
+	$(call docker_build_and_run,arm64)
+	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_ARM64))
+	$(call docker_test_and_clean)
 	rm Dockerfile.tmp
 
 debian-bookworm_x86_64: $(DEB_PACKAGE_X86_64)
@@ -321,7 +321,7 @@ debian-bookworm_arm64: $(DEB_PACKAGE_ARM64)
 # in CI only, since GitHub Actions upgraded the Docker engine from 20.10.2 to 23.0.6:
 #   exec /bin/sh: exec format error
 #
-#	$(call docker_build_and_run,arm64)
-#	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_ARM64))
-#	$(call docker_test_and_clean)
+	$(call docker_build_and_run,arm64)
+	$(call docker_exec,dpkg -i /root/$(DEB_PACKAGE_ARM64))
+	$(call docker_test_and_clean)
 	rm Dockerfile.tmp


### PR DESCRIPTION
This splits the package building and testing logic into x86_64 and arm64 targets, and allows triggering either both, or just one of them.

It also changes the GitHub actions for package testing and release to no longer use QEMU emulation (which recently started failing with segfaults), and instead uses separate runners for each architecture.

In passing remove stale "DOCKER_BUILDKIT=1" settings from package release action, which should no longer be needed since GH actions updated their Docker version.