### PR TITLE
Use --very-verbose flag for logging received data from Azure EventHub, Google Pub/Sub, syslog

### DIFF
--- a/input/system/azure/logs.go
+++ b/input/system/azure/logs.go
@@ -191,7 +191,7 @@ func runEventHubHandlers(ctx context.Context, partitionIDs []string, logger *uti
 	wg.Wait()
 }
 
-func setupEventHubReceiver(ctx context.Context, wg *sync.WaitGroup, logger *util.Logger, config config.ServerConfig, azureLogStream chan AzurePostgresLogRecord) error {
+func setupEventHubReceiver(ctx context.Context, wg *sync.WaitGroup, logger *util.Logger, config config.ServerConfig, azureLogStream chan AzurePostgresLogRecord, opts state.CollectionOpts) error {
 	partitionIDs, err := getEventHubPartitionIDs(ctx, config)
 	if err != nil {
 		return err
@@ -204,6 +204,14 @@ func setupEventHubReceiver(ctx context.Context, wg *sync.WaitGroup, logger *util
 		err = json.Unmarshal(event.Body, &eventData)
 		if err != nil {
 			logger.PrintWarning("Error parsing Azure Event Hub event: %s", err)
+		}
+		if opts.VeryVerbose {
+			jsonData, err := json.MarshalIndent(eventData, "", "  ")
+			if err != nil {
+				logger.PrintVerbose("Failed to convert AzureEventHubData struct to JSON: %v", err)
+			}
+			logger.PrintVerbose("Received Azure EventHub log data in the following format:\n")
+			logger.PrintVerbose(string(jsonData))
 		}
 		for _, record := range eventData.Records {
 			if record.Category == "PostgreSQLLogs" && record.OperationName == "LogEvent" {
@@ -230,7 +238,7 @@ func SetupLogSubscriber(ctx context.Context, wg *sync.WaitGroup, opts state.Coll
 			if _, ok := eventHubReceivers[server.Config.AzureEventhubNamespace+"/"+server.Config.AzureEventhubName]; ok {
 				continue
 			}
-			err := setupEventHubReceiver(ctx, wg, prefixedLogger, server.Config, azureLogStream)
+			err := setupEventHubReceiver(ctx, wg, prefixedLogger, server.Config, azureLogStream, opts)
 			if err != nil {
 				if opts.TestRun {
 					return err
@@ -322,14 +330,6 @@ func setupLogTransformer(ctx context.Context, wg *sync.WaitGroup, servers []*sta
 			case in, ok := <-in:
 				if !ok {
 					return
-				}
-				if opts.VeryVerbose {
-					jsonData, err := json.MarshalIndent(in, "", "  ")
-					if err != nil {
-						logger.PrintVerbose("Failed to convert AzurePostgresLogRecord struct to JSON: %v", err)
-					}
-					logger.PrintVerbose("Received Azure EventHub log data in the following format:\n")
-					logger.PrintVerbose(string(jsonData))
 				}
 
 				azureDbServerName := GetServerNameFromRecord(in)

--- a/input/system/azure/logs.go
+++ b/input/system/azure/logs.go
@@ -287,7 +287,7 @@ func ParseRecordToLogLines(in AzurePostgresLogRecord, parser state.LogParser) ([
 	}
 	logLine, ok := parser.ParseLine(logLineContent)
 	if !ok {
-		return []state.LogLine{}, fmt.Errorf("Can't parse log line: \"%s\"", logLineContent)
+		return []state.LogLine{}, fmt.Errorf("can't parse log line: \"%s\"", logLineContent)
 	}
 
 	logLines := []state.LogLine{logLine}
@@ -322,6 +322,14 @@ func setupLogTransformer(ctx context.Context, wg *sync.WaitGroup, servers []*sta
 			case in, ok := <-in:
 				if !ok {
 					return
+				}
+				if opts.VeryVerbose {
+					jsonData, err := json.MarshalIndent(in, "", "  ")
+					if err != nil {
+						logger.PrintVerbose("Failed to convert AzurePostgresLogRecord struct to JSON: %v", err)
+					}
+					logger.PrintVerbose("Received Azure EventHub log data in the following format:\n")
+					logger.PrintVerbose(string(jsonData))
 				}
 
 				azureDbServerName := GetServerNameFromRecord(in)

--- a/input/system/selfhosted/logs.go
+++ b/input/system/selfhosted/logs.go
@@ -183,7 +183,7 @@ func SetupLogTails(ctx context.Context, wg *sync.WaitGroup, opts state.Collectio
 			}
 		} else if server.Config.LogSyslogServer != "" {
 			logStream := setupLogTransformer(ctx, wg, server, opts, prefixedLogger, parsedLogStream)
-			err := setupSyslogHandler(ctx, server.Config, logStream, prefixedLogger)
+			err := setupSyslogHandler(ctx, server.Config, logStream, prefixedLogger, opts)
 			if err != nil {
 				prefixedLogger.PrintError("ERROR - %s", err)
 			}

--- a/input/system/selfhosted/syslog_handler.go
+++ b/input/system/selfhosted/syslog_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"os"
 	"regexp"
@@ -13,13 +14,14 @@ import (
 	"gopkg.in/mcuadros/go-syslog.v2"
 
 	"github.com/pganalyze/collector/config"
+	"github.com/pganalyze/collector/state"
 	"github.com/pganalyze/collector/util"
 )
 
 var logLinePartsRegexp = regexp.MustCompile(`^\s*\[(\d+)-(\d+)\] (.*)`)
 var logLineNumberPartsRegexp = regexp.MustCompile(`^\[(\d+)-(\d+)\]$`)
 
-func setupSyslogHandler(ctx context.Context, config config.ServerConfig, out chan<- SelfHostedLogStreamItem, prefixedLogger *util.Logger) error {
+func setupSyslogHandler(ctx context.Context, config config.ServerConfig, out chan<- SelfHostedLogStreamItem, prefixedLogger *util.Logger, opts state.CollectionOpts) error {
 	logSyslogServer := config.LogSyslogServer
 	channel := make(syslog.LogPartsChannel)
 	handler := syslog.NewChannelHandler(channel)
@@ -86,9 +88,18 @@ func setupSyslogHandler(ctx context.Context, config config.ServerConfig, out cha
 	server.Boot()
 
 	go func(ctx context.Context, server *syslog.Server, channel syslog.LogPartsChannel) {
+	outer:
 		for {
 			select {
 			case logParts := <-channel:
+				if opts.VeryVerbose {
+					jsonData, err := json.MarshalIndent(logParts, "", "  ")
+					if err != nil {
+						prefixedLogger.PrintVerbose("Failed to convert LogParts struct to JSON: %v", err)
+					}
+					prefixedLogger.PrintVerbose("Received syslog log data in the following format:\n")
+					prefixedLogger.PrintVerbose(string(jsonData))
+				}
 				item := SelfHostedLogStreamItem{}
 
 				item.OccurredAt, _ = logParts["timestamp"].(time.Time)
@@ -129,7 +140,7 @@ func setupSyslogHandler(ctx context.Context, config config.ServerConfig, out cha
 				// and disambiguate based on logParts["client"]
 			case <-ctx.Done():
 				server.Kill()
-				break
+				break outer
 			}
 		}
 	}(ctx, server, channel)

--- a/input/system/selfhosted/syslog_handler.go
+++ b/input/system/selfhosted/syslog_handler.go
@@ -88,7 +88,6 @@ func setupSyslogHandler(ctx context.Context, config config.ServerConfig, out cha
 	server.Boot()
 
 	go func(ctx context.Context, server *syslog.Server, channel syslog.LogPartsChannel) {
-	outer:
 		for {
 			select {
 			case logParts := <-channel:
@@ -140,7 +139,7 @@ func setupSyslogHandler(ctx context.Context, config config.ServerConfig, out cha
 				// and disambiguate based on logParts["client"]
 			case <-ctx.Done():
 				server.Kill()
-				break outer
+				return
 			}
 		}
 	}(ctx, server, channel)

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 	flag.BoolVar(&reload, "reload", false, "Reloads the collector daemon that's running on the host")
 	flag.BoolVar(&noReload, "no-reload", false, "Disables automatic config reloading during a test run")
 	flag.BoolVarP(&logger.Verbose, "verbose", "v", false, "Outputs additional debugging information, use this if you're encountering errors or other problems")
-	flag.BoolVarP(&veryVerbose, "very-verbose", "vv", false, "Enable very verbose logging (will also enable verbose logging)")
+	flag.BoolVar(&veryVerbose, "very-verbose", false, "Enable very verbose logging (will also enable verbose logging)")
 	flag.BoolVarP(&logger.Quiet, "quiet", "q", false, "Only outputs error messages to the logs and hides informational and warning messages")
 	flag.BoolVar(&logToSyslog, "syslog", false, "Write all log output to syslog instead of stderr (disabled by default)")
 	flag.BoolVar(&logToJSON, "json-logs", false, "Write all log output to stderr as newline delimited json (disabled by default, ignored if --syslog is set)")

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 	flag.BoolVar(&reload, "reload", false, "Reloads the collector daemon that's running on the host")
 	flag.BoolVar(&noReload, "no-reload", false, "Disables automatic config reloading during a test run")
 	flag.BoolVarP(&logger.Verbose, "verbose", "v", false, "Outputs additional debugging information, use this if you're encountering errors or other problems")
-	flag.BoolVarP(&veryVerbose, "very-verbose", "", false, "Enable very verbose logging (will also enable verbose logging)")
+	flag.BoolVarP(&veryVerbose, "very-verbose", "vv", false, "Enable very verbose logging (will also enable verbose logging)")
 	flag.BoolVarP(&logger.Quiet, "quiet", "q", false, "Only outputs error messages to the logs and hides informational and warning messages")
 	flag.BoolVar(&logToSyslog, "syslog", false, "Write all log output to syslog instead of stderr (disabled by default)")
 	flag.BoolVar(&logToJSON, "json-logs", false, "Write all log output to stderr as newline delimited json (disabled by default, ignored if --syslog is set)")


### PR DESCRIPTION
With https://github.com/pganalyze/collector/pull/719, we introduced a new flag `--very-verbose`, which enables emitting the incoming logs with Otel.
With this PR, expand the usage of `--very-verbose`, to enable the logging of incoming logs with Azure EventHub, Google Pub/Sub, and syslog.

See how the logs will look like in the following gist:
https://gist.github.com/keiko713/ebc0c8dbfcfd6ecb297fb1c1f3229e50

Internal memo: for https://github.com/pganalyze/pganalyze/issues/5073