### PR TITLE
Improve disk size reporting for Aurora

### DIFF
--- a/input/system/rds/system.go
+++ b/input/system/rds/system.go
@@ -100,7 +100,8 @@ func GetSystemState(server *state.Server, logger *util.Logger) (system state.Sys
 	system.Info.AmazonRds.ParameterApplyStatus = *group.ParameterApplyStatus
 
 	dbInstanceID := *instance.DBInstanceIdentifier
-	cloudWatchReader := awsutil.NewRdsCloudWatchReader(sess, logger, dbInstanceID)
+	dbClusterID := util.StringPtrToString(instance.DBClusterIdentifier)
+	cloudWatchReader := awsutil.NewRdsCloudWatchReader(sess, logger, dbInstanceID, dbClusterID)
 
 	system.Disks = make(state.DiskMap)
 	system.Disks["default"] = state.Disk{
@@ -225,7 +226,7 @@ func GetSystemState(server *state.Server, logger *util.Logger) (system state.Sys
 					usedBytes := uint64(diskPartition.Used * 1024)
 					totalBytes := uint64(diskPartition.Total * 1024)
 					if isAurora {
-						auroraVolumeUsed := uint64(cloudWatchReader.GetRdsIntMetric("VolumeBytesUsed", "Bytes"))
+						auroraVolumeUsed := uint64(cloudWatchReader.GetRdsClusterIntMetric("VolumeBytesUsed", "Bytes"))
 						if auroraVolumeUsed > 0 {
 							usedBytes = auroraVolumeUsed
 						}
@@ -262,7 +263,7 @@ func GetSystemState(server *state.Server, logger *util.Logger) (system state.Sys
 		system.Memory.SwapUsedBytes = uint64(cloudWatchReader.GetRdsIntMetric("SwapUsage", "Bytes"))
 
 		if isAurora {
-			auroraVolumeUsed := uint64(cloudWatchReader.GetRdsIntMetric("VolumeBytesUsed", "Bytes"))
+			auroraVolumeUsed := uint64(cloudWatchReader.GetRdsClusterIntMetric("VolumeBytesUsed", "Bytes"))
 			system.DiskPartitions = make(state.DiskPartitionMap)
 			system.DiskPartitions["/"] = state.DiskPartition{
 				DiskName:   "default",

--- a/input/system/rds/system.go
+++ b/input/system/rds/system.go
@@ -222,21 +222,26 @@ func GetSystemState(server *state.Server, logger *util.Logger) (system state.Sys
 				system.DataDirectoryPartition = "/rdsdbdata"
 				system.DiskPartitions = make(state.DiskPartitionMap)
 
-				for _, diskPartition := range osSnapshot.FileSystems {
-					usedBytes := uint64(diskPartition.Used * 1024)
-					totalBytes := uint64(diskPartition.Total * 1024)
-					if isAurora {
-						auroraVolumeUsed := uint64(cloudWatchReader.GetRdsClusterIntMetric("VolumeBytesUsed", "Bytes"))
-						if auroraVolumeUsed > 0 {
-							usedBytes = auroraVolumeUsed
+				if isAurora {
+					auroraVolumeUsed := cloudWatchReader.GetRdsClusterIntMetric("VolumeBytesUsed")
+					if auroraVolumeUsed >= 0 {
+						for _, diskPartition := range osSnapshot.FileSystems {
+							system.DiskPartitions[diskPartition.MountPoint] = state.DiskPartition{
+								DiskName:      "default",
+								PartitionName: diskPartition.Name,
+								UsedBytes:     uint64(auroraVolumeUsed),
+								TotalBytes:    AuroraMaxStorage,
+							}
 						}
-						totalBytes = AuroraMaxStorage
 					}
-					system.DiskPartitions[diskPartition.MountPoint] = state.DiskPartition{
-						DiskName:      "default",
-						PartitionName: diskPartition.Name,
-						UsedBytes:     usedBytes,
-						TotalBytes:    totalBytes,
+				} else {
+					for _, diskPartition := range osSnapshot.FileSystems {
+						system.DiskPartitions[diskPartition.MountPoint] = state.DiskPartition{
+							DiskName:      "default",
+							PartitionName: diskPartition.Name,
+							UsedBytes:     uint64(diskPartition.Used * 1024),
+							TotalBytes:    uint64(diskPartition.Total * 1024),
+						}
 					}
 				}
 			}
@@ -263,12 +268,14 @@ func GetSystemState(server *state.Server, logger *util.Logger) (system state.Sys
 		system.Memory.SwapUsedBytes = uint64(cloudWatchReader.GetRdsIntMetric("SwapUsage", "Bytes"))
 
 		if isAurora {
-			auroraVolumeUsed := uint64(cloudWatchReader.GetRdsClusterIntMetric("VolumeBytesUsed", "Bytes"))
-			system.DiskPartitions = make(state.DiskPartitionMap)
-			system.DiskPartitions["/"] = state.DiskPartition{
-				DiskName:   "default",
-				UsedBytes:  auroraVolumeUsed,
-				TotalBytes: AuroraMaxStorage,
+			auroraVolumeUsed := cloudWatchReader.GetRdsClusterIntMetric("VolumeBytesUsed")
+			if auroraVolumeUsed >= 0 {
+				system.DiskPartitions = make(state.DiskPartitionMap)
+				system.DiskPartitions["/"] = state.DiskPartition{
+					DiskName:   "default",
+					UsedBytes:  uint64(auroraVolumeUsed),
+					TotalBytes: AuroraMaxStorage,
+				}
 			}
 		} else if instance.AllocatedStorage != nil {
 			bytesTotal := *instance.AllocatedStorage * 1024 * 1024 * 1024

--- a/input/system/rds/system.go
+++ b/input/system/rds/system.go
@@ -13,9 +13,10 @@ import (
 	"github.com/pganalyze/collector/util/awsutil"
 )
 
-// Aurora storage is automatically extended up until 64TB, so we should always
-// report that limit as the total disk space (to avoid bogus disk space warnings)
-const AuroraMaxStorage = 64 * 1024 * 1024 * 1024 * 1024
+// Aurora storage is automatically extended up to 128TB, so report that as
+// total disk space when we can't determine the actual limit from CloudWatch
+// (AuroraVolumeBytesLeftTotal is only available for Aurora MySQL, not PostgreSQL)
+const AuroraMaxStorage = 128 * 1024 * 1024 * 1024 * 1024
 
 // GetSystemState - Gets system information about an Amazon RDS instance
 func GetSystemState(server *state.Server, logger *util.Logger) (system state.SystemState) {
@@ -219,15 +220,21 @@ func GetSystemState(server *state.Server, logger *util.Logger) (system state.Sys
 
 				system.DataDirectoryPartition = "/rdsdbdata"
 				system.DiskPartitions = make(state.DiskPartitionMap)
+
 				for _, diskPartition := range osSnapshot.FileSystems {
+					usedBytes := uint64(diskPartition.Used * 1024)
 					totalBytes := uint64(diskPartition.Total * 1024)
 					if isAurora {
+						auroraVolumeUsed := uint64(cloudWatchReader.GetRdsIntMetric("VolumeBytesUsed", "Bytes"))
+						if auroraVolumeUsed > 0 {
+							usedBytes = auroraVolumeUsed
+						}
 						totalBytes = AuroraMaxStorage
 					}
 					system.DiskPartitions[diskPartition.MountPoint] = state.DiskPartition{
 						DiskName:      "default",
 						PartitionName: diskPartition.Name,
-						UsedBytes:     uint64(diskPartition.Used * 1024),
+						UsedBytes:     usedBytes,
 						TotalBytes:    totalBytes,
 					}
 				}
@@ -254,21 +261,22 @@ func GetSystemState(server *state.Server, logger *util.Logger) (system state.Sys
 		system.Memory.FreeBytes = uint64(cloudWatchReader.GetRdsIntMetric("FreeableMemory", "Bytes"))
 		system.Memory.SwapUsedBytes = uint64(cloudWatchReader.GetRdsIntMetric("SwapUsage", "Bytes"))
 
-		var bytesTotal, bytesFree int64
-		if instance.AllocatedStorage != nil {
-			bytesTotal = *instance.AllocatedStorage * 1024 * 1024 * 1024
-			bytesFree = cloudWatchReader.GetRdsIntMetric("FreeStorageSpace", "Bytes")
-
-			totalBytes := uint64(bytesTotal)
-			if isAurora {
-				totalBytes = AuroraMaxStorage
+		if isAurora {
+			auroraVolumeUsed := uint64(cloudWatchReader.GetRdsIntMetric("VolumeBytesUsed", "Bytes"))
+			system.DiskPartitions = make(state.DiskPartitionMap)
+			system.DiskPartitions["/"] = state.DiskPartition{
+				DiskName:   "default",
+				UsedBytes:  auroraVolumeUsed,
+				TotalBytes: AuroraMaxStorage,
 			}
-
+		} else if instance.AllocatedStorage != nil {
+			bytesTotal := *instance.AllocatedStorage * 1024 * 1024 * 1024
+			bytesFree := cloudWatchReader.GetRdsIntMetric("FreeStorageSpace", "Bytes")
 			system.DiskPartitions = make(state.DiskPartitionMap)
 			system.DiskPartitions["/"] = state.DiskPartition{
 				DiskName:   "default",
 				UsedBytes:  uint64(bytesTotal - bytesFree),
-				TotalBytes: totalBytes,
+				TotalBytes: uint64(bytesTotal),
 			}
 		}
 	}

--- a/input/system/rds/system.go
+++ b/input/system/rds/system.go
@@ -223,15 +223,18 @@ func GetSystemState(server *state.Server, logger *util.Logger) (system state.Sys
 				system.DiskPartitions = make(state.DiskPartitionMap)
 
 				if isAurora {
-					auroraVolumeUsed := cloudWatchReader.GetRdsClusterIntMetric("VolumeBytesUsed")
-					if auroraVolumeUsed >= 0 {
-						for _, diskPartition := range osSnapshot.FileSystems {
-							system.DiskPartitions[diskPartition.MountPoint] = state.DiskPartition{
-								DiskName:      "default",
-								PartitionName: diskPartition.Name,
-								UsedBytes:     uint64(auroraVolumeUsed),
-								TotalBytes:    AuroraMaxStorage,
-							}
+					auroraVolumeUsed := cloudWatchReader.GetRdsClusterIntMetric("VolumeBytesUsed", "Bytes")
+					for _, diskPartition := range osSnapshot.FileSystems {
+						var usedBytes, totalBytes uint64
+						if auroraVolumeUsed >= 0 {
+							usedBytes = uint64(auroraVolumeUsed)
+							totalBytes = AuroraMaxStorage
+						}
+						system.DiskPartitions[diskPartition.MountPoint] = state.DiskPartition{
+							DiskName:      "default",
+							PartitionName: diskPartition.Name,
+							UsedBytes:     usedBytes,
+							TotalBytes:    totalBytes,
 						}
 					}
 				} else {
@@ -268,14 +271,17 @@ func GetSystemState(server *state.Server, logger *util.Logger) (system state.Sys
 		system.Memory.SwapUsedBytes = uint64(cloudWatchReader.GetRdsIntMetric("SwapUsage", "Bytes"))
 
 		if isAurora {
-			auroraVolumeUsed := cloudWatchReader.GetRdsClusterIntMetric("VolumeBytesUsed")
+			auroraVolumeUsed := cloudWatchReader.GetRdsClusterIntMetric("VolumeBytesUsed", "Bytes")
+			system.DiskPartitions = make(state.DiskPartitionMap)
+			var usedBytes, totalBytes uint64
 			if auroraVolumeUsed >= 0 {
-				system.DiskPartitions = make(state.DiskPartitionMap)
-				system.DiskPartitions["/"] = state.DiskPartition{
-					DiskName:   "default",
-					UsedBytes:  uint64(auroraVolumeUsed),
-					TotalBytes: AuroraMaxStorage,
-				}
+				usedBytes = uint64(auroraVolumeUsed)
+				totalBytes = AuroraMaxStorage
+			}
+			system.DiskPartitions["/"] = state.DiskPartition{
+				DiskName:   "default",
+				UsedBytes:  usedBytes,
+				TotalBytes: totalBytes,
 			}
 		} else if instance.AllocatedStorage != nil {
 			bytesTotal := *instance.AllocatedStorage * 1024 * 1024 * 1024

--- a/input/system/rds/system.go
+++ b/input/system/rds/system.go
@@ -225,16 +225,11 @@ func GetSystemState(server *state.Server, logger *util.Logger) (system state.Sys
 				if isAurora {
 					auroraVolumeUsed := cloudWatchReader.GetRdsClusterIntMetric("VolumeBytesUsed", "Bytes")
 					for _, diskPartition := range osSnapshot.FileSystems {
-						var usedBytes, totalBytes uint64
-						if auroraVolumeUsed >= 0 {
-							usedBytes = uint64(auroraVolumeUsed)
-							totalBytes = AuroraMaxStorage
-						}
 						system.DiskPartitions[diskPartition.MountPoint] = state.DiskPartition{
 							DiskName:      "default",
 							PartitionName: diskPartition.Name,
-							UsedBytes:     usedBytes,
-							TotalBytes:    totalBytes,
+							UsedBytes:     uint64(auroraVolumeUsed),
+							TotalBytes:    AuroraMaxStorage,
 						}
 					}
 				} else {
@@ -273,15 +268,10 @@ func GetSystemState(server *state.Server, logger *util.Logger) (system state.Sys
 		if isAurora {
 			auroraVolumeUsed := cloudWatchReader.GetRdsClusterIntMetric("VolumeBytesUsed", "Bytes")
 			system.DiskPartitions = make(state.DiskPartitionMap)
-			var usedBytes, totalBytes uint64
-			if auroraVolumeUsed >= 0 {
-				usedBytes = uint64(auroraVolumeUsed)
-				totalBytes = AuroraMaxStorage
-			}
 			system.DiskPartitions["/"] = state.DiskPartition{
 				DiskName:   "default",
-				UsedBytes:  usedBytes,
-				TotalBytes: totalBytes,
+				UsedBytes:  uint64(auroraVolumeUsed),
+				TotalBytes: AuroraMaxStorage,
 			}
 		} else if instance.AllocatedStorage != nil {
 			bytesTotal := *instance.AllocatedStorage * 1024 * 1024 * 1024

--- a/input/system/rds/system.go
+++ b/input/system/rds/system.go
@@ -14,8 +14,8 @@ import (
 )
 
 // Aurora storage is automatically extended up to 128TB, so report that as
-// total disk space when we can't determine the actual limit from CloudWatch
-// (AuroraVolumeBytesLeftTotal is only available for Aurora MySQL, not PostgreSQL)
+// total disk space since CloudWatch does not expose the actual limit for
+// Aurora PostgreSQL.
 const AuroraMaxStorage = 128 * 1024 * 1024 * 1024 * 1024
 
 // GetSystemState - Gets system information about an Amazon RDS instance
@@ -222,25 +222,22 @@ func GetSystemState(server *state.Server, logger *util.Logger) (system state.Sys
 				system.DataDirectoryPartition = "/rdsdbdata"
 				system.DiskPartitions = make(state.DiskPartitionMap)
 
+				var auroraVolumeUsed int64
 				if isAurora {
-					auroraVolumeUsed := cloudWatchReader.GetRdsClusterIntMetric("VolumeBytesUsed", "Bytes")
-					for _, diskPartition := range osSnapshot.FileSystems {
-						system.DiskPartitions[diskPartition.MountPoint] = state.DiskPartition{
-							DiskName:      "default",
-							PartitionName: diskPartition.Name,
-							UsedBytes:     uint64(auroraVolumeUsed),
-							TotalBytes:    AuroraMaxStorage,
-						}
+					auroraVolumeUsed = cloudWatchReader.GetRdsClusterIntMetric("VolumeBytesUsed", "Bytes")
+				}
+				for _, diskPartition := range osSnapshot.FileSystems {
+					dp := state.DiskPartition{
+						DiskName:      "default",
+						PartitionName: diskPartition.Name,
+						UsedBytes:     uint64(diskPartition.Used * 1024),
+						TotalBytes:    uint64(diskPartition.Total * 1024),
 					}
-				} else {
-					for _, diskPartition := range osSnapshot.FileSystems {
-						system.DiskPartitions[diskPartition.MountPoint] = state.DiskPartition{
-							DiskName:      "default",
-							PartitionName: diskPartition.Name,
-							UsedBytes:     uint64(diskPartition.Used * 1024),
-							TotalBytes:    uint64(diskPartition.Total * 1024),
-						}
+					if isAurora && diskPartition.MountPoint == system.DataDirectoryPartition {
+						dp.UsedBytes = uint64(auroraVolumeUsed)
+						dp.TotalBytes = AuroraMaxStorage
 					}
+					system.DiskPartitions[diskPartition.MountPoint] = dp
 				}
 			}
 		}

--- a/util/awsutil/rds.go
+++ b/util/awsutil/rds.go
@@ -181,20 +181,23 @@ func (reader RdsCloudWatchReader) getMetric(metricName string, unit string, dime
 			},
 		},
 	}
+	reader.logger.PrintInfo("CloudWatch request: metric=%s dimension=%s:%s unit=%s", metricName, dimensionName, dimensionValue, unit)
 	resp, err := reader.svc.GetMetricStatistics(params)
 
 	if err != nil {
-		reader.logger.PrintVerbose(err.Error())
+		reader.logger.PrintInfo("CloudWatch error for %s: %s", metricName, err.Error())
 		return 0.0
 	}
 
 	if len(resp.Datapoints) == 0 {
+		reader.logger.PrintInfo("CloudWatch no datapoints for %s (%s:%s)", metricName, dimensionName, dimensionValue)
 		return 0.0
 	}
 
 	val := resp.Datapoints[0].Average
 	if val != nil {
-		return *resp.Datapoints[0].Average
+		reader.logger.PrintInfo("CloudWatch result for %s: %f", metricName, *val)
+		return *val
 	}
 
 	return 0.0

--- a/util/awsutil/rds.go
+++ b/util/awsutil/rds.go
@@ -162,13 +162,14 @@ func (reader RdsCloudWatchReader) GetRdsFloatMetric(metricName string, unit stri
 // dimension. Uses a 1-hour lookback window since Aurora volume metrics like
 // VolumeBytesUsed are reported infrequently (not continuously). Returns -1 if
 // no datapoints are available.
-func (reader RdsCloudWatchReader) GetRdsClusterIntMetric(metricName string) int64 {
+func (reader RdsCloudWatchReader) GetRdsClusterIntMetric(metricName string, unit string) int64 {
 	params := &cloudwatch.GetMetricStatisticsInput{
 		EndTime:    aws.Time(time.Now()),
 		MetricName: aws.String(metricName),
 		Namespace:  aws.String("AWS/RDS"),
 		Period:     aws.Int64(300),
 		StartTime:  aws.Time(time.Now().Add(-1 * time.Hour)),
+		Unit:       aws.String(unit),
 		Statistics: []*string{
 			aws.String("Average"),
 		},

--- a/util/awsutil/rds.go
+++ b/util/awsutil/rds.go
@@ -158,9 +158,49 @@ func (reader RdsCloudWatchReader) GetRdsFloatMetric(metricName string, unit stri
 	return reader.getMetric(metricName, unit, "DBInstanceIdentifier", reader.instance)
 }
 
-// GetRdsClusterIntMetric - Gets an integer value from Cloudwatch using the cluster dimension
-func (reader RdsCloudWatchReader) GetRdsClusterIntMetric(metricName string, unit string) int64 {
-	return int64(reader.getMetric(metricName, unit, "DBClusterIdentifier", reader.cluster))
+// GetRdsClusterIntMetric - Gets an integer value from Cloudwatch using the cluster
+// dimension. Uses a 1-hour lookback window since Aurora volume metrics like
+// VolumeBytesUsed are reported infrequently (not continuously). Returns -1 if
+// no datapoints are available.
+func (reader RdsCloudWatchReader) GetRdsClusterIntMetric(metricName string) int64 {
+	params := &cloudwatch.GetMetricStatisticsInput{
+		EndTime:    aws.Time(time.Now()),
+		MetricName: aws.String(metricName),
+		Namespace:  aws.String("AWS/RDS"),
+		Period:     aws.Int64(300),
+		StartTime:  aws.Time(time.Now().Add(-1 * time.Hour)),
+		Statistics: []*string{
+			aws.String("Average"),
+		},
+		Dimensions: []*cloudwatch.Dimension{
+			{
+				Name:  aws.String("DBClusterIdentifier"),
+				Value: aws.String(reader.cluster),
+			},
+		},
+	}
+	resp, err := reader.svc.GetMetricStatistics(params)
+
+	if err != nil {
+		return -1
+	}
+
+	if len(resp.Datapoints) == 0 {
+		return -1
+	}
+
+	var latest *cloudwatch.Datapoint
+	for _, dp := range resp.Datapoints {
+		if latest == nil || dp.Timestamp.After(*latest.Timestamp) {
+			latest = dp
+		}
+	}
+
+	if latest.Average != nil {
+		return int64(*latest.Average)
+	}
+
+	return -1
 }
 
 func (reader RdsCloudWatchReader) getMetric(metricName string, unit string, dimensionName string, dimensionValue string) float64 {
@@ -181,23 +221,20 @@ func (reader RdsCloudWatchReader) getMetric(metricName string, unit string, dime
 			},
 		},
 	}
-	reader.logger.PrintInfo("CloudWatch request: metric=%s dimension=%s:%s unit=%s", metricName, dimensionName, dimensionValue, unit)
 	resp, err := reader.svc.GetMetricStatistics(params)
 
 	if err != nil {
-		reader.logger.PrintInfo("CloudWatch error for %s: %s", metricName, err.Error())
+		reader.logger.PrintVerbose(err.Error())
 		return 0.0
 	}
 
 	if len(resp.Datapoints) == 0 {
-		reader.logger.PrintInfo("CloudWatch no datapoints for %s (%s:%s)", metricName, dimensionName, dimensionValue)
 		return 0.0
 	}
 
 	val := resp.Datapoints[0].Average
 	if val != nil {
-		reader.logger.PrintInfo("CloudWatch result for %s: %f", metricName, *val)
-		return *val
+		return *resp.Datapoints[0].Average
 	}
 
 	return 0.0

--- a/util/awsutil/rds.go
+++ b/util/awsutil/rds.go
@@ -159,7 +159,7 @@ func (reader RdsCloudWatchReader) GetRdsFloatMetric(metricName string, unit stri
 }
 
 // GetRdsClusterIntMetric - Gets an integer value from Cloudwatch using the cluster
-// dimension. Uses a 1-hour lookback window since Aurora volume metrics like
+// dimension. Uses a 3-hour lookback window since Aurora volume metrics like
 // VolumeBytesUsed are reported infrequently (not continuously). Returns -1 if
 // no datapoints are available.
 func (reader RdsCloudWatchReader) GetRdsClusterIntMetric(metricName string, unit string) int64 {
@@ -168,7 +168,7 @@ func (reader RdsCloudWatchReader) GetRdsClusterIntMetric(metricName string, unit
 		MetricName: aws.String(metricName),
 		Namespace:  aws.String("AWS/RDS"),
 		Period:     aws.Int64(300),
-		StartTime:  aws.Time(time.Now().Add(-1 * time.Hour)),
+		StartTime:  aws.Time(time.Now().Add(-3 * time.Hour)),
 		Unit:       aws.String(unit),
 		Statistics: []*string{
 			aws.String("Average"),

--- a/util/awsutil/rds.go
+++ b/util/awsutil/rds.go
@@ -160,7 +160,7 @@ func (reader RdsCloudWatchReader) GetRdsFloatMetric(metricName string, unit stri
 
 // GetRdsClusterIntMetric - Gets an integer value from Cloudwatch using the cluster
 // dimension. Uses a 3-hour lookback window since Aurora volume metrics like
-// VolumeBytesUsed are reported infrequently (not continuously). Returns -1 if
+// VolumeBytesUsed are reported infrequently (not continuously). Returns 0 if
 // no datapoints are available.
 func (reader RdsCloudWatchReader) GetRdsClusterIntMetric(metricName string, unit string) int64 {
 	params := &cloudwatch.GetMetricStatisticsInput{
@@ -183,11 +183,11 @@ func (reader RdsCloudWatchReader) GetRdsClusterIntMetric(metricName string, unit
 	resp, err := reader.svc.GetMetricStatistics(params)
 
 	if err != nil {
-		return -1
+		return 0
 	}
 
 	if len(resp.Datapoints) == 0 {
-		return -1
+		return 0
 	}
 
 	var latest *cloudwatch.Datapoint
@@ -201,7 +201,7 @@ func (reader RdsCloudWatchReader) GetRdsClusterIntMetric(metricName string, unit
 		return int64(*latest.Average)
 	}
 
-	return -1
+	return 0
 }
 
 func (reader RdsCloudWatchReader) getMetric(metricName string, unit string, dimensionName string, dimensionValue string) float64 {

--- a/util/awsutil/rds.go
+++ b/util/awsutil/rds.go
@@ -140,11 +140,12 @@ func GetRdsParameter(group *rds.DBParameterGroupStatus, name string, svc *rds.RD
 type RdsCloudWatchReader struct {
 	svc      *cloudwatch.CloudWatch
 	instance string
+	cluster  string
 	logger   *util.Logger
 }
 
-func NewRdsCloudWatchReader(sess *session.Session, logger *util.Logger, instance string) RdsCloudWatchReader {
-	return RdsCloudWatchReader{svc: cloudwatch.New(sess), instance: instance, logger: logger}
+func NewRdsCloudWatchReader(sess *session.Session, logger *util.Logger, instance string, cluster string) RdsCloudWatchReader {
+	return RdsCloudWatchReader{svc: cloudwatch.New(sess), instance: instance, cluster: cluster, logger: logger}
 }
 
 // GetRdsIntMetric - Gets an integer value from Cloudwatch
@@ -154,6 +155,15 @@ func (reader RdsCloudWatchReader) GetRdsIntMetric(metricName string, unit string
 
 // GetRdsFloatMetric - Gets a float value from Cloudwatch
 func (reader RdsCloudWatchReader) GetRdsFloatMetric(metricName string, unit string) float64 {
+	return reader.getMetric(metricName, unit, "DBInstanceIdentifier", reader.instance)
+}
+
+// GetRdsClusterIntMetric - Gets an integer value from Cloudwatch using the cluster dimension
+func (reader RdsCloudWatchReader) GetRdsClusterIntMetric(metricName string, unit string) int64 {
+	return int64(reader.getMetric(metricName, unit, "DBClusterIdentifier", reader.cluster))
+}
+
+func (reader RdsCloudWatchReader) getMetric(metricName string, unit string, dimensionName string, dimensionValue string) float64 {
 	params := &cloudwatch.GetMetricStatisticsInput{
 		EndTime:    aws.Time(time.Now()),
 		MetricName: aws.String(metricName),
@@ -166,8 +176,8 @@ func (reader RdsCloudWatchReader) GetRdsFloatMetric(metricName string, unit stri
 		},
 		Dimensions: []*cloudwatch.Dimension{
 			{
-				Name:  aws.String("DBInstanceIdentifier"),
-				Value: aws.String(reader.instance),
+				Name:  aws.String(dimensionName),
+				Value: aws.String(dimensionValue),
 			},
 		},
 	}


### PR DESCRIPTION
Use the `VolumeBytesUsed` CloudWatch metric (queried by `DBClusterIdentifier`) for Aurora instead of the previously inaccurate OS-level filesystem values or `AllocatedStorage`. This was wrongly reporting a few MB storage usage regardless of the actual cluster storage size.
With the `GetRdsClusterIntMetric` function (to obtain `VolumeBytesUsed` metric), use the 3 hours lookback window to retrieve the data reliably (see below for more detail).

In passing, update `AuroraMaxStorage` from 64TB to 128TB to reflect the current Aurora storage limit.

Several notes (likely worth noting this in the UI side):
* Aurora volume metrics like `VolumeBytesUsed` are [reported infrequently](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.AuroraMonitoring.Metrics.html) ("collected at intervals, not continuously"). In testing, a 10-minute window returned no data at all, and a 1-hour window still produced frequent gaps. A 3-hour window reliably returns data. When data is available, we pick the most recent datapoint.
  * This means that the data can be at max 3 hours old, also there might be still gap (will report 0B in that case)
* `VolumeBytesUsed` is only available as a cluster-level metric (dimension: `DBClusterIdentifier`), not per-instance.
  * This means all instances in the same cluster will report the same disk usage

This server is using this branch:
https://staging.pganalyze.com/servers/336fdc7yijartkopql6yerfisy/system/storage?t=24h