### PR TITLE
Update Go to 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: 1.25
+        go-version: 1.26
       id: go
 
     - name: Set up protoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: 1.25
+        go-version: 1.26
       id: go
 
     - name: Set up protoc
@@ -54,7 +54,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: 1.25
+        go-version: 1.26
       id: go
 
     - name: Set up protoc

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-// +heroku goVersion go1.25
+// +heroku goVersion go1.26
 
 module github.com/pganalyze/collector
 
@@ -114,4 +114,4 @@ require (
 	google.golang.org/grpc v1.80.0 // indirect
 )
 
-go 1.25.0
+go 1.26

--- a/integration_test/Dockerfile.test-citus
+++ b/integration_test/Dockerfile.test-citus
@@ -5,7 +5,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.23.5
+ENV GOVERSION 1.26.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-guided-setup
+++ b/integration_test/Dockerfile.test-guided-setup
@@ -11,7 +11,7 @@ STOPSIGNAL SIGRTMIN+3
 ENTRYPOINT ["/lib/systemd/systemd"]
 CMD ["--log-level=info"]
 
-ENV GOVERSION 1.23.5
+ENV GOVERSION 1.26.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-otel-vector
+++ b/integration_test/Dockerfile.test-otel-vector
@@ -5,7 +5,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.23.5
+ENV GOVERSION 1.26.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg10
+++ b/integration_test/Dockerfile.test-pg10
@@ -5,7 +5,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.23.5
+ENV GOVERSION 1.26.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg11
+++ b/integration_test/Dockerfile.test-pg11
@@ -5,7 +5,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.23.5
+ENV GOVERSION 1.26.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg12
+++ b/integration_test/Dockerfile.test-pg12
@@ -5,7 +5,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.23.5
+ENV GOVERSION 1.26.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg13
+++ b/integration_test/Dockerfile.test-pg13
@@ -5,7 +5,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.23.5
+ENV GOVERSION 1.26.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg14
+++ b/integration_test/Dockerfile.test-pg14
@@ -5,7 +5,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.23.5
+ENV GOVERSION 1.26.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg15
+++ b/integration_test/Dockerfile.test-pg15
@@ -5,7 +5,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.23.5
+ENV GOVERSION 1.26.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg16
+++ b/integration_test/Dockerfile.test-pg16
@@ -5,7 +5,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.23.5
+ENV GOVERSION 1.26.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-pg17
+++ b/integration_test/Dockerfile.test-pg17
@@ -5,7 +5,7 @@ RUN echo en_US.UTF-8 UTF-8 >> /etc/locale.gen
 
 ARG TARGETARCH
 
-ENV GOVERSION 1.23.5
+ENV GOVERSION 1.26.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/integration_test/Dockerfile.test-reload
+++ b/integration_test/Dockerfile.test-reload
@@ -11,7 +11,7 @@ STOPSIGNAL SIGRTMIN+3
 ENTRYPOINT ["/lib/systemd/systemd"]
 CMD ["--log-level=info"]
 
-ENV GOVERSION 1.23.5
+ENV GOVERSION 1.26.3
 ENV CODE_DIR /collector
 ENV PATH $PATH:/usr/local/go/bin
 

--- a/packages/src/Dockerfile.build.deb-systemd
+++ b/packages/src/Dockerfile.build.deb-systemd
@@ -2,7 +2,7 @@ FROM debian:bullseye
 
 ARG TARGETARCH
 ENV GOPATH /go
-ENV GOVERSION 1.23.5
+ENV GOVERSION 1.26.3
 ENV CODE_DIR $GOPATH/src/github.com/pganalyze/collector
 ENV PATH $PATH:/usr/local/go/bin
 ENV ROOT_DIR /root

--- a/packages/src/Dockerfile.build.rpm-systemd
+++ b/packages/src/Dockerfile.build.rpm-systemd
@@ -2,7 +2,7 @@ FROM amazonlinux:2
 
 ARG TARGETARCH
 ENV GOPATH /go
-ENV GOVERSION 1.23.5
+ENV GOVERSION 1.26.3
 ENV CODE_DIR $GOPATH/src/github.com/pganalyze/collector
 ENV PATH $PATH:/usr/local/go/bin
 ENV ROOT_DIR /root


### PR DESCRIPTION
There are some [improvements in this release](https://go.dev/doc/go1.26) that likely improve the collector performance, such as the reduced cgo overhead, and the new garbage collector. Require 1.26 to ensure its consistently used.