### PR TITLE
Allow IAM authentication to use private service connect (PSC) endpoint 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -115,6 +115,7 @@ type ServerConfig struct {
 	GcpCredentialsFile    string `ini:"gcp_credentials_file"`
 	GcpRegion             string `ini:"gcp_region"`
 	GcpUsePublicIP        bool   `ini:"gcp_use_public_ip"`
+	GcpUsePSC             bool   `ini:"gcp_use_psc"`
 
 	CrunchyBridgeClusterID string `ini:"crunchy_bridge_cluster_id"`
 	CrunchyBridgeAPIKey    string `ini:"crunchy_bridge_api_key"`

--- a/config/read.go
+++ b/config/read.go
@@ -261,6 +261,9 @@ func getDefaultConfig() *ServerConfig {
 	if gcpUsePublicIp := os.Getenv("GCP_USE_PUBLIC_IP"); gcpUsePublicIp != "" {
 		config.GcpUsePublicIP = parseConfigBool(gcpUsePublicIp)
 	}
+	if gcpUsePSC := os.Getenv("GCP_USE_PSC"); gcpUsePSC != "" {
+		config.GcpUsePSC = parseConfigBool(gcpUsePSC)
+	}
 	if crunchyBridgeClusterID := os.Getenv("CRUNCHY_BRIDGE_CLUSTER_ID"); crunchyBridgeClusterID != "" {
 		config.CrunchyBridgeClusterID = crunchyBridgeClusterID
 	}

--- a/input/postgres/establish_connection.go
+++ b/input/postgres/establish_connection.go
@@ -72,14 +72,18 @@ func connectToDb(ctx context.Context, config config.ServerConfig, logger *util.L
 			} else {
 				if config.GcpCloudSQLInstanceID != "" {
 					hostOverride = strings.Join([]string{config.GcpProjectID, config.GcpRegion, config.GcpCloudSQLInstanceID}, ":")
-					if config.GcpUsePublicIP {
+					if config.GcpUsePSC {
+						driverName = "cloudsql-postgres-psc"
+					} else if config.GcpUsePublicIP {
 						driverName = "cloudsql-postgres-public"
 					} else {
 						driverName = "cloudsql-postgres"
 					}
 				} else if config.GcpAlloyDBClusterID != "" && config.GcpAlloyDBInstanceID != "" {
 					hostOverride = fmt.Sprintf("projects/%s/locations/%s/clusters/%s/instances/%s", config.GcpProjectID, config.GcpRegion, config.GcpAlloyDBClusterID, config.GcpAlloyDBInstanceID)
-					if config.GcpUsePublicIP {
+					if config.GcpUsePSC {
+						driverName = "alloydb-postgres-psc"
+					} else if config.GcpUsePublicIP {
 						driverName = "alloydb-postgres-public"
 					} else {
 						driverName = "alloydb-postgres"

--- a/runner/run.go
+++ b/runner/run.go
@@ -36,8 +36,10 @@ func Run(ctx context.Context, wg *sync.WaitGroup, opts state.CollectionOpts, log
 	shutdown = func() {}
 	var driverCleanup func() error
 	var driverCleanupPublic func() error
+	var driverCleanupPsc func() error
 	var driverCleanupAlloyDb func() error
 	var driverCleanupPublicAlloyDb func() error
+	var driverCleanupPscAlloyDb func() error
 
 	scheduler, err := scheduler.GetScheduler()
 	if err != nil {
@@ -90,6 +92,17 @@ func Run(ctx context.Context, wg *sync.WaitGroup, opts state.CollectionOpts, log
 			}
 		}
 
+		if cfg.DbUseIamAuth && cfg.SystemType == "google_cloudsql" && cfg.GcpCloudSQLInstanceID != "" && cfg.GcpUsePSC && driverCleanupPsc == nil {
+			driverCleanupPsc, err = cloudsql_pgxv5.RegisterDriver("cloudsql-postgres-psc", cloudsqlconn.WithIAMAuthN(),
+				cloudsqlconn.WithDefaultDialOptions(cloudsqlconn.WithPSC()),
+			)
+
+			if err != nil {
+				logger.PrintError("Failed to register cloudsql-postgres-psc driver: %s", err)
+				return
+			}
+		}
+
 		if cfg.DbUseIamAuth && cfg.SystemType == "google_cloudsql" && cfg.GcpAlloyDBClusterID != "" && driverCleanupAlloyDb == nil {
 			driverCleanupAlloyDb, err = alloydb_pgxv5.RegisterDriver("alloydb-postgres", alloydbconn.WithIAMAuthN())
 
@@ -106,6 +119,17 @@ func Run(ctx context.Context, wg *sync.WaitGroup, opts state.CollectionOpts, log
 
 			if err != nil {
 				logger.PrintError("Failed to register alloydb-postgres-public driver: %s", err)
+				return
+			}
+		}
+
+		if cfg.DbUseIamAuth && cfg.SystemType == "google_cloudsql" && cfg.GcpAlloyDBClusterID != "" && cfg.GcpUsePSC && driverCleanupPscAlloyDb == nil {
+			driverCleanupPscAlloyDb, err = alloydb_pgxv5.RegisterDriver("alloydb-postgres-psc", alloydbconn.WithIAMAuthN(),
+				alloydbconn.WithDefaultDialOptions(alloydbconn.WithPSC()),
+			)
+
+			if err != nil {
+				logger.PrintError("Failed to register alloydb-postgres-psc driver: %s", err)
 				return
 			}
 		}


### PR DESCRIPTION
As currently available, if a user enables IAM authentication, the Google SDK can only find the private IP address of the server, not the PSC endpoint if configured. There is also not currently a way to programmatically determine PSC since it requires user-specific configuration of DNS entries ahead of time. Therefore, allowing a specific configuration variable is the most straightforward path to allowing IAM with PSC.

PR Notes:
- [PR 793](https://github.com/pganalyze/collector/pull/793) will need to be modified once this is merged.
- This fix has been provided and tested with at least one active customer in a PoC environment after all required setup was done (DNS entries, etc.)