### PR TITLE
Add new configuration setting to require WebSockets, default off for now

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -241,6 +241,9 @@ type ServerConfig struct {
 	HTTPClient          *http.Client
 	HTTPClientWithRetry *http.Client
 
+	// Require WebSocket connection (if false, will try WebSocket but fall back to legacy HTTPS API)
+	APIRequireWebsocket bool `ini:"api_require_websocket"`
+
 	// WebSocket URL to be used for API WebSocket connection
 	WebSocketUrl string
 

--- a/config/read.go
+++ b/config/read.go
@@ -391,6 +391,9 @@ func getDefaultConfig() *ServerConfig {
 	if noProxy := os.Getenv("no_proxy"); noProxy != "" {
 		config.NoProxy = noProxy
 	}
+	if apiRequireWebSocket := os.Getenv("API_REQUIRE_WEBSOCKET"); apiRequireWebSocket != "" {
+		config.APIRequireWebsocket = parseConfigBool(apiRequireWebSocket)
+	}
 
 	return config
 }

--- a/output/grant.go
+++ b/output/grant.go
@@ -31,6 +31,9 @@ func EnsureGrant(ctx context.Context, server *state.Server, opts state.Collectio
 	err := server.WebSocket.Connect()
 	if err != nil {
 		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectWebSocket, "error starting WebSocket: %s", err)
+		if server.Config.APIRequireWebsocket {
+			return fmt.Errorf("Error starting WebSocket: %w", err)
+		}
 	} else {
 		// Wait for initial config so we don't incorrectly use an HTTP-based grant
 		ok := waitWithTimeout(ctx, server.InitialConfigReceived, 1*time.Second)
@@ -40,6 +43,9 @@ func EnsureGrant(ctx context.Context, server *state.Server, opts state.Collectio
 			return nil
 		} else {
 			server.SelfTest.MarkCollectionAspectError(state.CollectionAspectWebSocket, "error starting WebSocket: initial configuration not received in time")
+			if server.Config.APIRequireWebsocket {
+				return fmt.Errorf("Error starting WebSocket: initial configuration not received in time")
+			}
 		}
 	}
 

--- a/output/upload.go
+++ b/output/upload.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/zlib"
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -100,6 +101,8 @@ func uploadViaWebsocketOrHttp(ctx context.Context, server *state.Server, logger 
 	if server.WebSocket.Connected() {
 		logger.PrintVerbose("Uploading snapshot to websocket")
 		server.WebSocket.Write <- compressedData.Bytes()
+	} else if server.Config.APIRequireWebsocket {
+		return errors.New("Error uploading snapshot: WebSocket not connected")
 	} else {
 		s3Location, err := uploadSnapshot(ctx, server.Config.HTTPClientWithRetry, server.Grant.Load(), logger, compressedData.Bytes(), snapshotUUID)
 		if err != nil {


### PR DESCRIPTION
This introduces a new setting "api_require_websocket" / "API_REQUIRE_WEBSOCKET" that requires the Snapshot API connection to go over the newer WebSocket API instead of the legacy HTTPS API.

The WebSocket API is geared towards long-lived connections (lower overhead) and allows the server side to push down requests, like for running EXPLAIN on-demand as part of the opt-in collector workflow for Workbooks.

We are currently planning to change the default value of this to "on" in a future collector release. Currently this defaults to "off" which is the same behaviour as before (try WebSocket, but allow HTTPS fallback).