### PR TITLE
Update messages when the monitoring user doesn't have a proper setup

### DIFF
--- a/input/postgres/replication.go
+++ b/input/postgres/replication.go
@@ -96,7 +96,7 @@ func GetReplication(ctx context.Context, c *Collection, db *sql.DB) (state.Postg
 				"You are not connecting as a user with the pg_monitor role or a superuser." +
 				" Please make sure the monitoring user used by the collector has been granted the pg_monitor role or is a superuser.")
 			if c.Config.SystemType == "aiven" {
-				c.Logger.PrintInfo("For aiven, you can also set up the monitoring helper functions (https://pganalyze.com/docs/install/aiven/01_create_monitoring_user).")
+				c.Logger.PrintInfo("For Aiven, you can also set up the monitoring helper functions (https://pganalyze.com/docs/install/aiven/01_create_monitoring_user).")
 			}
 		}
 		sourceTable = "pg_stat_replication"

--- a/input/postgres/replication.go
+++ b/input/postgres/replication.go
@@ -92,9 +92,12 @@ func GetReplication(ctx context.Context, c *Collection, db *sql.DB) (state.Postg
 		sourceTable = "pganalyze.get_stat_replication()"
 	} else {
 		if c.Config.SystemType != "heroku" && !c.ConnectedAsSuperUser && !c.ConnectedAsMonitoringRole {
-			c.Logger.PrintInfo("Warning: You are not connecting as superuser. Please setup" +
-				" the monitoring helper functions (https://pganalyze.com/docs/install/aiven/01_create_monitoring_user)" +
-				" or connect as superuser, to get replication statistics.")
+			c.Logger.PrintInfo("Warning: Monitoring user may have insufficient permissions to retrieve replication statistics.\n" +
+				"You are not connecting as a user with the pg_monitor role or a superuser." +
+				" Please make sure the monitoring user used by the collector has been granted the pg_monitor role or is a superuser.")
+			if c.Config.SystemType == "aiven" {
+				c.Logger.PrintInfo("For aiven, you can also set up the monitoring helper functions (https://pganalyze.com/docs/install/aiven/01_create_monitoring_user).")
+			}
 		}
 		sourceTable = "pg_stat_replication"
 	}

--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -171,11 +171,11 @@ func GetStatements(ctx context.Context, c *Collection, db *sql.DB, showtext bool
 			c.SelfTest.HintCollectionAspect(state.CollectionAspectPgStatStatements, "Please make sure the monitoring user used by the collector has been granted the pg_monitor role or is a superuser.")
 			c.Logger.PrintInfo("Warning: Monitoring user may have insufficient permissions to capture all queries.\n" +
 				"You are not connecting as a superuser." +
-				" Please make sure the monitoring user used by the collector has been granted the pg_monitor role or is a superuser, to get query statistics for all roles.")
+				" Please make sure the monitoring user used by the collector has been granted the pg_monitor role or is a superuser in order to get query statistics for all roles.")
 			if c.Config.SystemType == "aiven" {
 				docsLink := "https://pganalyze.com/docs/install/aiven/03_create_pg_stat_statements_helpers"
 				c.SelfTest.HintCollectionAspect(state.CollectionAspectPgStatStatements, "For aiven, you can also set up the monitoring helper functions (%s).", selftest.URLPrinter.Sprint(docsLink))
-				c.Logger.PrintInfo("For aiven, you can also set up the monitoring helper functions (%s).", docsLink)
+				c.Logger.PrintInfo("For Aiven, you can also set up the monitoring helper functions (%s).", docsLink)
 			}
 		}
 		if !showtext {

--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -168,12 +168,15 @@ func GetStatements(ctx context.Context, c *Collection, db *sql.DB, showtext bool
 	} else {
 		if c.Config.SystemType != "heroku" && !c.ConnectedAsSuperUser && !c.ConnectedAsMonitoringRole && c.GlobalOpts.TestRun {
 			c.SelfTest.MarkCollectionAspectWarning(state.CollectionAspectPgStatStatements, "monitoring user may have insufficient permissions to capture all queries")
-			c.SelfTest.HintCollectionAspect(state.CollectionAspectPgStatStatements, "Please set up"+
-				" the monitoring helper functions (%s)"+
-				" or connect as superuser to get query statistics for all roles.", selftest.URLPrinter.Sprint("https://pganalyze.com/docs/install/aiven/03_create_pg_stat_statements_helpers"))
-			c.Logger.PrintInfo("Warning: You are not connecting as superuser. Please setup" +
-				" the monitoring helper functions (https://pganalyze.com/docs/install/aiven/03_create_pg_stat_statements_helpers)" +
-				" or connect as superuser, to get query statistics for all roles.")
+			c.SelfTest.HintCollectionAspect(state.CollectionAspectPgStatStatements, "Please make sure the monitoring user used by the collector has been granted the pg_monitor role or is a superuser.")
+			c.Logger.PrintInfo("Warning: Monitoring user may have insufficient permissions to capture all queries.\n" +
+				"You are not connecting as a superuser." +
+				" Please make sure the monitoring user used by the collector has been granted the pg_monitor role or is a superuser, to get query statistics for all roles.")
+			if c.Config.SystemType == "aiven" {
+				docsLink := "https://pganalyze.com/docs/install/aiven/03_create_pg_stat_statements_helpers"
+				c.SelfTest.HintCollectionAspect(state.CollectionAspectPgStatStatements, "For aiven, you can also set up the monitoring helper functions (%s).", selftest.URLPrinter.Sprint(docsLink))
+				c.Logger.PrintInfo("For aiven, you can also set up the monitoring helper functions (%s).", docsLink)
+			}
 		}
 		if !showtext {
 			sourceTable = extSchema + ".pg_stat_statements(false)"


### PR DESCRIPTION
Previously, when the monitoring user is neither superuser nor has pg_monitor role, we were showing error messages saying that please use a superuser or create a helper function. While this is true for Aiven, especially for "creating a helper function" guidance, it's not true for other cases and when the user hits this with other providers, the error message is confusing and make it not clear which actions to take. Update the messaging to make it clear the next action for these cases.

This part, to link the Aiven doc was updated in https://github.com/pganalyze/collector/pull/532 and I did say "it's okay to use Aiven link", but we had some report from the other provider's customer who was confused by this error, so I think it's better to avoid showing the link.
https://github.com/pganalyze/collector/pull/532/files#r1566602511