### PR TITLE
unpackPostgresOidArray: Correctly support 64-bit OIDs

### DIFF
--- a/input/postgres/helpers.go
+++ b/input/postgres/helpers.go
@@ -30,7 +30,7 @@ func unpackPostgresOidArray(input null.String) (result []state.Oid) {
 	}
 
 	for _, cstr := range strings.Split(strings.Trim(input.String, "{}"), ",") {
-		cint, _ := strconv.ParseInt(cstr, 10, 32)
+		cint, _ := strconv.ParseInt(cstr, 10, 64)
 		result = append(result, state.Oid(cint))
 	}
 


### PR DESCRIPTION
Postgres allows OIDs to get very large (beyond the 32-bit integer boundary) which can cause problems in practice when unpacking arrays of OIDs.