### PR TITLE
Raise error when collector config has duplicate servers

### DIFF
--- a/runner/run.go
+++ b/runner/run.go
@@ -44,7 +44,7 @@ func Run(ctx context.Context, wg *sync.WaitGroup, opts state.CollectionOpts, log
 		return
 	}
 
-	conf, err := config.Read(logger, configFilename)
+	conf, err := config.Read(opts.TestRun, logger, configFilename)
 	if err != nil {
 		logger.PrintError("Config Error: %s", err)
 		keepRunning = !opts.TestRun && !opts.DiscoverLogLocation

--- a/setup/steps/ensure_monitoring_user_password.go
+++ b/setup/steps/ensure_monitoring_user_password.go
@@ -22,6 +22,7 @@ var EnsureMonitoringUserPassword = &s.Step{
 		// We're using config.Read here (and only here) to be able to use the same
 		// GetPqOpenString we use in the main collector code
 		cfg, err := config.Read(
+			false,
 			&mainUtil.Logger{Destination: log.New(os.Stderr, "", 0)},
 			state.ConfigFilename,
 		)


### PR DESCRIPTION
Currently if the collector config has duplicate entries for the same server, we log out an error message but it's treated as a non-fatal issue: the collector skips duplicate servers and a test run succeeds. That can lead to users not realizing there's an issue with their config, so this change turns it into a fatal error that must be addressed.

This can be tested locally with:
```
make build && PGA_API_SYSTEM_SCOPE=test ./pganalyze-collector --test
```
Note that `PGA_API_SYSTEM_SCOPE=test` is needed because a self-hosted server has its first database name [appended to the system scope](https://github.com/pganalyze/collector/blob/b3ccc143d638008bd39301bf6651f1b9ab05dab6/config/identify_system.go#L111), so by default it's identified as a separate server. We could remove the database name from the system scope and move the current behavior to a fallback system scope so existing servers aren't churned, but there could be unexpected consequences to that kind of change so I've omitted it for now.

