### PR TITLE
Adds the ability to create multiple OTel endpoints on different ports for the same collector

### DIFF
--- a/input/system/selfhosted/logs.go
+++ b/input/system/selfhosted/logs.go
@@ -138,7 +138,7 @@ func SetupOtelHandlerForServer(ctx context.Context, wg *sync.WaitGroup, opts sta
 	}
 
 	logStream := setupLogTransformer(ctx, wg, server, opts, logger, parsedLogStream)
-	return setupOtelHandler(ctx, server, logStream, parsedLogStream, logger)
+	return setupOtelHandler(ctx, server, logStream, parsedLogStream, logger, opts)
 }
 
 // SetupLogTails - Sets up continuously running log tails for all servers with a

--- a/util/slice_contains.go
+++ b/util/slice_contains.go
@@ -1,0 +1,12 @@
+package util
+
+// helper function to check if a string is contained in a slice
+// to avoid starting multiple servers for the same endpoint
+func SliceContains(arr []string, val string) bool {
+	for _, v := range arr {
+		if v == val {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Currently, the collector only supports one OTel endpoint for each running collector. The endpoint is also tied to a specific server configuration.

This allows creating multiple OTel V1 API endpoints to receive protobuf messages from Fluentbit in a Kubernetes environment. Multiple [OUTPUT] sections can be configured to send log data for specific server logs to the given endpoint which allows the collector to segregate and publish it with the appropriate server.

Additionally, I added the option to print out the Fluentbit payload if `--debug-logs` is enabled at runtime. The lingering issue with receiving logs correctly from some users comes down to how the `Tag` and `Match` properties of the Fluentbit configuration are set for [INPUT] and [OUTPUT]. Without being able to print out the actual JSON payload and examine for all of the expected properties, some of the code paths fail silently. The only current solution, however, is to ensure that the tags are configured correctly.

So, this breaks the Kubernetes plugin that adds metadata through an additional `kubernetes` node in the payload which users can filter on in the `skipDueToK8sFilter` function.

```
    [INPUT]
        Name tail
        Path /var/log/containers/cluster-example-*_default_postgres*.log
        Tag kube.cluster-example
        multiline.parser docker, cri
        DB /var/log/flb_kube1.db
```

The documentation implies that a user should be able to customize the tag and then add the `kubernetes` metadata using a [FILTER], but the auto expanding of the tag prefix proved unreliable in nearly every configuration.

```
  filters: |
    [FILTER]
        Name kubernetes
        Match kube.*
        Merge_Log On
        Keep_Log Off
        K8S-Logging.Parser On
        K8S-Logging.Exclude off
        Kube_Tag_Prefix kube.var.log.containers.
```

Without the `kubernetes` node doesn't exist in the payload, that fails. 

Therefore, the proper way, as far as I can find, is to set each [INPUT] to access the desired logs, and then filter different log [OUTPUT]s to the different OTel endpoints for that server.

```
    [OUTPUT]
        Name  opentelemetry
        Match kube.*cluster-example2-*
        Host  192.168.12.242
        Port  4319

    [OUTPUT]
        Name  opentelemetry
        Match kube.*cluster-example-*
        Host  192.168.12.242
        Port  4318
```