### PR TITLE
Amazon RDS: Also check monitoring interval for Enhanced Monitoring

### DIFF
--- a/input/system/rds/system.go
+++ b/input/system/rds/system.go
@@ -121,7 +121,7 @@ func GetSystemState(server *state.Server, logger *util.Logger) (system state.Sys
 
 	system.XlogUsedBytes = uint64(cloudWatchReader.GetRdsIntMetric("TransactionLogsDiskUsage", "Bytes"))
 
-	if instance.EnhancedMonitoringResourceArn != nil {
+	if instance.EnhancedMonitoringResourceArn != nil && instance.MonitoringInterval != nil && *instance.MonitoringInterval != 0 {
 		system.Info.AmazonRds.EnhancedMonitoring = true
 
 		svc := cloudwatchlogs.New(sess)


### PR DESCRIPTION
We previously only checked for the Enhanced Monitoring Resource ARN to be set, but that field will remain set when Enhanced Monitoring was once turned on, but then turned off. Instead also check the monitoring interval which will be 0 in such situations.

Fixes missing system metrics on RDS when Enhanced Monitoring is turned off.