### PR TITLE
Miscellaneous refactors and cleanup

### DIFF
--- a/input/collector.go
+++ b/input/collector.go
@@ -42,11 +42,11 @@ func getCollectorStats() state.CollectorStats {
 	}
 }
 
-func getCollectorPlatform(server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) state.CollectorPlatform {
+func getCollectorPlatform(server *state.Server, opts state.CollectionOpts, logger *util.Logger) state.CollectorPlatform {
 	hostInfo, err := host.Info()
 	if err != nil {
 		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectTelemetry, "could not get collector host information: %s", err)
-		if globalCollectionOpts.TestRun {
+		if opts.TestRun {
 			logger.PrintVerbose("Could not get collector host information: %s", err)
 		}
 		return state.CollectorPlatform{}
@@ -58,7 +58,7 @@ func getCollectorPlatform(server *state.Server, globalCollectionOpts state.Colle
 		virtSystem = hostInfo.VirtualizationSystem
 	}
 	return state.CollectorPlatform{
-		StartedAt:            globalCollectionOpts.StartedAt,
+		StartedAt:            opts.StartedAt,
 		Architecture:         runtime.GOARCH,
 		Hostname:             hostInfo.Hostname,
 		OperatingSystem:      hostInfo.OS,

--- a/input/postgres/buffer_cache.go
+++ b/input/postgres/buffer_cache.go
@@ -31,10 +31,10 @@ WHERE reldatabase IS NOT NULL -- filters out unused pages
 GROUP BY 1, 2
 `
 
-func GetBufferCache(ctx context.Context, c *Collection, server *state.Server, globalCollectionOpts state.CollectionOpts, channel chan state.BufferCache) {
+func GetBufferCache(ctx context.Context, c *Collection, server *state.Server, opts state.CollectionOpts, channel chan state.BufferCache) {
 	start := time.Now()
 	bufferCache := make(state.BufferCache)
-	db, err := EstablishConnection(ctx, server, c.Logger, globalCollectionOpts, "")
+	db, err := EstablishConnection(ctx, server, c.Logger, opts, "")
 	if err != nil {
 		c.Logger.PrintError("GetBufferCache: %s", err)
 		channel <- bufferCache
@@ -52,7 +52,7 @@ func GetBufferCache(ctx context.Context, c *Collection, server *state.Server, gl
 	sizeGB := 0
 	db.QueryRowContext(ctx, QueryMarkerSQL+bufferCacheSizeSQL).Scan(&sizeGB)
 	if sizeGB > server.Config.MaxBufferCacheMonitoringGB {
-		if globalCollectionOpts.TestRun {
+		if opts.TestRun {
 			c.Logger.PrintWarning("GetBufferCache: skipping collection. To enable, set max_buffer_cache_monitoring_gb to a value over %d", sizeGB)
 		}
 		channel <- bufferCache

--- a/input/postgres/databases.go
+++ b/input/postgres/databases.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/pganalyze/collector/state"
 )
@@ -31,7 +30,7 @@ FROM pg_catalog.pg_database d
 	ON d.oid = sd.datid`
 
 func GetDatabases(ctx context.Context, db *sql.DB) ([]state.PostgresDatabase, state.PostgresDatabaseStatsMap, error) {
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+fmt.Sprintf(databasesSQL))
+	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+databasesSQL)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/input/postgres/establish_connection.go
+++ b/input/postgres/establish_connection.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -66,7 +67,7 @@ func connectToDb(ctx context.Context, config config.ServerConfig, logger *util.L
 			}
 		} else if config.SystemType == "google_cloudsql" {
 			if config.GcpProjectID == "" || config.GcpRegion == "" || config.GcpCloudSQLInstanceID == "" {
-				return nil, fmt.Errorf("To use IAM auth with Google Cloud SQL, you must specify project ID, region, and instance ID")
+				return nil, errors.New("To use IAM auth with Google Cloud SQL, you must specify project ID, region, and instance ID")
 			}
 			hostOverride = strings.Join([]string{config.GcpProjectID, config.GcpRegion, config.GcpCloudSQLInstanceID}, ":")
 			// When using cloud-sql-go-connector, this needs to be set as disable
@@ -74,7 +75,7 @@ func connectToDb(ctx context.Context, config config.ServerConfig, logger *util.L
 			sslmodeOverride = "disable"
 			driverName = "cloudsql-postgres"
 		} else {
-			return nil, fmt.Errorf("IAM auth is only supported for Amazon RDS, Aurora, and Google Cloud SQL - turn off IAM auth setting to use password-based authentication")
+			return nil, errors.New("IAM auth is only supported for Amazon RDS, Aurora, and Google Cloud SQL - turn off IAM auth setting to use password-based authentication")
 		}
 	}
 

--- a/input/postgres/establish_connection.go
+++ b/input/postgres/establish_connection.go
@@ -85,8 +85,6 @@ func connectToDb(ctx context.Context, config config.ServerConfig, logger *util.L
 	}
 	connectString += " application_name=" + globalCollectionOpts.CollectorApplicationName
 
-	// logger.PrintVerbose("sql.Open(\"postgres\", \"%s\")", connectString)
-
 	db, err = sql.Open(driverName, connectString)
 	if err != nil {
 		return nil, err

--- a/input/postgres/helpers.go
+++ b/input/postgres/helpers.go
@@ -11,19 +11,6 @@ import (
 	"github.com/pganalyze/collector/state"
 )
 
-func unpackPostgresInt32Array(input null.String) (result []int32) {
-	if !input.Valid {
-		return
-	}
-
-	for _, cstr := range strings.Split(strings.Trim(input.String, "{}"), ",") {
-		cint, _ := strconv.ParseInt(cstr, 10, 32)
-		result = append(result, int32(cint))
-	}
-
-	return
-}
-
 func unpackPostgresOidArray(input null.String) (result []state.Oid) {
 	if !input.Valid {
 		return

--- a/input/postgres/log_pg_read_file.go
+++ b/input/postgres/log_pg_read_file.go
@@ -33,7 +33,7 @@ SELECT (SELECT size FROM pg_catalog.pg_ls_logdir() WHERE name = $1),
 `
 
 // LogPgReadFile - Gets log files using the pg_read_file function
-func LogPgReadFile(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (state.PersistedLogState, []state.LogFile, []state.PostgresQuerySample, error) {
+func LogPgReadFile(ctx context.Context, server *state.Server, opts state.CollectionOpts, logger *util.Logger) (state.PersistedLogState, []state.LogFile, []state.PostgresQuerySample, error) {
 	var err error
 	var psl state.PersistedLogState = server.LogPrevState
 	var logFiles []state.LogFile
@@ -41,14 +41,14 @@ func LogPgReadFile(ctx context.Context, server *state.Server, globalCollectionOp
 
 	linesNewerThan := time.Now().Add(-2 * time.Minute)
 
-	db, err := EstablishConnection(ctx, server, logger, globalCollectionOpts, "")
+	db, err := EstablishConnection(ctx, server, logger, opts, "")
 	if err != nil {
 		logger.PrintWarning("Could not connect to fetch logs: %s", err)
 		return server.LogPrevState, nil, nil, err
 	}
 	defer db.Close()
 
-	h, err := NewCollection(ctx, logger, server, globalCollectionOpts, db)
+	h, err := NewCollection(ctx, logger, server, opts, db)
 	if err != nil {
 		logger.PrintError("Error setting up collection helper: %s", err)
 		return server.LogPrevState, nil, nil, err

--- a/input/system/google_cloudsql/logs.go
+++ b/input/system/google_cloudsql/logs.go
@@ -138,7 +138,7 @@ func setupPubSubSubscriber(ctx context.Context, wg *sync.WaitGroup, logger *util
 	return nil
 }
 
-func SetupLogSubscriber(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.CollectionOpts, logger *util.Logger, servers []*state.Server, parsedLogStream chan state.ParsedLogStreamItem) error {
+func SetupLogSubscriber(ctx context.Context, wg *sync.WaitGroup, opts state.CollectionOpts, logger *util.Logger, servers []*state.Server, parsedLogStream chan state.ParsedLogStreamItem) error {
 	gcpLogStream := make(chan LogStreamItem, state.LogStreamBufferLen)
 	setupLogTransformer(ctx, wg, servers, gcpLogStream, parsedLogStream, logger)
 
@@ -154,7 +154,7 @@ func SetupLogSubscriber(ctx context.Context, wg *sync.WaitGroup, globalCollectio
 			}
 			err := setupPubSubSubscriber(ctx, wg, prefixedLogger, server.Config, gcpLogStream)
 			if err != nil {
-				if globalCollectionOpts.TestRun {
+				if opts.TestRun {
 					return err
 				}
 

--- a/input/system/heroku/http_handler.go
+++ b/input/system/heroku/http_handler.go
@@ -11,9 +11,9 @@ import (
 	"github.com/pganalyze/collector/util"
 )
 
-func SetupHttpHandlerLogs(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.CollectionOpts, logger *util.Logger, servers []*state.Server, parsedLogStream chan state.ParsedLogStreamItem) {
+func SetupHttpHandlerLogs(ctx context.Context, wg *sync.WaitGroup, opts state.CollectionOpts, logger *util.Logger, servers []*state.Server, parsedLogStream chan state.ParsedLogStreamItem) {
 	herokuLogStream := make(chan HttpSyslogMessage, state.LogStreamBufferLen)
-	setupLogTransformer(ctx, wg, servers, herokuLogStream, parsedLogStream, globalCollectionOpts, logger)
+	setupLogTransformer(ctx, wg, servers, herokuLogStream, parsedLogStream, opts, logger)
 
 	go func() {
 		http.HandleFunc("/", util.HttpRedirectToApp)

--- a/input/system/system.go
+++ b/input/system/system.go
@@ -15,14 +15,14 @@ import (
 )
 
 // DownloadLogFiles - Downloads all new log files for the remote system and returns them
-func DownloadLogFiles(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (psl state.PersistedLogState, files []state.LogFile, querySamples []state.PostgresQuerySample, err error) {
+func DownloadLogFiles(ctx context.Context, server *state.Server, opts state.CollectionOpts, logger *util.Logger) (psl state.PersistedLogState, files []state.LogFile, querySamples []state.PostgresQuerySample, err error) {
 	if server.Config.SystemType == "amazon_rds" {
 		psl, files, querySamples, err = rds.DownloadLogFiles(ctx, server, logger)
 		if err != nil {
 			return
 		}
 	} else if server.Config.LogPgReadFile {
-		psl, files, querySamples, err = postgres.LogPgReadFile(ctx, server, globalCollectionOpts, logger)
+		psl, files, querySamples, err = postgres.LogPgReadFile(ctx, server, opts, logger)
 		if err != nil {
 			return
 		}
@@ -34,7 +34,7 @@ func DownloadLogFiles(ctx context.Context, server *state.Server, globalCollectio
 }
 
 // GetSystemState - Retrieves a system snapshot for this system and returns it
-func GetSystemState(ctx context.Context, server *state.Server, logger *util.Logger, globalCollectionOpts state.CollectionOpts) (system state.SystemState) {
+func GetSystemState(ctx context.Context, server *state.Server, logger *util.Logger, opts state.CollectionOpts) (system state.SystemState) {
 	config := server.Config
 	dbHost := config.GetDbHost()
 	if config.SystemType == "amazon_rds" {
@@ -57,7 +57,7 @@ func GetSystemState(ctx context.Context, server *state.Server, logger *util.Logg
 	} else if dbHost == "" || dbHost == "localhost" || dbHost == "127.0.0.1" || config.AlwaysCollectSystemData {
 		system = selfhosted.GetSystemState(server, logger)
 	} else {
-		if globalCollectionOpts.TestRun {
+		if opts.TestRun {
 			// Detected as self hosted, but not collecting system state as we
 			// didn't detect the collector is running on the same instance as
 			// the database server.

--- a/input/system/tembo/logs.go
+++ b/input/system/tembo/logs.go
@@ -82,17 +82,17 @@ func connectWebsocket(ctx context.Context, logger *util.Logger, server *state.Se
 }
 
 // SetupWebsocketHandlerLogs - Sets up a websocket handler for Tembo logs
-func SetupWebsocketHandlerLogs(ctx context.Context, wg *sync.WaitGroup, logger *util.Logger, servers []*state.Server, globalCollectionOpts state.CollectionOpts, parsedLogStream chan state.ParsedLogStreamItem) {
+func SetupWebsocketHandlerLogs(ctx context.Context, wg *sync.WaitGroup, logger *util.Logger, servers []*state.Server, opts state.CollectionOpts, parsedLogStream chan state.ParsedLogStreamItem) {
 	for _, server := range servers {
 		prefixedLogger := logger.WithPrefix(server.Config.SectionName)
 
 		if server.Config.TemboLogsAPIURL != "" {
-			setupWebsocketForServer(ctx, wg, globalCollectionOpts, prefixedLogger, server, parsedLogStream)
+			setupWebsocketForServer(ctx, wg, opts, prefixedLogger, server, parsedLogStream)
 		}
 	}
 }
 
-func setupWebsocketForServer(ctx context.Context, wg *sync.WaitGroup, globalCollectionOpts state.CollectionOpts, logger *util.Logger, server *state.Server, parsedLogStream chan state.ParsedLogStreamItem) {
+func setupWebsocketForServer(ctx context.Context, wg *sync.WaitGroup, opts state.CollectionOpts, logger *util.Logger, server *state.Server, parsedLogStream chan state.ParsedLogStreamItem) {
 	// Only ingest log lines that were written in the last minute before startup
 	linesNewerThan := time.Now().Add(-1 * time.Minute)
 	logParser := server.GetLogParser()
@@ -109,7 +109,7 @@ func setupWebsocketForServer(ctx context.Context, wg *sync.WaitGroup, globalColl
 			if conn == nil {
 				conn, cancelConn, err = connectWebsocket(ctx, logger, server)
 				if err != nil {
-					if globalCollectionOpts.TestRun {
+					if opts.TestRun {
 						logger.PrintError("Error connecting to Tembo logs websocket: %s", err)
 						return
 					}

--- a/logs/querysample/normalize_test.go
+++ b/logs/querysample/normalize_test.go
@@ -3,7 +3,7 @@ package querysample_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"testing"
 
@@ -156,7 +156,7 @@ func TestAutoExplainQuerySample(t *testing.T) {
 	jsonKeyValueSeparatorRegexp := regexp.MustCompile(`": `)
 
 	for _, pair := range autoExplainQuerySampleTests {
-		explainIn, err := ioutil.ReadFile("testdata/" + pair.testName + ".in.json")
+		explainIn, err := os.ReadFile("testdata/" + pair.testName + ".in.json")
 		if err != nil {
 			t.Fatalf("Error loading input file: %s", err)
 		}
@@ -171,7 +171,7 @@ func TestAutoExplainQuerySample(t *testing.T) {
 						t.Fatalf("For %v (%s): Error normalizing: %s", pair.testName, variant, err)
 					}
 				}
-				explainOut, err := ioutil.ReadFile("testdata/" + pair.testName + ".out_" + variant + ".json")
+				explainOut, err := os.ReadFile("testdata/" + pair.testName + ".out_" + variant + ".json")
 				if err != nil {
 					t.Fatalf("For %v (%s): Error loading output file: %s", pair.testName, variant, err)
 				}

--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func main() {
 		testRun = true
 	}
 
-	globalCollectionOpts := state.CollectionOpts{
+	opts := state.CollectionOpts{
 		StartedAt:                        time.Now(),
 		SubmitCollectedData:              !benchmark && true,
 		TestRun:                          testRun,
@@ -177,15 +177,15 @@ func main() {
 	}
 
 	if dryRun || dryRunLogs {
-		globalCollectionOpts.SubmitCollectedData = false
-		globalCollectionOpts.TestRun = true
+		opts.SubmitCollectedData = false
+		opts.TestRun = true
 	}
 
-	if globalCollectionOpts.TestRun || globalCollectionOpts.TestRunLogs ||
-		globalCollectionOpts.DebugLogs || globalCollectionOpts.DiscoverLogLocation {
-		globalCollectionOpts.CollectorApplicationName = "pganalyze_test_run"
+	if opts.TestRun || opts.TestRunLogs ||
+		opts.DebugLogs || opts.DiscoverLogLocation {
+		opts.CollectorApplicationName = "pganalyze_test_run"
 	} else {
-		globalCollectionOpts.CollectorApplicationName = "pganalyze_collector"
+		opts.CollectorApplicationName = "pganalyze_collector"
 	}
 
 	if analyzeLogfile != "" {
@@ -276,7 +276,7 @@ ReadConfigAndRun:
 	ctx, cancel := context.WithCancel(context.Background())
 	wg := sync.WaitGroup{}
 	exitCode := 0
-	keepRunning, testRunSuccess, writeStateFile, shutdown := runner.Run(ctx, &wg, globalCollectionOpts, logger, configFilename)
+	keepRunning, testRunSuccess, writeStateFile, shutdown := runner.Run(ctx, &wg, opts, logger, configFilename)
 
 	if keepRunning {
 		// Block here until we get any of the registered signals

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -190,7 +189,7 @@ func main() {
 	}
 
 	if analyzeLogfile != "" {
-		contentBytes, err := ioutil.ReadFile(analyzeLogfile)
+		contentBytes, err := os.ReadFile(analyzeLogfile)
 		if err != nil {
 			fmt.Printf("ERROR: %s\n", err)
 			return
@@ -231,7 +230,7 @@ func main() {
 	}
 
 	if filterLogFile != "" {
-		contentBytes, err := ioutil.ReadFile(filterLogFile)
+		contentBytes, err := os.ReadFile(filterLogFile)
 		if err != nil {
 			fmt.Printf("ERROR: %s\n", err)
 			return
@@ -249,7 +248,7 @@ func main() {
 
 	if pidFilename != "" {
 		pid := os.Getpid()
-		err := ioutil.WriteFile(pidFilename, []byte(strconv.Itoa(pid)), 0644)
+		err := os.WriteFile(pidFilename, []byte(strconv.Itoa(pid)), 0644)
 		if err != nil {
 			logger.PrintError("Could not write pidfile to \"%s\" as requested, exiting.", pidFilename)
 			return

--- a/output/grant.go
+++ b/output/grant.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pganalyze/collector/util"
 )
 
-func GetGrant(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (state.Grant, error) {
+func GetGrant(ctx context.Context, server *state.Server, opts state.CollectionOpts, logger *util.Logger) (state.Grant, error) {
 	grant := state.Grant{Config: pganalyze_collector.ServerMessage_Config{Features: &pganalyze_collector.ServerMessage_Features{}}}
 	req, err := http.NewRequestWithContext(ctx, "GET", server.Config.APIBaseURL+"/v2/snapshots/grant", nil)
 	if err != nil {

--- a/runner/emit_test_lines.go
+++ b/runner/emit_test_lines.go
@@ -10,8 +10,8 @@ import (
 	"github.com/pganalyze/collector/util"
 )
 
-func EmitTestLogMsg(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) error {
-	db, err := postgres.EstablishConnection(ctx, server, logger, globalCollectionOpts, "")
+func EmitTestLogMsg(ctx context.Context, server *state.Server, opts state.CollectionOpts, logger *util.Logger) error {
+	db, err := postgres.EstablishConnection(ctx, server, logger, opts, "")
 	if err != nil {
 		return err
 	}
@@ -21,8 +21,8 @@ func EmitTestLogMsg(ctx context.Context, server *state.Server, globalCollectionO
 	return err
 }
 
-func EmitTestExplain(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) error {
-	db, err := postgres.EstablishConnection(ctx, server, logger, globalCollectionOpts, "")
+func EmitTestExplain(ctx context.Context, server *state.Server, opts state.CollectionOpts, logger *util.Logger) error {
+	db, err := postgres.EstablishConnection(ctx, server, logger, opts, "")
 	if err != nil {
 		return err
 	}

--- a/runner/full_1min.go
+++ b/runner/full_1min.go
@@ -12,14 +12,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-func gather1minStatsForServer(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (state.PersistedState, error) {
+func gather1minStatsForServer(ctx context.Context, server *state.Server, opts state.CollectionOpts, logger *util.Logger) (state.PersistedState, error) {
 	var err error
 	var connection *sql.DB
 
 	newState := server.PrevState
 	collectedAt := time.Now()
 
-	connection, err = postgres.EstablishConnection(ctx, server, logger, globalCollectionOpts, "")
+	connection, err = postgres.EstablishConnection(ctx, server, logger, opts, "")
 	if err != nil {
 		return newState, errors.Wrap(err, "failed to connect to database")
 	}
@@ -36,7 +36,7 @@ func gather1minStatsForServer(ctx context.Context, server *state.Server, globalC
 		}
 	}
 
-	c, err := postgres.NewCollection(ctx, logger, server, globalCollectionOpts, connection)
+	c, err := postgres.NewCollection(ctx, logger, server, opts, connection)
 	if err != nil {
 		return newState, err
 	}
@@ -89,7 +89,7 @@ func gather1minStatsForServer(ctx context.Context, server *state.Server, globalC
 	return newState, nil
 }
 
-func Gather1minStatsFromAllServers(ctx context.Context, servers []*state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) {
+func Gather1minStatsFromAllServers(ctx context.Context, servers []*state.Server, opts state.CollectionOpts, logger *util.Logger) {
 	var wg sync.WaitGroup
 
 	for idx := range servers {
@@ -102,7 +102,7 @@ func Gather1minStatsFromAllServers(ctx context.Context, servers []*state.Server,
 			prefixedLogger := logger.WithPrefixAndRememberErrors(server.Config.SectionName)
 
 			server.StateMutex.Lock()
-			newState, err := gather1minStatsForServer(ctx, server, globalCollectionOpts, prefixedLogger)
+			newState, err := gather1minStatsForServer(ctx, server, opts, prefixedLogger)
 
 			if err != nil {
 				server.StateMutex.Unlock()

--- a/runner/generate_helper_sql.go
+++ b/runner/generate_helper_sql.go
@@ -38,8 +38,8 @@ $$
   WHERE schemaname NOT IN ('pg_catalog', 'information_schema') AND tablename <> 'pg_subscription';
 $$ LANGUAGE sql VOLATILE SECURITY DEFINER;`}
 
-func GenerateStatsHelperSql(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (string, error) {
-	db, err := postgres.EstablishConnection(ctx, server, logger, globalCollectionOpts, "")
+func GenerateStatsHelperSql(ctx context.Context, server *state.Server, opts state.CollectionOpts, logger *util.Logger) (string, error) {
+	db, err := postgres.EstablishConnection(ctx, server, logger, opts, "")
 	if err != nil {
 		return "", err
 	}
@@ -64,8 +64,8 @@ func GenerateStatsHelperSql(ctx context.Context, server *state.Server, globalCol
 	return output.String(), nil
 }
 
-func GenerateExplainAnalyzeHelperSql(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) (string, error) {
-	db, err := postgres.EstablishConnection(ctx, server, logger, globalCollectionOpts, "")
+func GenerateExplainAnalyzeHelperSql(ctx context.Context, server *state.Server, opts state.CollectionOpts, logger *util.Logger) (string, error) {
+	db, err := postgres.EstablishConnection(ctx, server, logger, opts, "")
 	if err != nil {
 		return "", err
 	}
@@ -81,11 +81,11 @@ func GenerateExplainAnalyzeHelperSql(ctx context.Context, server *state.Server, 
 		output.WriteString(fmt.Sprintf("\\c %s\n", pq.QuoteIdentifier(dbName)))
 		output.WriteString("CREATE SCHEMA IF NOT EXISTS pganalyze;\n")
 		output.WriteString(fmt.Sprintf("GRANT USAGE ON SCHEMA pganalyze TO %s;\n", pq.QuoteIdentifier(server.Config.GetDbUsername())))
-		output.WriteString(fmt.Sprintf("GRANT CREATE ON SCHEMA pganalyze TO %s;\n", pq.QuoteIdentifier(globalCollectionOpts.GenerateExplainAnalyzeHelperRole)))
-		output.WriteString(fmt.Sprintf("SET ROLE %s;\n", pq.QuoteIdentifier(globalCollectionOpts.GenerateExplainAnalyzeHelperRole)))
+		output.WriteString(fmt.Sprintf("GRANT CREATE ON SCHEMA pganalyze TO %s;\n", pq.QuoteIdentifier(opts.GenerateExplainAnalyzeHelperRole)))
+		output.WriteString(fmt.Sprintf("SET ROLE %s;\n", pq.QuoteIdentifier(opts.GenerateExplainAnalyzeHelperRole)))
 		output.WriteString(util.ExplainAnalyzeHelper + "\n")
 		output.WriteString("RESET ROLE;\n")
-		output.WriteString(fmt.Sprintf("REVOKE CREATE ON SCHEMA pganalyze FROM %s;\n", pq.QuoteIdentifier(globalCollectionOpts.GenerateExplainAnalyzeHelperRole)))
+		output.WriteString(fmt.Sprintf("REVOKE CREATE ON SCHEMA pganalyze FROM %s;\n", pq.QuoteIdentifier(opts.GenerateExplainAnalyzeHelperRole)))
 		output.WriteString("\n")
 	}
 

--- a/runner/websocket.go
+++ b/runner/websocket.go
@@ -20,8 +20,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-func SetupWebsocketForAllServers(ctx context.Context, servers []*state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) {
-	if globalCollectionOpts.ForceEmptyGrant {
+func SetupWebsocketForAllServers(ctx context.Context, servers []*state.Server, opts state.CollectionOpts, logger *util.Logger) {
+	if opts.ForceEmptyGrant {
 		return
 	}
 	for idx := range servers {
@@ -33,7 +33,7 @@ func SetupWebsocketForAllServers(ctx context.Context, servers []*state.Server, g
 					return
 				default:
 					if server.WebSocket.Load() == nil {
-						connect(ctx, server, globalCollectionOpts, logger)
+						connect(ctx, server, opts, logger)
 					}
 					time.Sleep(3 * 60 * time.Second) // Delay between reconnect attempts
 				}
@@ -42,7 +42,7 @@ func SetupWebsocketForAllServers(ctx context.Context, servers []*state.Server, g
 	}
 }
 
-func connect(ctx context.Context, server *state.Server, globalCollectionOpts state.CollectionOpts, logger *util.Logger) {
+func connect(ctx context.Context, server *state.Server, opts state.CollectionOpts, logger *util.Logger) {
 	connCtx, cancelConn := context.WithCancel(ctx)
 	proxyConfig := httpproxy.Config{
 		HTTPProxy:  server.Config.HTTPProxy,
@@ -74,7 +74,7 @@ func connect(ctx context.Context, server *state.Server, globalCollectionOpts sta
 	headers["Pganalyze-System-Id-Fallback"] = []string{server.Config.SystemIDFallback}
 	headers["Pganalyze-System-Type-Fallback"] = []string{server.Config.SystemTypeFallback}
 	headers["Pganalyze-System-Scope-Fallback"] = []string{server.Config.SystemScopeFallback}
-	if globalCollectionOpts.TestRun {
+	if opts.TestRun {
 		headers["Pganalyze-Test-Run"] = []string{"true"}
 	}
 	headers["User-Agent"] = []string{util.CollectorNameAndVersion}

--- a/state/state_file.go
+++ b/state/state_file.go
@@ -8,16 +8,16 @@ import (
 	"github.com/pganalyze/collector/util"
 )
 
-func WriteStateFile(servers []*Server, globalCollectionOpts CollectionOpts, logger *util.Logger) {
+func WriteStateFile(servers []*Server, opts CollectionOpts, logger *util.Logger) {
 	stateOnDisk := StateOnDisk{PrevStateByServer: make(map[config.ServerIdentifier]PersistedState), FormatVersion: StateOnDiskFormatVersion}
 
 	for _, server := range servers {
 		stateOnDisk.PrevStateByServer[server.Config.Identifier] = server.PrevState
 	}
 
-	file, err := os.Create(globalCollectionOpts.StateFilename)
+	file, err := os.Create(opts.StateFilename)
 	if err != nil {
-		logger.PrintWarning("Could not write out state file to %s because of error: %s", globalCollectionOpts.StateFilename, err)
+		logger.PrintWarning("Could not write out state file to %s because of error: %s", opts.StateFilename, err)
 		return
 	}
 	defer file.Close()
@@ -27,10 +27,10 @@ func WriteStateFile(servers []*Server, globalCollectionOpts CollectionOpts, logg
 }
 
 // ReadStateFile - This reads in the prevState structs from the state file - only run this on initial bootup and SIGHUP!
-func ReadStateFile(servers []*Server, globalCollectionOpts CollectionOpts, logger *util.Logger) {
+func ReadStateFile(servers []*Server, opts CollectionOpts, logger *util.Logger) {
 	var stateOnDisk StateOnDisk
 
-	file, err := os.Open(globalCollectionOpts.StateFilename)
+	file, err := os.Open(opts.StateFilename)
 	if err != nil {
 		if !util.IsHeroku() {
 			logger.PrintVerbose("Did not open state file: %s", err)


### PR DESCRIPTION
See individual commits:

- Rename reloadRun to reload
- Stop using deprecated ioutil package
- Save four thousand characters
- Drop unnecessary fmt.Sprintf
- Drop unnecessary fmt.Errorf calls
- Drop obsolete debugging output
- Drop unused function

This likely conflicts with #679 and #680; those should land first.
