### PR TITLE
Support specifying multiple ports for log OTEL servers

### DIFF
--- a/contrib/helm/pganalyze-collector/README.md
+++ b/contrib/helm/pganalyze-collector/README.md
@@ -1,6 +1,6 @@
 # pganalyze-collector
 
-![Version: 0.63.0](https://img.shields.io/badge/Version-0.63.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.63.0](https://img.shields.io/badge/AppVersion-v0.63.0-informational?style=flat-square)
+![Version: 0.66.2](https://img.shields.io/badge/Version-0.66.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.66.2](https://img.shields.io/badge/AppVersion-v0.66.2-informational?style=flat-square)
 
 pganalyze statistics collector
 
@@ -50,6 +50,7 @@ pganalyze statistics collector
 | service.create | bool | `false` | Specifies whether a service should be created for receiving logs via OpenTelemtry This service is used when Postgres is running within the cluster and Postgres logs are sent out to the collector using log collectors like Fluent Bit |
 | service.name | string | `"pganalyze-collector-otel-service"` | The name of the service to use. If not set and create is true, a name is generated using the fullname template. This is the name referenced by the log sender like Fluent Bit |
 | service.port | int | `4318` | The port of service. This is the port referenced by the log sender like Fluent Bit |
+| service.ports | list | `[{"name":"otel1","port":4318,"targetPort":4318},{"name":"otel2","port":4319,"targetPort":4319}]` | The list of port and target ports for OTEL logging When this is specified, above port and targetPort will be ignored. If you need to have multiple log OTEL servers, use this. |
 | service.targetPort | int | `4318` | The target port of the log OTEL server port. This should match to the port number specified with db_log_otel_server |
 | service.type | string | `"ClusterIP"` | The type of service to create. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/contrib/helm/pganalyze-collector/README.md
+++ b/contrib/helm/pganalyze-collector/README.md
@@ -47,10 +47,10 @@ pganalyze statistics collector
 | securityContext.runAsNonRoot | bool | `true` |  |
 | securityContext.runAsUser | int | `1000` |  |
 | securityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
-| service.create | bool | `false` | Specifies whether a service should be created for receiving logs via OpenTelemtry This service is used when Postgres is running within the cluster and Postgres logs are sent out to the collector using log collectors like Fluent Bit |
+| service.create | bool | `false` | Specifies whether a service should be created for receiving logs via OpenTelemetry. This service is used when Postgres is running within the cluster and Postgres logs are sent out to the collector using log collectors like Fluent Bit |
 | service.name | string | `"pganalyze-collector-otel-service"` | The name of the service to use. If not set and create is true, a name is generated using the fullname template. This is the name referenced by the log sender like Fluent Bit |
 | service.port | int | `4318` | The port of service. This is the port referenced by the log sender like Fluent Bit |
-| service.ports | list | `[{"name":"otel1","port":4318,"targetPort":4318},{"name":"otel2","port":4319,"targetPort":4319}]` | The list of port and target ports for OTEL logging When this is specified, above port and targetPort will be ignored. If you need to have multiple log OTEL servers, use this. |
+| service.ports | list | `[{"name":"otel1","port":4318,"targetPort":4318},{"name":"otel2","port":4319,"targetPort":4319}]` | The list of port and target ports for OTEL logging. When this is specified, above port and targetPort will be ignored. If you need to have multiple log OTEL servers, use this. |
 | service.targetPort | int | `4318` | The target port of the log OTEL server port. This should match to the port number specified with db_log_otel_server |
 | service.type | string | `"ClusterIP"` | The type of service to create. |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/contrib/helm/pganalyze-collector/templates/service.yaml
+++ b/contrib/helm/pganalyze-collector/templates/service.yaml
@@ -7,10 +7,20 @@ metadata:
     {{- include "pganalyze-collector.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.ports }}
+  ports:
+    {{- range .Values.service.ports }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .targetPort }}
+      protocol: TCP
+    {{- end }}
+  {{- else }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
+  {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "pganalyze-collector.name" . }}
 {{- end }}

--- a/contrib/helm/pganalyze-collector/values.yaml
+++ b/contrib/helm/pganalyze-collector/values.yaml
@@ -84,6 +84,16 @@ service:
   # -- The target port of the log OTEL server port.
   # This should match to the port number specified with db_log_otel_server
   targetPort: 4318
+  # -- The list of port and target ports for OTEL logging
+  # When this is specified, above port and targetPort will be ignored.
+  # If you need to have multiple log OTEL servers, use this.
+  ports:
+    - name: otel1
+      port: 4318
+      targetPort: 4318
+    - name: otel2
+      port: 4319
+      targetPort: 4319
 
 podAnnotations: {}
 

--- a/contrib/helm/pganalyze-collector/values.yaml
+++ b/contrib/helm/pganalyze-collector/values.yaml
@@ -68,7 +68,7 @@ serviceAccount:
   name: ""
 
 service:
-  # -- Specifies whether a service should be created for receiving logs via OpenTelemtry
+  # -- Specifies whether a service should be created for receiving logs via OpenTelemetry.
   # This service is used when Postgres is running within the cluster and Postgres logs
   # are sent out to the collector using log collectors like Fluent Bit
   create: false
@@ -84,7 +84,7 @@ service:
   # -- The target port of the log OTEL server port.
   # This should match to the port number specified with db_log_otel_server
   targetPort: 4318
-  # -- The list of port and target ports for OTEL logging
+  # -- The list of port and target ports for OTEL logging.
   # When this is specified, above port and targetPort will be ignored.
   # If you need to have multiple log OTEL servers, use this.
   ports:


### PR DESCRIPTION
Currently, when using a helm chart,  you can only expose one port for the [db_log_otel_server](https://pganalyze.com/docs/collector/settings#self-managed-servers).
With https://github.com/pganalyze/collector/pull/719, we should be able to create and expose more than one servers, and this helm chart update ensures that specifying to expose multiple ports of the collector is possible using a helm chart. 