### PR TITLE
GH release action: Fix "packages" name conflict

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,7 @@ on:
 
 jobs:
   build:
-    # Use older Ubuntu release to avoid building with a too new glibc, which will cause
-    # errors on older distributions, if anyone uses the generated binary directly.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions: {}
     # ensure we don't release on create events for branches (only tags)
     if: ${{ startsWith( github.ref, 'refs/tags' ) }}
@@ -46,7 +44,7 @@ jobs:
         path: pganalyze-collector-linux-amd64
 
   build_arm:
-    runs-on: ubicloud-standard-2-arm
+    runs-on: ubuntu-22.04-arm
     permissions: {}
     # ensure we don't release on create events for branches (only tags)
     if: ${{ startsWith( github.ref, 'refs/tags' ) }}
@@ -56,7 +54,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: 1.21
+        go-version: 1.23
       id: go
 
     - name: Set up protoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
     - name: Upload packages as artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: packages
+        name: packages_x86_64
         path: |
           packages/tmp/pganalyze-collector-*.x86_64.rpm
           packages/tmp/pganalyze-collector_*_amd64.deb
@@ -138,7 +138,7 @@ jobs:
     - name: Upload packages as artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: packages
+        name: packages_arm64
         path: |
           packages/tmp/pganalyze-collector-*.aarch64.rpm
           packages/tmp/pganalyze-collector_*_arm64.deb
@@ -186,10 +186,15 @@ jobs:
       with:
         name: pganalyze-collector-linux-arm64
 
-    - name: Download build packages
+    - name: Download build packages (x86_64)
       uses: actions/download-artifact@v4
       with:
-        name: packages
+        name: packages_x86_64
+
+    - name: Download build packages (arm64)
+      uses: actions/download-artifact@v4
+      with:
+        name: packages_arm64
 
     - name: Download helm package
       uses: actions/download-artifact@v4


### PR DESCRIPTION
During the release process we group together the created packages as an artifact, to then upload them individually to the GitHub release entry.

Previously this was able to use a single "packages" zip file for both x86_64 and arm64 packages, but we now need to split this since we split the actions.