### PR TITLE
Use large runner for all build actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     # Use new enough OS that has CGroupsv2 enabled (required by the integration tests)
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-22.04-4-cores
     env:
       TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable
     services:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-4-cores
     permissions: {}
     # ensure we don't release on create events for branches (only tags)
     if: ${{ startsWith( github.ref, 'refs/tags' ) }}


### PR DESCRIPTION
This was needed for the release step as well. Pin to Ubuntu 22.04 for now for consistency.