### PR TITLE
feat / helm chart: allow passing deployment annotations

### DIFF
--- a/contrib/helm/pganalyze-collector/README.md
+++ b/contrib/helm/pganalyze-collector/README.md
@@ -18,6 +18,7 @@ pganalyze statistics collector
 | configMap.create | bool | `false` | Specifies whether a config map should be created. The config map can be used to set runtime environment variables |
 | configMap.name | string | `""` | The name of the config map to load environment variables from. If not set and create is true, a name is generated using the fullname template |
 | configMap.values | object | `{}` | Values to initialize the ConfigMap with. Only applicable if create is true |
+| deploymentAnnotations | object | `{}` | Annotations to add to the Deployment metadata (not the pod template). Useful for workload controllers like Stakater Reloader that watch workload-level annotations to trigger rolling restarts on ConfigMap/Secret changes. |
 | extraEnv | object | `{}` | Environment variables to be passed to the container Config settings can be defined here, or can be defined via configMap + secret |
 | extraEnvRaw | list | `[]` | Environment variables to be passed to the container Config settings can be defined in raw form, for use with externally maintained env value sources (configMapKeyRef, fieldRef, resourceFieldRef, secretKeyRef) |
 | fullnameOverride | string | `""` |  |

--- a/contrib/helm/pganalyze-collector/templates/deployment.yaml
+++ b/contrib/helm/pganalyze-collector/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "pganalyze-collector.fullname" . }}
   labels:
     {{- include "pganalyze-collector.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/contrib/helm/pganalyze-collector/values.yaml
+++ b/contrib/helm/pganalyze-collector/values.yaml
@@ -97,6 +97,12 @@ service:
       port: 4319
       targetPort: 4319
 
+# -- Annotations to add to the Deployment metadata (not the pod template).
+# Useful for workload controllers like Stakater Reloader that watch
+# workload-level annotations to trigger rolling restarts on ConfigMap/Secret
+# changes.
+deploymentAnnotations: {}
+
 podAnnotations: {}
 
 # -- Labels to add to the pod


### PR DESCRIPTION
this is useful to have tools like https://github.com/stakater/reloader automatically restart the collector on changes to configuration