### PR TITLE
Better support for running EXPLAIN with pganalyze.explain_analyze helper

### DIFF
--- a/util/helpers/explain_analyze.sql
+++ b/util/helpers/explain_analyze.sql
@@ -2,6 +2,7 @@ CREATE OR REPLACE FUNCTION pganalyze.explain_analyze(query text, params text[], 
 DECLARE
   prepared_query text;
   params_str text;
+  params_str2 text;
   param_types_str text;
   explain_prefix text;
   explain_flag text;
@@ -29,14 +30,18 @@ BEGIN
   END LOOP;
   explain_prefix := explain_prefix || ') ';
 
-  SELECT COALESCE('(' || pg_catalog.array_to_string(
-    ARRAY(
-      SELECT pg_catalog.quote_literal(p)
-      FROM pg_catalog.unnest(params) _(p)
-    ),
-    ',',
-    'NULL'
-  ) || ')', '') INTO params_str;
+  IF cardinality(params) > 0 THEN
+    SELECT '(' || pg_catalog.array_to_string(
+      ARRAY(
+        SELECT pg_catalog.quote_literal(p)
+        FROM pg_catalog.unnest(params) _(p)
+      ),
+      ',',
+      'NULL'
+    ) || ')' INTO params_str;
+  ELSE
+    SELECT '' INTO params_str;
+  END IF;
   SELECT COALESCE('(' || pg_catalog.string_agg(
     CASE
       WHEN p ~ '^[a-z0-9_]+(\[\])?$' THEN p

--- a/util/helpers/explain_analyze.sql
+++ b/util/helpers/explain_analyze.sql
@@ -29,8 +29,21 @@ BEGIN
   END LOOP;
   explain_prefix := explain_prefix || ') ';
 
-  SELECT COALESCE('(' || pg_catalog.string_agg(pg_catalog.quote_literal(p), ',') || ')', '') FROM pg_catalog.unnest(params) _(p) INTO params_str;
-  SELECT COALESCE('(' || pg_catalog.string_agg(pg_catalog.quote_ident(p), ',') || ')', '') FROM pg_catalog.unnest(param_types) _(p) INTO param_types_str;
+  SELECT COALESCE('(' || pg_catalog.array_to_string(
+    ARRAY(
+      SELECT pg_catalog.quote_literal(p)
+      FROM pg_catalog.unnest(params) _(p)
+    ),
+    ',',
+    'NULL'
+  ) || ')', '') INTO params_str;
+  SELECT COALESCE('(' || pg_catalog.string_agg(
+    CASE
+      WHEN p ~ '^[a-z0-9_]+(\[\])?$' THEN p
+      ELSE pg_catalog.quote_ident(p)
+    END,
+    ','
+  ) || ')', '') FROM pg_catalog.unnest(param_types) _(p) INTO param_types_str;
 
   EXECUTE 'PREPARE pganalyze_explain_analyze ' || param_types_str || ' AS ' || prepared_query;
   BEGIN

--- a/util/helpers/explain_analyze.sql
+++ b/util/helpers/explain_analyze.sql
@@ -43,7 +43,7 @@ BEGIN
   END IF;
   SELECT COALESCE('(' || pg_catalog.string_agg(
     CASE
-      WHEN p ~ '^[a-z0-9_]+(\[\])?$' THEN p
+      WHEN p ~ '^[a-z_][a-z0-9_]*(\[\])?$' THEN p
       ELSE pg_catalog.quote_ident(p)
     END,
     ','

--- a/util/helpers/explain_analyze.sql
+++ b/util/helpers/explain_analyze.sql
@@ -2,7 +2,6 @@ CREATE OR REPLACE FUNCTION pganalyze.explain_analyze(query text, params text[], 
 DECLARE
   prepared_query text;
   params_str text;
-  params_str2 text;
   param_types_str text;
   explain_prefix text;
   explain_flag text;


### PR DESCRIPTION
With more tests, we noticed that passing parameter values and types separately to this function is not working well for several cases.

For values, as `pg_catelog.string_agg` will never emit NULLs and only aggregates non-null values, it fails when we actually want to pass NULL as a value. Use array_to_string instead as a workaround.

For types, when something like int4[] is passed, as it was quoting as "int4[]" previously, this also didn't work. We check the input type and if it matches to the regexp (type pattern, especially ones the pganalyze app would pass), it skips quote_ident.