### PR TITLE
WIP: Replace prepare statements with plain queries

### DIFF
--- a/input/postgres/backend_counts.go
+++ b/input/postgres/backend_counts.go
@@ -27,14 +27,7 @@ func GetBackendCounts(ctx context.Context, c *Collection, db *sql.DB) ([]state.P
 		sourceTable = "pg_catalog.pg_stat_activity"
 	}
 
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+fmt.Sprintf(backendCountsSQL, sourceTable))
-	if err != nil {
-		return nil, err
-	}
-
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+fmt.Sprintf(backendCountsSQL, sourceTable))
 	if err != nil {
 		return nil, err
 	}

--- a/input/postgres/backends.go
+++ b/input/postgres/backends.go
@@ -47,14 +47,7 @@ func GetBackends(ctx context.Context, c *Collection, db *sql.DB) ([]state.Postgr
 		sourceTable = "pg_catalog.pg_stat_activity"
 	}
 
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+fmt.Sprintf(activitySQL, blockingPidsField, queryIdField, sourceTable))
-	if err != nil {
-		return nil, err
-	}
-
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+fmt.Sprintf(activitySQL, blockingPidsField, queryIdField, sourceTable))
 	if err != nil {
 		return nil, err
 	}

--- a/input/postgres/buffer_cache.go
+++ b/input/postgres/buffer_cache.go
@@ -57,13 +57,7 @@ func GetBufferCache(ctx context.Context, server *state.Server, logger *util.Logg
 		return
 	}
 
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+fmt.Sprintf(bufferCacheSQL, schemaName))
-	if err != nil {
-		logger.PrintError("GetBufferCache: %s", err)
-		return
-	}
-	defer stmt.Close()
-	rows, err := stmt.QueryContext(ctx)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+fmt.Sprintf(bufferCacheSQL, schemaName))
 	if err != nil {
 		logger.PrintError("GetBufferCache: %s", err)
 		return

--- a/input/postgres/databases.go
+++ b/input/postgres/databases.go
@@ -30,14 +30,7 @@ FROM pg_catalog.pg_database d
 	ON d.oid = sd.datid`
 
 func GetDatabases(ctx context.Context, db *sql.DB) ([]state.PostgresDatabase, state.PostgresDatabaseStatsMap, error) {
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+databasesSQL)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+databasesSQL)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/input/postgres/extensions.go
+++ b/input/postgres/extensions.go
@@ -16,14 +16,7 @@ SELECT extname,
 	 `
 
 func GetExtensions(ctx context.Context, db *sql.DB, currentDatabaseOid state.Oid) ([]state.PostgresExtension, error) {
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+extensionsSQL)
-	if err != nil {
-		return nil, err
-	}
-
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+extensionsSQL)
 	if err != nil {
 		return nil, err
 	}

--- a/input/postgres/functions.go
+++ b/input/postgres/functions.go
@@ -71,14 +71,7 @@ func GetFunctions(ctx context.Context, logger *util.Logger, db *sql.DB, postgres
 		systemCatalogFilter = relationSQLdefaultSystemCatalogFilter
 	}
 
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+fmt.Sprintf(functionsSQL, kindFields, systemCatalogFilter))
-	if err != nil {
-		return nil, err
-	}
-
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx, ignoreRegexp)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+fmt.Sprintf(functionsSQL, kindFields, systemCatalogFilter), ignoreRegexp)
 	if err != nil {
 		return nil, err
 	}
@@ -139,14 +132,7 @@ func GetFunctionStats(ctx context.Context, db *sql.DB, postgresVersion state.Pos
 		systemCatalogFilter = relationSQLdefaultSystemCatalogFilter
 	}
 
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+fmt.Sprintf(functionStatsSQL, systemCatalogFilter))
-	if err != nil {
-		err = fmt.Errorf("FunctionStats/Prepare: %s", err)
-		return
-	}
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx, ignoreRegexp)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+fmt.Sprintf(functionStatsSQL, systemCatalogFilter), ignoreRegexp)
 	if err != nil {
 		err = fmt.Errorf("FunctionStats/Query: %s", err)
 		return

--- a/input/postgres/plans.go
+++ b/input/postgres/plans.go
@@ -90,14 +90,7 @@ func GetPlans(ctx context.Context, c *Collection, db *sql.DB, showtext bool) (st
 		querySql = fmt.Sprintf(statPlanSQL, extSchema, showtext)
 	}
 
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+querySql)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+querySql)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/input/postgres/relation_column_stats.go
+++ b/input/postgres/relation_column_stats.go
@@ -56,13 +56,7 @@ func GetColumnStats(ctx context.Context, c *Collection, db *sql.DB, dbName strin
 		}
 	}
 
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+fmt.Sprintf(columnStatsSQL, sourceTable))
-	if err != nil {
-		return nil, err
-	}
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+fmt.Sprintf(columnStatsSQL, sourceTable))
 	if err != nil {
 		return nil, err
 	}

