### PR TITLE
Improve warning when collector is paused by duplicate process

### DIFF
--- a/runner/activity.go
+++ b/runner/activity.go
@@ -24,7 +24,7 @@ func processActivityForServer(ctx context.Context, server *state.Server, opts st
 	newState := server.ActivityPrevState
 
 	if server.Pause.Load() {
-		logger.PrintVerbose("Duplicate collector detected. Please ensure only one collector is monitoring this Postgres server")
+		logger.PrintVerbose("Duplicate collector detected: Please ensure only one collector is monitoring this Postgres server")
 		return newState, false, nil
 	}
 

--- a/runner/activity.go
+++ b/runner/activity.go
@@ -24,7 +24,7 @@ func processActivityForServer(ctx context.Context, server *state.Server, opts st
 	newState := server.ActivityPrevState
 
 	if server.Pause.Load() {
-		logger.PrintVerbose("Snapshot processing disabled by pganalyze server")
+		logger.PrintVerbose("Duplicate collector detected. Please ensure only one collector is monitoring this Postgres server")
 		return newState, false, nil
 	}
 

--- a/runner/full.go
+++ b/runner/full.go
@@ -105,7 +105,7 @@ func processServer(ctx context.Context, server *state.Server, opts state.Collect
 	newGrant.Config = pganalyze_collector.ServerMessage_Config{Features: &pganalyze_collector.ServerMessage_Features{}}
 
 	if server.Pause.Load() {
-		logger.PrintWarning("Snapshot processing disabled by pganalyze server")
+		logger.PrintWarning("Duplicate collector detected. Please ensure only one collector is monitoring this Postgres server")
 		return newState, newGrant, collectionStatus, nil
 	}
 

--- a/runner/full.go
+++ b/runner/full.go
@@ -105,7 +105,7 @@ func processServer(ctx context.Context, server *state.Server, opts state.Collect
 	newGrant.Config = pganalyze_collector.ServerMessage_Config{Features: &pganalyze_collector.ServerMessage_Features{}}
 
 	if server.Pause.Load() {
-		logger.PrintWarning("Duplicate collector detected. Please ensure only one collector is monitoring this Postgres server")
+		logger.PrintWarning("Duplicate collector detected: Please ensure only one collector is monitoring this Postgres server")
 		return newState, newGrant, collectionStatus, nil
 	}
 

--- a/selftest/summary.go
+++ b/selftest/summary.go
@@ -139,7 +139,7 @@ func summarizeDbChecks(status *state.SelfTestResult, aspect state.DbCollectionAs
 	} else if len(checks) > 1 {
 		summaryMsg = fmt.Sprintf("ok in %s and %d other monitored database(s)%s", firstDb, len(checks)-1, verboseHint)
 	} else {
-		summaryMsg = fmt.Sprintf("ok in %s (no other databases are configured to be monitored)", firstDb)
+		summaryMsg = fmt.Sprintf("ok in %s (no other databases are monitored)", firstDb)
 	}
 
 	return icon, summaryMsg


### PR DESCRIPTION
The collector pause warning may have made sense to us internally, but it doesn't help users identify the issue on their own. This PR rewords it to be very clear about how to resolve the issue, though it removes the "processing disabled" part to avoid making the message too long.

In passing, this PR also updates the test run summary to use simpler wording.