### PR TITLE
Add Oracle Linux as a supported OS to the install script

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -65,19 +65,19 @@ then
   pkg=yum
   distribution=el
   version=9
-elif grep -q '^ID="\(rhel\|centos\|almalinux\|rocky\)"$' /etc/os-release;
+elif grep -q '^ID="\(rhel\|centos\|almalinux\|rocky\|ol\)"$' /etc/os-release;
 then
-  # RHEL, CentOS, AlmaLinux and Rocky Linux
+  # RHEL, CentOS, AlmaLinux, Rocky Linux and Oracle Linux
   pkg=yum
   distribution=el
   version=$(grep VERSION_ID /etc/os-release | cut -d= -f2 | tr -d '"' | cut -d. -f1)
   if [ "$version" != 7 ] && [ "$version" != 8 ] && [ "$version" != 9 ];
   then
-    if confirm "Unsupported RHEL, CentOS, AlmaLinux or Rocky Linux version; try RHEL9 package?";
+    if confirm "Unsupported RHEL, CentOS, AlmaLinux, Rocky Linux or Oracle Linux version; try RHEL9 package?";
     then
       version=9
     else
-      fail "unrecognized RHEL, CentOS, AlmaLinux or Rocky Linux version: ${version}"
+      fail "unrecognized RHEL, CentOS, AlmaLinux, Rocky Linux or Oracle Linux version: ${version}"
     fi
   fi
 elif grep -q '^ID=fedora$' /etc/os-release;


### PR DESCRIPTION
Tested manually with the Oracle Linux 9 instance and it worked. Given that Oracle Linux is 100% application binary compatible with RHEL, we should be okay adding it to the supported OS list.