### PR TITLE
Remove special error handling as func no longer returns that error

### DIFF
--- a/runner/logs.go
+++ b/runner/logs.go
@@ -487,9 +487,6 @@ func testAzureLogStream(ctx context.Context, wg *sync.WaitGroup, server *state.S
 	err := azure.SetupLogSubscriber(ctx, wg, globalCollectionOpts, logger, []*state.Server{server}, parsedLogStream)
 	if err != nil {
 		logger.PrintError("ERROR - Could not get logs through Azure Event Hub: %s", err)
-		if strings.HasPrefix(err.Error(), "failed to configure Azure AD JWT provider: failed") {
-			logger.PrintInfo("HINT - This error occurs when there are no Azure AD credentials configured. Please review the pganalyze documentation: https://pganalyze.com/docs/log-insights/setup/azure-database/troubleshooting#error-failed-to-configure-azure-ad-jwt-provider")
-		}
 		return false
 	}
 


### PR DESCRIPTION
While I was checking some other place, I realized that this part of the code is no longer reachable.
That particular error message from `azure.SetupLogSubscriber` was retired in https://github.com/pganalyze/collector/pull/415

https://github.com/pganalyze/collector/pull/415/files#diff-6f5880431e90b30b7cc480560bbf2f8e4a80fcbe85c03ca3cacae1276cb3512eL67

Let's make sure to remove it, also given that it's been a while since that change happened, I'd say that it's safe to remove the docs too (will do that in the docs PR).
