### PR TITLE
Helper: Don't require "locate" to determine the pg_controldata path

### DIFF
--- a/helper/main.go
+++ b/helper/main.go
@@ -85,12 +85,17 @@ func getStatus(dataDirectory string) {
 			}
 		}
 
-		var cmdOut []byte
-		cmdOut, err = exec.Command("locate", "-r", "bin/pg_controldata$").Output()
+		postmasterBin, err := filepath.EvalSymlinks(filepath.Join("/proc", strconv.Itoa(status.PostmasterPid), "exe"))
 		if err != nil {
-			pgControldataBinary = "pg_controldata"
+			var cmdOut []byte
+			cmdOut, err = exec.Command("locate", "-r", "bin/pg_controldata$").Output()
+			if err != nil {
+				pgControldataBinary = "pg_controldata"
+			} else {
+				pgControldataBinary = string(cmdOut[:len(cmdOut)-1])
+			}
 		} else {
-			pgControldataBinary = string(cmdOut[:len(cmdOut)-1])
+			pgControldataBinary = filepath.Join(filepath.Dir(postmasterBin), "pg_controldata")
 		}
 
 		pgControldataOut, err = exec.Command(pgControldataBinary, status.DataDirectory).Output()


### PR DESCRIPTION
Previously we relied on the locate utility to find pg_controldata on the filesystem, but that can be brittle and doesn't work when locate is not installed, like it was observed on Debian/Ubuntu systems, that also don't have Postgres binaries in the PATH with the PGDG packages.

Instead, use the directory the postmaster executable is located in as the assumed location of the pg_controldata binary.

This fixes cluster ID detection (via the Postgres system identifier) for a typical PGDG-based Debian/Ubuntu install.