### PR TITLE
Tweak explain_analyze helper invocation to avoid pg_hint_plan limitation

### DIFF
--- a/input/postgres/explain_analyze.go
+++ b/input/postgres/explain_analyze.go
@@ -52,7 +52,7 @@ func runExplainAnalyze(ctx context.Context, db *sql.DB, query string, parameters
 	}
 	defer tx.Rollback()
 
-	err = tx.QueryRowContext(ctx, marker+"SELECT pganalyze.explain_analyze($1, $2, $3, $4)", marker+query, pq.Array(parameters), pq.Array(parameterTypes), pq.Array(analyzeFlags)).Scan(&explainOutput)
+	err = tx.QueryRowContext(ctx, marker+"SELECT pganalyze.explain_analyze($1, $2, $3, $4)", query, pq.Array(parameters), pq.Array(parameterTypes), pq.Array(analyzeFlags)).Scan(&explainOutput)
 
 	return
 }


### PR DESCRIPTION
For the collector-based Query Tuning workflow, the collector receives
a query text from the pganalyze server and runs it on the target
database. This query text may include pg_hint_plan hints, as users use
workbooks to optimize queries.

However, it looks like pg_hint_plan ignores hints if they are not in
the _first_ comment in a query. The collector prepends a query marker
as a separate comment, and this causes pg_hint_plan to ignore any
hints specified in the query.

Avoid passing our query marker, since we're already prepending it to
the top-level explain_analyze invocation, and nested queries will not
show up in pg_stat_activity anyway.
