### PR TITLE
Fetch system metrics from API with Crunchy Bridge

### DIFF
--- a/input/system/crunchy_bridge/system.go
+++ b/input/system/crunchy_bridge/system.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/pganalyze/collector/input/system/selfhosted"
 	"github.com/pganalyze/collector/state"
 	"github.com/pganalyze/collector/util"
 )
@@ -12,15 +11,9 @@ import (
 // GetSystemState - Gets system information about a Crunchy Bridge instance
 func GetSystemState(ctx context.Context, server *state.Server, logger *util.Logger) (system state.SystemState) {
 	config := server.Config
-	// With Crunchy Bridge, we are assuming that the collector is deployed on Container Apps,
-	// which run directly on the database server. Most of the metrics can be obtained
-	// using the same way as a self hosted server, since the container receives a bind mount
-	// of /proc and /sys from the host. Note this excludes disk usage metrics, which we instead
-	// get from the API.
-	system = selfhosted.GetSystemState(server, logger, true)
 	system.Info.Type = state.CrunchyBridgeSystem
 
-	// When API key is provided, use API to obtain extra info including disk usage metrics
+	// When API key is provided, use API to obtain cluster info and system metrics
 	if config.CrunchyBridgeAPIKey == "" {
 		return
 	}
@@ -48,6 +41,63 @@ func GetSystemState(ctx context.Context, server *state.Server, logger *util.Logg
 	}
 	if parsedCreatedAt, err := time.Parse(time.RFC3339, clusterInfo.CreatedAt); err != nil {
 		system.Info.CrunchyBridge.CreatedAt = parsedCreatedAt
+	}
+
+	cpuMetrics, err := client.GetCPUMetrics(ctx)
+	if err != nil {
+		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectSystemStats, "error getting cluster CPU metrics: %s", err)
+		logger.PrintError("CrunchyBridge/System: Encountered error when getting cluster CPU metrics %v\n", err)
+		return
+	}
+	system.CPUStats["all"] = state.CPUStatistic{
+		DiffedOnInput: true,
+		DiffedValues: &state.DiffedSystemCPUStats{
+			IowaitPercent: cpuMetrics.Iowait,
+			SystemPercent: cpuMetrics.System,
+			UserPercent:   cpuMetrics.User,
+			StealPercent:  cpuMetrics.Steal,
+		},
+	}
+
+	loadAverageMetrics, err := client.GetLoadAverageMetrics(ctx)
+	if err != nil {
+		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectSystemStats, "error getting cluster Load Average metrics: %s", err)
+		logger.PrintError("CrunchyBridge/System: Encountered error when getting cluster Load Average metrics %v\n", err)
+		return
+	}
+	system.Scheduler.Loadavg1min = loadAverageMetrics.One
+
+	memoryMetrics, err := client.GetMemoryMetrics(ctx)
+	if err != nil {
+		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectSystemStats, "error getting cluster memory metrics: %s", err)
+		logger.PrintError("CrunchyBridge/System: Encountered error when getting cluster memory metrics %v\n", err)
+		return
+	}
+	totalMemoryInBytes := clusterInfo.Memory * 1024 * 1024 * 1024
+	system.Memory.TotalBytes = uint64(totalMemoryInBytes)
+	// ApplicationBytes is not the best way for representing "used bytes",
+	// but in the UI side, we use this as "process" memory if this value exits
+	// which would be the closest to the used bytes
+	system.Memory.ApplicationBytes = uint64(float64(totalMemoryInBytes) * memoryMetrics.MemoryUsedPct)
+	system.Memory.SwapUsedBytes = uint64(float64(totalMemoryInBytes) * memoryMetrics.SwapUsedPct)
+
+	iopsMetrics, err := client.GetIOPSMetrics(ctx)
+	if err != nil {
+		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectSystemStats, "error getting cluster IOPS metrics: %s", err)
+		logger.PrintError("CrunchyBridge/System: Encountered error when getting cluster IOPS metrics %v\n", err)
+		return
+	}
+
+	system.Disks = make(state.DiskMap)
+	system.Disks["default"] = state.Disk{}
+
+	system.DiskStats = make(state.DiskStatsMap)
+	system.DiskStats["default"] = state.DiskStats{
+		DiffedOnInput: true,
+		DiffedValues: &state.DiffedDiskStats{
+			ReadOperationsPerSecond:  iopsMetrics.Reads,
+			WriteOperationsPerSecond: iopsMetrics.Writes,
+		},
 	}
 
 	diskUsageMetrics, err := client.GetDiskUsageMetrics(ctx)


### PR DESCRIPTION
Currently, we're using gopsutil to fetch Crunchy's system metrics, assuming that the collector is deployed on Container Apps. Recently, with the change of cgroups with Container Apps, we are no longer able to pull these system info using gopsutil.

With this PR, instead of trying to get the system metrics using gopsutil, fetch these metrics from the API. Below is how it looks in the Crunchy Bridge UI and the pganalyze UI.

### CPU & Load Average section
* pganalyze UI has "idle", which is kinda hack not to make other percentage inflate - you can see this more in the code comment
* In the pganalyze UI, we should likely be hiding load avg 5 mins and 15 mins as it doesn't exist and it's likely confusing to people for why it's zero
![image](https://github.com/user-attachments/assets/2be074bd-5411-4afa-9dfd-77076034c426)
![image](https://github.com/user-attachments/assets/6d22f54a-29cb-422e-a39a-94c81860dc53)

### Memory
* "memory used" in Crunchy is shown as "Process Memory" in pganalyze
* In the pganalyze UI, maaaybe we should hide metrics that are not available in Crunchy (like we want to do above in load average)
![image](https://github.com/user-attachments/assets/bb9db6af-fd5f-4ca1-b8c7-73c06d3b6120)
![image](https://github.com/user-attachments/assets/9625cfa1-55ca-414b-83e1-f631a38ad76c)

### I/O & Storage
* Storage space graph hasn't changed so it should be in a good shape
* IOPS is the one that is now using the API metrics, looking good
* We have other things in the pganalyze UI that we no longer report (I/O utilization in the screenshot, I/O Latency, etc.) - we should hide them
![image](https://github.com/user-attachments/assets/8cd89408-2dcb-4252-bedd-27a3444af14d)
![image](https://github.com/user-attachments/assets/5ba29f14-f7d4-4ea7-9c4a-8a09be4e5c05)
