### PR TITLE
Add vector OTLP export config example to contrib/vector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,20 @@ jobs:
         make test
         DOCKER_BUILDKIT=1 make integration_test
         shellcheck contrib/install.sh
+
+  test_contrib:
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Install vector
+      run: |
+        sudo bash -c "$(curl -L https://setup.vector.dev)"
+        sudo apt-get install vector
+
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Run tests (contrib/vector)
+      run: |
+        make -C contrib/vector test

--- a/contrib/vector/Makefile
+++ b/contrib/vector/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	OUTPUT=`cat cnpg_remap_expected.json` vector test cnpg_remap.yaml cnpg_remap_test.yaml

--- a/contrib/vector/cnpg_remap.yaml
+++ b/contrib/vector/cnpg_remap.yaml
@@ -1,0 +1,93 @@
+# Note: When changing this, also update values.yaml example
+transforms:
+  cnpg_remap:
+    type: remap
+    inputs:
+      - kubernetes_logs
+    source: |
+      structured = parse_json!(.message)
+
+      severity_text = if includes(["emerg", "err", "crit", "alert"], structured.level) {
+          "ERROR"
+        } else if structured.level == "warning" {
+          "WARN"
+        } else if structured.level == "debug" {
+          "DEBUG"
+        } else if includes(["info", "notice"], structured.level) {
+          "INFO"
+        } else {
+          structured.level
+        }
+
+      structuredLogger = del(structured.logger)
+      structuredLevel = del(structured.level)
+
+      podLabels = []
+      for_each(zip(keys!(.kubernetes.pod_labels), values!(.kubernetes.pod_labels))) -> |_index, values| {
+        podLabels = push(podLabels, {
+          "key": values[0],
+          "value": {"stringValue": values[1]}
+        })
+      }
+
+      bodyValues = [
+        {"key": "logger", "value": {"stringValue": structuredLogger }},
+        {"key": "error_severity", "value": {"stringValue": structuredLevel}},
+        {"key": "kubernetes", "value": {
+          "kvlistValue": {
+            "values": [
+              {"key": "namespace_name", "value": {"stringValue": .kubernetes.pod_namespace}},
+              {"key": "pod_name", "value": {"stringValue": .kubernetes.pod_name}},
+              {"key": "labels", "value": { "kvlistValue": { "values": podLabels}}}
+            ]
+          }
+        }}
+      ]
+
+      if structuredLogger == "postgres" {
+        recordValues = []
+        for_each(zip(keys!(structured.record), values!(structured.record))) -> |_index, values| {
+          recordValues = push(recordValues, {
+            "key": values[0],
+            "value": {"stringValue": values[1]}
+          })
+        }
+
+        bodyValues = push(bodyValues, {
+          "key": "record",
+          "value": { "kvlistValue": {"values": recordValues}}
+        })
+      } else {
+        for_each(zip(keys!(structured), values!(structured))) -> |_index, values| {
+          stringValue = if is_string(values[1]) {
+              values[1]
+            } else {
+              encode_json(values[1])
+            }
+
+          bodyValues = push(bodyValues, {
+            "key": values[0],
+            "value": {"stringValue": stringValue}
+          })
+        }
+      }
+
+      output = {
+        "resource": {
+          "attributes": [
+            {"key": "source_type", "value": {"stringValue": .source_type }},
+            {"key": "service.name", "value": {"stringValue": .kubernetes.pod_labels."cnpg.io/cluster" }},
+            {"key": "host.hostname", "value": {"stringValue": .kubernetes.pod_name }}
+          ]
+        },
+        "scopeLogs": [{
+          "logRecords": [{
+            "timeUnixNano": to_unix_timestamp(parse_timestamp!(.timestamp, "%+"), unit: "nanoseconds"),
+            "observedTimeUnixNano": to_unix_timestamp(parse_timestamp!(structured.ts, "%+"), unit: "nanoseconds"),
+            "body": {"kvlistValue": {"values": bodyValues}},
+            "severityText": severity_text
+          }]
+        }]
+      }
+
+      . = output

