### PR TITLE
Allow sending otel payload in JSON format

### DIFF
--- a/input/system/selfhosted/otel_handler.go
+++ b/input/system/selfhosted/otel_handler.go
@@ -76,6 +76,10 @@ func skipDueToK8sFilter(kubernetes *common.KeyValueList, server *state.Server, p
 	var k8sPodName string
 	var k8sNamespaceName string
 
+	if kubernetes == nil {
+		return false
+	}
+
 	k8sLabels := make(map[string]string)
 	for _, rv := range kubernetes.Values {
 		if rv.Key == "pod_name" {


### PR DESCRIPTION
When user specifies `Content-Type: application/json`, handler will attempt to parse logsData from JSON instead of assuming it's a raw protobuf payload. Fixes #580.

This PR also includes a fix for panic error due to CNPG output not containing `"kubernetes"` section.
K8s pod/namespace information is not part of a record anyway as it only contains what CNPG container logs into stderr.

If we want to act on kubernetes metadata like k8s namespace, pod name, labels, it likely needs to be in `ResourceLogs[].Resource`.

@lfittl I would like to include native support for more kinds of logs from https://cloudnative-pg.io/documentation/1.26/logging/#other-logs, e.g `wal-archive` in particular. It would give great visibility into issues like failure to upload wal. Seeking guidance on how to approach this best.

<img width="1293" alt="image" src="https://github.com/user-attachments/assets/2b388cc2-86d9-42bb-a9f3-54a14decd30d" />