### PR TITLE
PlanetScale: Infer actual database username by dropping branch suffix

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -458,7 +458,7 @@ func (config ServerConfig) GetDbPortOrDefault() int {
 	return port
 }
 
-// GetDbUsername - Gets the database hostname from the given configuration
+// GetDbUsername - Gets the original database username from the given configuration
 func (config ServerConfig) GetDbUsername() string {
 	if config.DbURL != "" {
 		u, err := url.Parse(config.DbURL)
@@ -471,6 +471,23 @@ func (config ServerConfig) GetDbUsername() string {
 	}
 
 	return config.DbUsername
+}
+
+// GetEffectiveDbUsername - Gets the effective database username from the given configuration
+//
+// This takes into account any remapping that needs to happen for providers that use an
+// intermediary proxy with special username suffixes.
+func (config ServerConfig) GetEffectiveDbUsername() string {
+	username := config.GetDbUsername()
+	if config.SystemType == "planetscale" {
+		parts := strings.Split(username, ".")
+		if len(parts) > 1 {
+			parts = parts[:len(parts)-1]
+			username = strings.Join(parts, ".")
+		}
+	}
+
+	return username
 }
 
 // GetDbName - Gets the database name from the given configuration

--- a/input/postgres/collection.go
+++ b/input/postgres/collection.go
@@ -67,7 +67,7 @@ func NewCollection(ctx context.Context, logger *util.Logger, server *state.Serve
 	for _, role := range roles {
 		roleByName[role.Name] = role
 	}
-	collectorRole := roleByName[server.Config.GetDbUsername()]
+	collectorRole := roleByName[server.Config.GetEffectiveDbUsername()]
 	connectedAsSuperUser := collectorRole.SuperUser || collectorRole.CloudSuperUser
 	connectedAsMonitoringRole := collectorRole.MonitoringUser
 

--- a/input/system/heroku/logs.go
+++ b/input/system/heroku/logs.go
@@ -200,7 +200,7 @@ func setupLogTransformer(ctx context.Context, wg *sync.WaitGroup, servers []*sta
 					continue
 				}
 
-				logLine.Username = server.Config.GetDbUsername()
+				logLine.Username = server.Config.GetEffectiveDbUsername()
 				logLine.Database = server.Config.GetDbName()
 				out <- state.ParsedLogStreamItem{Identifier: server.Config.Identifier, LogLine: *logLine}
 			}

--- a/output/transform/logs.go
+++ b/output/transform/logs.go
@@ -27,7 +27,7 @@ func transformPostgresQuerySamples(server *state.Server, s snapshot.CompactLogSn
 		}
 
 		if sampleIn.Username == "" {
-			sampleIn.Username = server.Config.GetDbUsername()
+			sampleIn.Username = server.Config.GetEffectiveDbUsername()
 		}
 
 		if sampleIn.Database == "" {


### PR DESCRIPTION
This is necessary for monitoring user checks to work as expected.