--- a/contrib/vector/cnpg_remap_expected.json
+++ b/contrib/vector/cnpg_remap_expected.json
@@ -1,0 +1,224 @@
+{
+    "resource": {
+        "attributes": [
+            {
+                "key": "source_type",
+                "value": {
+                    "stringValue": "kubernetes_logs"
+                }
+            },
+            {
+                "key": "service.name",
+                "value": {
+                    "stringValue": "cluster-test1"
+                }
+            },
+            {
+                "key": "host.hostname",
+                "value": {
+                    "stringValue": "cluster-test1-1"
+                }
+            }
+        ]
+    },
+    "scopeLogs": [
+        {
+            "logRecords": [
+                {
+                    "body": {
+                        "kvlistValue": {
+                            "values": [
+                                {
+                                    "key": "logger",
+                                    "value": {
+                                        "stringValue": "postgres"
+                                    }
+                                },
+                                {
+                                    "key": "error_severity",
+                                    "value": {
+                                        "stringValue": "info"
+                                    }
+                                },
+                                {
+                                    "key": "kubernetes",
+                                    "value": {
+                                        "kvlistValue": {
+                                            "values": [
+                                                {
+                                                    "key": "namespace_name",
+                                                    "value": {
+                                                        "stringValue": "default"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "pod_name",
+                                                    "value": {
+                                                        "stringValue": "cluster-test1-1"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "labels",
+                                                    "value": {
+                                                        "kvlistValue": {
+                                                            "values": [
+                                                                {
+                                                                    "key": "cnpg.io/cluster",
+                                                                    "value": {
+                                                                        "stringValue": "cluster-test1"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "key": "cnpg.io/instanceName",
+                                                                    "value": {
+                                                                        "stringValue": "cluster-test1-1"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "key": "cnpg.io/instanceRole",
+                                                                    "value": {
+                                                                        "stringValue": "primary"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "key": "cnpg.io/podRole",
+                                                                    "value": {
+                                                                        "stringValue": "instance"
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "key": "role",
+                                                                    "value": {
+                                                                        "stringValue": "primary"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
+                                {
+                                    "key": "record",
+                                    "value": {
+                                        "kvlistValue": {
+                                            "values": [
+                                                {
+                                                    "key": "application_name",
+                                                    "value": {
+                                                        "stringValue": "psql"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "backend_type",
+                                                    "value": {
+                                                        "stringValue": "client backend"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "command_tag",
+                                                    "value": {
+                                                        "stringValue": "SELECT"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "connection_from",
+                                                    "value": {
+                                                        "stringValue": "[local]"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "database_name",
+                                                    "value": {
+                                                        "stringValue": "postgres"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "error_severity",
+                                                    "value": {
+                                                        "stringValue": "LOG"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "log_time",
+                                                    "value": {
+                                                        "stringValue": "2025-12-09 00:32:20.822 UTC"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "message",
+                                                    "value": {
+                                                        "stringValue": "duration: 2002.071 ms  plan:\nQuery Text: SELECT pg_sleep(2);\nResult  (cost=0.00..0.01 rows=1 width=4) (actual rows=1.00 loops=1)"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "process_id",
+                                                    "value": {
+                                                        "stringValue": "4003"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "query_id",
+                                                    "value": {
+                                                        "stringValue": "-8886085649470066503"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "session_id",
+                                                    "value": {
+                                                        "stringValue": "69376dbf.fa3"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "session_line_num",
+                                                    "value": {
+                                                        "stringValue": "1"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "session_start_time",
+                                                    "value": {
+                                                        "stringValue": "2025-12-09 00:30:55 UTC"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "sql_state_code",
+                                                    "value": {
+                                                        "stringValue": "00000"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "transaction_id",
+                                                    "value": {
+                                                        "stringValue": "0"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "user_name",
+                                                    "value": {
+                                                        "stringValue": "postgres"
+                                                    }
+                                                },
+                                                {
+                                                    "key": "virtual_transaction_id",
+                                                    "value": {
+                                                        "stringValue": "2/81"
+                                                    }
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "observedTimeUnixNano": 1765240340823314307,
+                    "severityText": "INFO",
+                    "timeUnixNano": 1765240340823517719
+                }
+            ]
+        }
+    ]
+}

--- a/contrib/vector/cnpg_remap_test.yaml
+++ b/contrib/vector/cnpg_remap_test.yaml
@@ -1,0 +1,28 @@
+tests:
+  - name: "Test for cnpg_remap transform"
+    inputs:
+      - insert_at: "cnpg_remap"
+        type: "log"
+        log_fields:
+          kubernetes:
+            pod_labels:
+              cnpg.io/cluster: "cluster-test1"
+              cnpg.io/instanceName: "cluster-test1-1"
+              cnpg.io/instanceRole: "primary"
+              cnpg.io/podRole: "instance"
+              role: "primary"
+            pod_name: "cluster-test1-1"
+            pod_namespace: "default"
+            pod_owner: "Cluster/cluster-test1"
+          message: "{\"level\":\"info\",\"ts\":\"2025-12-09T00:32:20.823314307Z\",\"logger\":\"postgres\",\"msg\":\"record\",\"logging_pod\":\"cluster-test1-1\",\"record\":{\"log_time\":\"2025-12-09 00:32:20.822 UTC\",\"user_name\":\"postgres\",\"database_name\":\"postgres\",\"process_id\":\"4003\",\"connection_from\":\"[local]\",\"session_id\":\"69376dbf.fa3\",\"session_line_num\":\"1\",\"command_tag\":\"SELECT\",\"session_start_time\":\"2025-12-09 00:30:55 UTC\",\"virtual_transaction_id\":\"2/81\",\"transaction_id\":\"0\",\"error_severity\":\"LOG\",\"sql_state_code\":\"00000\",\"message\":\"duration: 2002.071 ms  plan:\\nQuery Text: SELECT pg_sleep(2);\\nResult  (cost=0.00..0.01 rows=1 width=4) (actual rows=1.00 loops=1)\",\"application_name\":\"psql\",\"backend_type\":\"client backend\",\"query_id\":\"-8886085649470066503\"}}"
+          source_type: kubernetes_logs
+          stream: stderr
+          timestamp: "2025-12-09T00:32:20.823517719Z"
+    outputs:
+      - extract_from: "cnpg_remap"
+        conditions:
+          - type: "vrl"
+            source: |
+              expected = parse_json!(get_env_var!("OUTPUT"))
+              assert_eq!(., expected)
+

--- a/contrib/vector/values.yaml
+++ b/contrib/vector/values.yaml
@@ -1,0 +1,175 @@
+# Use this with the vector Helm chart to set up export of CloudNativePG (CNPG)
+# logs from a Kubernetes cluster to a pganalyze-collector running separately.
+#
+# See https://vector.dev/docs/setup/installation/package-managers/helm/
+#
+# !! Make sure to update the sink target uri to your pganalyze-collector's
+#    db_log_otel_server / LOG_OTEL_SERVER listen address below before deploying.
+
+# Each role is created with the following workloads:
+# Agent = DaemonSet
+# Aggregator = StatefulSet
+# Stateless-Aggregator = Deployment
+role: "Agent"
+
+service:
+  enabled: false
+
+# customConfig -- Override Vector's default configs, if used **all** options need to be specified. This section supports
+# using helm templates to populate dynamic values. See Vector's [configuration documentation](https://vector.dev/docs/reference/configuration/)
+# for all options.
+customConfig:
+  data_dir: /vector-data-dir
+  api:
+    enabled: false
+  sources:
+    kubernetes_logs:
+      type: kubernetes_logs
+      exclude_paths_glob_patterns:
+        - "/var/log/pods/kube-system_*/**"
+  sinks:
+    pganalyze:
+      inputs:
+        - cnpg_remap
+      type: opentelemetry
+      protocol:
+        type: http
+        # ! Update this to point to the pganalyze-collector with db_log_otel_server / LOG_OTEL_SERVER configured
+        uri: "http://pganalyze-collector-service:4318/v1/logs"
+        method: post
+        encoding:
+          codec: json
+        framing:
+          method: "character_delimited"
+          character_delimited:
+            delimiter: ","
+        payload_prefix: '{"resourceLogs":'
+        payload_suffix: '}'
+        batch:
+          max_events: 50
+          timeout_secs: 5
+        request:
+          headers:
+            content-type: "application/json"
+  transforms:
+    # Optionally filter source data to only process certain clusters/pods
+    #
+    # The pganalyze-collector itself can also filter using the db_log_otel_k8s_pod / LOG_OTEL_K8S_POD
+    # and db_log_otel_k8s_labels / LOG_OTEL_K8S_LABELS settings, see
+    # https://pganalyze.com/docs/collector/settings#self-managed-servers
+    #
+    # Filtering any clusters/pods not monitored here is recommended to reduce unnecessary log traffic.
+    cnpg_route:
+      type: route
+      inputs:
+        - kubernetes_logs
+      reroute_unmatched: false
+      route:
+        cnpg: |
+          exists(.kubernetes.pod_labels."cnpg.io/cluster") &&
+          exists(.kubernetes.pod_labels."cnpg.io/podRole") &&
+          .kubernetes.pod_labels."cnpg.io/podRole" == "instance" &&
+          ## Optionally filter out replicas
+          # exists(.kubernetes.pod_labels."cnpg.io/instanceRole") &&
+          # .kubernetes.pod_labels."cnpg.io/instanceRole" == "primary" &&
+          includes(
+            [
+              "cluster-test1",
+              "cluster-test2",
+            ],
+            .kubernetes.pod_labels."cnpg.io/cluster"
+          )
+    # Required remapping to OTLP Logs format (JSON encoded), inlining the CNPG jsonlog output
+    #
+    # Copied from cnpg_remap.yaml
+    cnpg_remap:
+      type: remap
+      inputs:
+        - cnpg_route.cnpg
+      source: |
+        structured = parse_json!(.message)
+
+        severity_text = if includes(["emerg", "err", "crit", "alert"], structured.level) {
+            "ERROR"
+          } else if structured.level == "warning" {
+            "WARN"
+          } else if structured.level == "debug" {
+            "DEBUG"
+          } else if includes(["info", "notice"], structured.level) {
+            "INFO"
+          } else {
+            structured.level
+          }
+
+        structuredLogger = del(structured.logger)
+        structuredLevel = del(structured.level)
+
+        podLabels = []
+        for_each(zip(keys!(.kubernetes.pod_labels), values!(.kubernetes.pod_labels))) -> |_index, values| {
+          podLabels = push(podLabels, {
+            "key": values[0],
+            "value": {"stringValue": values[1]}
+          })
+        }
+
+        bodyValues = [
+          {"key": "logger", "value": {"stringValue": structuredLogger }},
+          {"key": "error_severity", "value": {"stringValue": structuredLevel}},
+          {"key": "kubernetes", "value": {
+            "kvlistValue": {
+              "values": [
+                {"key": "namespace_name", "value": {"stringValue": .kubernetes.pod_namespace}},
+                {"key": "pod_name", "value": {"stringValue": .kubernetes.pod_name}},
+                {"key": "labels", "value": { "kvlistValue": { "values": podLabels}}}
+              ]
+            }
+          }}
+        ]
+
+        if structuredLogger == "postgres" {
+          recordValues = []
+          for_each(zip(keys!(structured.record), values!(structured.record))) -> |_index, values| {
+            recordValues = push(recordValues, {
+              "key": values[0],
+              "value": {"stringValue": values[1]}
+            })
+          }
+
+          bodyValues = push(bodyValues, {
+            "key": "record",
+            "value": { "kvlistValue": {"values": recordValues}}
+          })
+        } else {
+          for_each(zip(keys!(structured), values!(structured))) -> |_index, values| {
+            stringValue = if is_string(values[1]) {
+                values[1]
+              } else {
+                encode_json(values[1])
+              }
+
+            bodyValues = push(bodyValues, {
+              "key": values[0],
+              "value": {"stringValue": stringValue}
+            })
+          }
+        }
+
+        output = {
+          "resource": {
+            "attributes": [
+              {"key": "source_type", "value": {"stringValue": .source_type }},
+              {"key": "service.name", "value": {"stringValue": .kubernetes.pod_labels."cnpg.io/cluster" }},
+              {"key": "host.hostname", "value": {"stringValue": .kubernetes.pod_name }}
+            ]
+          },
+          "scopeLogs": [{
+            "logRecords": [{
+              "timeUnixNano": to_unix_timestamp(parse_timestamp!(.timestamp, "%+"), unit: "nanoseconds"),
+              "observedTimeUnixNano": to_unix_timestamp(parse_timestamp!(structured.ts, "%+"), unit: "nanoseconds"),
+              "body": {"kvlistValue": {"values": bodyValues}},
+              "severityText": severity_text
+            }]
+          }]
+        }
+
+        . = output


### PR DESCRIPTION
Based on a config snippet shared by Rauan Mayemir: https://github.com/pganalyze/collector/pull/711#issuecomment-2948706273

Refined to map kubernetes resource information into the log record (matching the format we see from Fluentbit), and adding a vector unit test for the VRL transformation script.