### PR TITLE
Pick up the correct oldest xmin for Aurora replication

### DIFF
--- a/input/postgres/server_stats.go
+++ b/input/postgres/server_stats.go
@@ -61,8 +61,17 @@ COALESCE((
 COALESCE((
 	SELECT
 		backend_xmin
-	FROM %s
-	WHERE backend_xmin IS NOT NULL
+	FROM (
+		SELECT
+			backend_xmin
+		FROM %s
+			UNION ALL
+		SELECT
+			feedback_xmin as backend_xmin
+		FROM
+			%s
+		WHERE feedback_xmin IS NOT NULL
+	) _(backend_xmin)
 	ORDER BY pg_catalog.age(backend_xmin) DESC
 	LIMIT 1
 ), '0'::xid) as standby
@@ -120,7 +129,14 @@ func GetServerStats(ctx context.Context, c *Collection, db *sql.DB, ps state.Per
 		} else {
 			sourceStatReplicationTable = "pg_catalog.pg_stat_replication"
 		}
-		err = db.QueryRowContext(ctx, QueryMarkerSQL+fmt.Sprintf(xminHorizonSQL, sourceStatReplicationTable)).Scan(
+
+		var auroraStatsRel string
+		if c.PostgresVersion.IsAwsAurora {
+			auroraStatsRel = "aurora_replica_status()"
+		} else {
+			auroraStatsRel = "(VALUES(NULL::xid)) AS _(feedback_xmin)"
+		}
+		err = db.QueryRowContext(ctx, QueryMarkerSQL+fmt.Sprintf(xminHorizonSQL, sourceStatReplicationTable, auroraStatsRel)).Scan(
 			&stats.XminHorizonBackend, &stats.XminHorizonReplicationSlot, &stats.XminHorizonReplicationSlotCatalog,
 			&stats.XminHorizonPreparedXact, &stats.XminHorizonStandby,
 		)

--- a/input/postgres/server_stats.go
+++ b/input/postgres/server_stats.go
@@ -67,9 +67,8 @@ COALESCE((
 		FROM %s
 			UNION ALL
 		SELECT
-			feedback_xmin as backend_xmin
-		FROM
-			%s
+			feedback_xmin::text::xid as backend_xmin
+		FROM %s
 		WHERE feedback_xmin IS NOT NULL
 	) _(backend_xmin)
 	ORDER BY pg_catalog.age(backend_xmin) DESC
@@ -134,7 +133,7 @@ func GetServerStats(ctx context.Context, c *Collection, db *sql.DB, ps state.Per
 		if c.PostgresVersion.IsAwsAurora {
 			auroraStatsRel = "aurora_replica_status()"
 		} else {
-			auroraStatsRel = "(VALUES(NULL::xid)) AS _(feedback_xmin)"
+			auroraStatsRel = "(VALUES(NULL)) AS _(feedback_xmin)"
 		}
 		err = db.QueryRowContext(ctx, QueryMarkerSQL+fmt.Sprintf(xminHorizonSQL, sourceStatReplicationTable, auroraStatsRel)).Scan(
 			&stats.XminHorizonBackend, &stats.XminHorizonReplicationSlot, &stats.XminHorizonReplicationSlotCatalog,


### PR DESCRIPTION
Aurora does not include the correct replication details in
pg_stat_replication, so check aurora_replica_status and use the older
of the two values to track XminHorizonStandby on the platform.
