### PR TITLE
GH actions has stopped providing Ubuntu 20.04 runners, update to 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,9 +81,7 @@ jobs:
         path: pganalyze-collector-linux-arm64
 
   build_packages_x86_64:
-    # Use older Ubuntu release to ensure availability of CGroupsv1 (which are necessary
-    # currently to support older systemd on some of the test containers)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions: {}
     # ensure we don't release on create events for branches (only tags)
     if: ${{ startsWith( github.ref, 'refs/tags' ) }}

--- a/.github/workflows/test-packages.yml
+++ b/.github/workflows/test-packages.yml
@@ -8,9 +8,7 @@ on:
 
 jobs:
   build_x86_64:
-    # Use older Ubuntu release to ensure availability of CGroupsv1 (which are necessary
-    # currently to support older systemd on some of the test containers)
-    runs-on: ubuntu-20.04-4-cores
+    runs-on: ubuntu-22.04-4-cores
     permissions: {}
 
     steps:


### PR DESCRIPTION
This effectively ends testing packages on Amazon Linux 2, since that requires CGroupsv1 which required Ubuntu 20.04. For now, leave the capability to test it in the relevant Makefile, in case we want to do manual testing.