### PR TITLE
remove warning when aurora_computer_plan_id is not enabled

### DIFF
--- a/input/postgres/plans.go
+++ b/input/postgres/plans.go
@@ -62,7 +62,7 @@ func GetPlans(ctx context.Context, c *Collection, db *sql.DB, showtext bool) (st
 		// aurora_compute_plan_id needs to be on to use aurora_stat_plans function
 		// 2026-04-30: For now, we've removed guidance in documentation to enable
 		//   this setting because of potential LWLock:pg_stat_statement locking/wait
-		//   issues on Aurora Serverless on high-concurrency workloads when it's enabled.
+		//   issues on Amazon Aurora on high-concurrency workloads when it's enabled.
 		//   We'll revisit this in the future when we have more information about the underlying
 		//   issue and potential fixes from AWS.
 

--- a/input/postgres/plans.go
+++ b/input/postgres/plans.go
@@ -60,10 +60,16 @@ func GetPlans(ctx context.Context, c *Collection, db *sql.DB, showtext bool) (st
 			return nil, nil, err
 		}
 		// aurora_compute_plan_id needs to be on to use aurora_stat_plans function
+		// 2026-04-30: For now, we've removed guidance in documentation to enable
+		//   this setting because of potential LWLock:pg_stat_statement locking/wait
+		//   issues on Aurora Serverless on high-concurrency workloads when it's enabled.
+		//   We'll revisit this in the future when we have more information about the underlying
+		//   issue and potential fixes from AWS.
+
 		if computePlanIdEnabled != "on" {
-			if c.GlobalOpts.TestRun {
-				c.Logger.PrintInfo("Function aurora_stat_plans() is not supported because aurora_compute_plan_id is turned off. Skipping collecting query plans and stats.")
-			}
+			// 	if c.GlobalOpts.TestRun {
+			// 		c.Logger.PrintInfo("Function aurora_stat_plans() is not supported because aurora_compute_plan_id is turned off. Skipping collecting query plans and stats.")
+			// 	}
 			return nil, nil, nil
 		}
 


### PR DESCRIPTION
Per recent discussions, removing this informational warning for now. cc: @lfittl 