### PR TITLE
Log event redaction: Fix off-by-one error when redacting full lines

### DIFF
--- a/logs/replace.go
+++ b/logs/replace.go
@@ -25,7 +25,7 @@ func ReplaceSecrets(logLines []state.LogLine, filterLogSecret []state.LogSecretK
 				return logLine.SecretMarkers[i].ByteStart < logLine.SecretMarkers[j].ByteEnd
 			})
 			content := []byte(logLine.Content)
-			bytesChecked := 0
+			bytesChecked := -1
 			offset := 0
 			for _, m := range logLine.SecretMarkers {
 				for _, k := range filterLogSecret {

--- a/logs/replace_test.go
+++ b/logs/replace_test.go
@@ -35,6 +35,11 @@ var replaceTests = []replaceTestpair{
 		output:          "duration: 2007.111 ms  plan:\n[redacted]\n",
 	},
 	{
+		filterLogSecret: "statement_text",
+		input:           "2025-12-03 07:31:44 UTC:1.1.1.1(123):myuser@mydb:[123]:ERROR:  canceling statement due to statement timeout\n2025-12-03 07:31:44 UTC:1.1.1.1(123):myuser@mydb:[123]:STATEMENT:  SELECT 1\n",
+		output:          "canceling statement due to statement timeout\n[redacted]",
+	},
+	{
 		filterLogSecret: "statement_parameter",
 		input:           "2018-03-11 20:00:02 UTC:1.1.1.1(2):a@b:[3]:LOG:  duration: 4079.697 ms  execute <unnamed>: \nSELECT * FROM x WHERE y = $1 LIMIT $2\n2018-03-11 20:00:02 UTC:1.1.1.1(2):a@b:[3]:DETAIL:  parameters: $1 = 'long string', $2 = '1', $3 = 'long string'\n",
 		output:          "duration: 4079.697 ms  execute <unnamed>: \nSELECT * FROM x WHERE y = $1 LIMIT $2\nparameters: $1 = '[redacted]', $2 = '[redacted]', $3 = '[redacted]'\n",


### PR DESCRIPTION
This caused log lines where the full line should be redacted (as is typically the case with STATEMENT lines when using log filtering) to not be redacted correctly.