### PR TITLE
Add nap to the SELECT statement from clause

### DIFF
--- a/runner/emit_test_lines.go
+++ b/runner/emit_test_lines.go
@@ -49,7 +49,7 @@ WHERE
 ), nap AS (
 	SELECT pg_catalog.pg_sleep(value) FROM naptime WHERE value >= 0
 )
-SELECT value FROM naptime`, setting).Scan(&naptime)
+SELECT value FROM naptime, nap`, setting).Scan(&naptime)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return fmt.Errorf("could not check current value for setting '%s'", setting)


### PR DESCRIPTION
Without this, the nap CTE actually does not run. This SQL needs to run sleep to actually run longer than the log min duration.

```sql
WITH naptime(value) AS (
SELECT
        COALESCE(pg_catalog.max(setting::float), 0) / 1000 * 1.2
FROM
        pg_settings
WHERE
        name = 'auto_explain.log_min_duration'
), nap AS (
        SELECT pg_catalog.pg_sleep(value) FROM naptime WHERE value >= 0
)
SELECT value FROM naptime;
 value 
-------
   1.2
(1 row)

Time: 4.074 ms
```
```sql
WITH naptime(value) AS (
SELECT
        COALESCE(pg_catalog.max(setting::float), 0) / 1000 * 1.2
FROM
        pg_settings
WHERE
        name = 'auto_explain.log_min_duration'
), nap AS (
        SELECT pg_catalog.pg_sleep(value) FROM naptime WHERE value >= 0
)
SELECT value FROM naptime, nap;
 value 
-------
   1.2
(1 row)

Time: 1207.640 ms (00:01.208)
```