### PR TITLE
Docker image: Raise alpine/musl stack size from 2MB to 8MB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,10 @@ build_dist:
 	fi
 
 build_dist_alpine:
-	# Increase stack size from Alpine's default of 80kb to 2mb - otherwise we see
-	# crashes on very complex queries, pg_query expects at least 100kb stack size
-	go build -o ${OUTFILE} -ldflags '-extldflags "-Wl,-z,stack-size=0x200000"'
+	# Increase stack size from Alpine's default of 80kb to 8mb (matching glibc's
+	# default main-thread stack set via RLIMIT_STACK) - otherwise we see crashes
+	# on very complex queries.
+	go build -o ${OUTFILE} -ldflags '-extldflags "-Wl,-z,stack-size=0x800000"'
 	make -C helper OUTFILE=../pganalyze-collector-helper
 	make -C setup OUTFILE=../pganalyze-collector-setup
 


### PR DESCRIPTION
This matches what glibc would typically use, and fixes a crash on a very complex query making heavy use of UNION in at least one customer report.