--- a/input/postgres/relation_stats.go
+++ b/input/postgres/relation_stats.go
@@ -179,14 +179,7 @@ func GetRelationStats(ctx context.Context, c *Collection, db *sql.DB, currentDat
 		systemCatalogFilter = relationSQLdefaultSystemCatalogFilter
 	}
 
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+fmt.Sprintf(relationStatsSQL, insertsSinceVacuumField, systemCatalogFilter))
-	if err != nil {
-		err = fmt.Errorf("RelationStats/Prepare: %s", err)
-		return
-	}
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx, c.Config.IgnoreSchemaRegexp)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+fmt.Sprintf(relationStatsSQL, insertsSinceVacuumField, systemCatalogFilter), c.Config.IgnoreSchemaRegexp)
 	if err != nil {
 		err = fmt.Errorf("RelationStats/Query: %s", err)
 		return
@@ -242,14 +235,7 @@ func GetRelationStats(ctx context.Context, c *Collection, db *sql.DB, currentDat
 }
 
 func GetIndexStats(ctx context.Context, c *Collection, db *sql.DB, currentDatabaseOid state.Oid, ts state.TransientState) (indexStats state.PostgresIndexStatsMap, err error) {
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+indexStatsSQL)
-	if err != nil {
-		err = fmt.Errorf("IndexStats/Prepare: %s", err)
-		return
-	}
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx, c.Config.IgnoreSchemaRegexp)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+indexStatsSQL, c.Config.IgnoreSchemaRegexp)
 	if err != nil {
 		err = fmt.Errorf("IndexStats/Query: %s", err)
 		return

--- a/input/postgres/relation_stats_aux.go
+++ b/input/postgres/relation_stats_aux.go
@@ -30,13 +30,7 @@ func handleRelationStatsAux(ctx context.Context, c *Collection, db *sql.DB, relS
 		return relStats, nil
 	}
 
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+citusRelationSizeSQL)
-	if err != nil {
-		return relStats, fmt.Errorf("RelationStatsExt/Prepare: %s", err)
-	}
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx, c.Config.IgnoreSchemaRegexp)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+citusRelationSizeSQL, c.Config.IgnoreSchemaRegexp)
 	if err != nil {
 		return relStats, fmt.Errorf("RelationStatsExt/Query: %s", err)
 	}
@@ -120,13 +114,7 @@ func handleIndexStatsAux(ctx context.Context, c *Collection, db *sql.DB, idxStat
 		return idxStats, nil
 	}
 
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+citusIndexSizeSQL)
-	if err != nil {
-		return idxStats, fmt.Errorf("IndexStatsExt/Prepare: %s", err)
-	}
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx, c.Config.IgnoreSchemaRegexp)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+citusIndexSizeSQL, c.Config.IgnoreSchemaRegexp)
 	if err != nil {
 		return idxStats, fmt.Errorf("IndexStatsExt/Query: %s", err)
 	}

--- a/input/postgres/relation_stats_ext.go
+++ b/input/postgres/relation_stats_ext.go
@@ -70,13 +70,7 @@ func GetRelationStatsExtended(ctx context.Context, c *Collection, db *sql.DB, db
 		}
 	}
 
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+fmt.Sprintf(extendedStatisticsSQL, exprsField, inheritedField, sourceTable))
-	if err != nil {
-		return nil, err
-	}
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx, c.Config.IgnoreSchemaRegexp)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+fmt.Sprintf(extendedStatisticsSQL, exprsField, inheritedField, sourceTable), c.Config.IgnoreSchemaRegexp)
 	if err != nil {
 		return nil, err
 	}

--- a/input/postgres/settings.go
+++ b/input/postgres/settings.go
@@ -31,15 +31,7 @@ SELECT DISTINCT ON (name)
  ORDER BY name, CASE source WHEN 'default' THEN 1 ELSE 0 END`
 
 func GetSettings(ctx context.Context, db *sql.DB) ([]state.PostgresSetting, error) {
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+settingsSQL)
-	if err != nil {
-		err = fmt.Errorf("Settings/Prepare: %s", err)
-		return nil, err
-	}
-
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+settingsSQL)
 	if err != nil {
 		err = fmt.Errorf("Settings/Query: %s", err)
 		return nil, err

--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -140,13 +140,7 @@ func GetStatementStats(ctx context.Context, c *Collection, db *sql.DB) (state.Po
 	}
 
 	querySql := QueryMarkerSQL + fmt.Sprintf(statementStatsSQL, topLevelField, totalTimeField, ioTimeFields, optionalFields, sourceTable)
-	stmt, err := db.PrepareContext(ctx, querySql)
-	if err != nil {
-		return nil, err
-	}
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx)
+	rows, err := db.QueryContext(ctx, querySql)
 	if err != nil {
 		return nil, err
 	}
@@ -199,13 +193,7 @@ func GetStatementTexts(ctx context.Context, c *Collection, db *sql.DB) (statemen
 	}
 
 	querySql := QueryMarkerSQL + fmt.Sprintf(statementTextSQL, topLevelField, sourceTable)
-	stmt, err := db.PrepareContext(ctx, querySql)
-	if err != nil {
-		return
-	}
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx)
+	rows, err := db.QueryContext(ctx, querySql)
 	if err != nil {
 		return
 	}

--- a/input/postgres/types.go
+++ b/input/postgres/types.go
@@ -45,13 +45,7 @@ func GetTypes(ctx context.Context, c *Collection, db *sql.DB, currentDatabaseOid
 		systemCatalogFilter = relationSQLdefaultSystemCatalogFilter
 	}
 
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+fmt.Sprintf(typesSQL, systemCatalogFilter))
-	if err != nil {
-		return nil, err
-	}
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+fmt.Sprintf(typesSQL, systemCatalogFilter))
 	if err != nil {
 		return nil, err
 	}

--- a/input/postgres/vacuum_progress.go
+++ b/input/postgres/vacuum_progress.go
@@ -88,14 +88,7 @@ func GetVacuumProgress(ctx context.Context, c *Collection, db *sql.DB) ([]state.
 	}
 	sql = fmt.Sprintf(vacuumProgressSQLDefault, activitySourceTable, fields, vacuumSourceTable)
 
-	stmt, err := db.PrepareContext(ctx, QueryMarkerSQL+sql)
-	if err != nil {
-		return nil, err
-	}
-
-	defer stmt.Close()
-
-	rows, err := stmt.QueryContext(ctx, c.Config.IgnoreSchemaRegexp)
+	rows, err := db.QueryContext(ctx, QueryMarkerSQL+sql, c.Config.IgnoreSchemaRegexp)
 	if err != nil {
 		return nil, err
 	}

--- a/runner/run.go
+++ b/runner/run.go
@@ -66,6 +66,8 @@ func Run(ctx context.Context, wg *sync.WaitGroup, opts state.CollectionOpts, log
 		if cfg.DbUseIamAuth && cfg.SystemType == "google_cloudsql" {
 			if cfg.GcpCloudSQLInstanceID != "" {
 				needsIAMCloudSQL = true
+				prefixedLogger.PrintInfo("Cloud SQL IAM auth enabled (instance: %s, use_public_ip: %v, use_psc: %v)",
+					cfg.GcpCloudSQLInstanceID, cfg.GcpUsePublicIP, cfg.GcpUsePSC)
 			}
 			if cfg.GcpAlloyDBClusterID != "" {
 				needsIAMAlloyDB = true

--- a/util/pgxdriver/pgxdriver.go
+++ b/util/pgxdriver/pgxdriver.go
@@ -41,7 +41,7 @@ func (p *pgxDriver) dbURI(name string) (string, error) {
 	}
 	instConnName := config.Config.Host
 	config.Config.Host = "localhost"
-	config.DefaultQueryExecMode = pgx.QueryExecModeExec
+	config.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
 	config.DialFunc = func(ctx context.Context, _, _ string) (net.Conn, error) {
 		return p.dial(ctx, instConnName)
 	}


### PR DESCRIPTION
We're forced to run through a transaction based connection pool, which doesn't support prepared statements due to connections being swapped out between the collector and the database server.

Replace all the explicit prepare/query calls with plain query calls instead.

Not expecting this to be accepted upstream, but its the version we're running internally that's working for us.