### PR TITLE
Report collector start time in request header

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -498,7 +498,7 @@ func CreateWebSocketDialer(conf ServerConfig) websocket.Dialer {
 	}
 }
 
-func APIHeaders(conf ServerConfig, testRun bool) map[string][]string {
+func APIHeaders(conf ServerConfig, testRun bool, startedAt time.Time) map[string][]string {
 	headers := make(map[string][]string)
 	headers["Pganalyze-Api-Key"] = []string{conf.APIKey}
 	headers["Pganalyze-System-Id"] = []string{conf.SystemID}
@@ -507,6 +507,7 @@ func APIHeaders(conf ServerConfig, testRun bool) map[string][]string {
 	headers["Pganalyze-System-Id-Fallback"] = []string{conf.SystemIDFallback}
 	headers["Pganalyze-System-Type-Fallback"] = []string{conf.SystemTypeFallback}
 	headers["Pganalyze-System-Scope-Fallback"] = []string{conf.SystemScopeFallback}
+	headers["Pganalyze-Collector-Started-At"] = []string{startedAt.Format(time.RFC3339)}
 	if testRun {
 		headers["Pganalyze-Test-Run"] = []string{"true"}
 	}

--- a/main.go
+++ b/main.go
@@ -311,6 +311,7 @@ ReadConfigAndRun:
 			cancel()
 			wg.Wait()
 			writeStateFile()
+			opts.StartedAt = time.Now() // Signal to pganalyze API that collector essentially restarted
 			goto ReadConfigAndRun
 		}
 

--- a/output/grant.go
+++ b/output/grant.go
@@ -49,7 +49,7 @@ func EnsureGrant(ctx context.Context, server *state.Server, opts state.Collectio
 		}
 	}
 
-	newGrant, err := getGrant(ctx, server.Config, opts.TestRun)
+	newGrant, err := getGrant(ctx, server.Config, opts)
 	if err != nil {
 		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectApiConnection, "error contacting API: %s", err)
 		if server.Grant.Load().ValidForS3Until.After(time.Now()) {
@@ -78,14 +78,14 @@ func waitWithTimeout(ctx context.Context, c chan struct{}, timeout time.Duration
 	}
 }
 
-func getGrant(ctx context.Context, conf config.ServerConfig, testRun bool) (*state.Grant, error) {
+func getGrant(ctx context.Context, conf config.ServerConfig, opts state.CollectionOpts) (*state.Grant, error) {
 	grant := &state.Grant{Config: pganalyze_collector.ServerMessage_Config{Features: &pganalyze_collector.ServerMessage_Features{}}}
 	req, err := http.NewRequestWithContext(ctx, "GET", conf.APIBaseURL+"/v2/snapshots/grant", nil)
 	if err != nil {
 		return grant, err
 	}
 
-	req.Header = config.APIHeaders(conf, testRun)
+	req.Header = config.APIHeaders(conf, opts.TestRun, opts.StartedAt)
 	req.Header.Add("Accept", "application/json")
 
 	resp, err := conf.HTTPClientWithRetry.Do(req)

--- a/output/upload.go
+++ b/output/upload.go
@@ -19,11 +19,11 @@ func SetupSnapshotUploadForAllServers(ctx context.Context, servers []*state.Serv
 		return
 	}
 	for _, server := range servers {
-		go snapshotUploadForServer(ctx, server, logger.WithPrefixAndRememberErrors(server.Config.SectionName), opts.TestRun)
+		go snapshotUploadForServer(ctx, server, logger.WithPrefixAndRememberErrors(server.Config.SectionName), opts)
 	}
 }
 
-func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *util.Logger, testRun bool) {
+func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *util.Logger, opts state.CollectionOpts) {
 	var compactLogTime time.Time
 	compactLogStats := make(map[string]uint8)
 	for {
@@ -37,10 +37,10 @@ func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *
 				continue
 			}
 
-			err = uploadViaWebsocketOrHttp(ctx, server, logger, testRun, data, s.SnapshotUuid, s.CollectedAt.AsTime(), false)
+			err = uploadViaWebsocketOrHttp(ctx, server, logger, opts, data, s.SnapshotUuid, s.CollectedAt.AsTime(), false)
 			if err != nil {
 				logger.PrintError("Error uploading snapshot: %s", err)
-			} else if !testRun {
+			} else if !opts.TestRun {
 				logger.PrintInfo("Submitted full snapshot successfully")
 			}
 		case s := <-server.CompactSnapshotUpload:
@@ -50,12 +50,12 @@ func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *
 				continue
 			}
 
-			err = uploadViaWebsocketOrHttp(ctx, server, logger, testRun, data, s.SnapshotUuid, s.CollectedAt.AsTime(), false)
+			err = uploadViaWebsocketOrHttp(ctx, server, logger, opts, data, s.SnapshotUuid, s.CollectedAt.AsTime(), false)
 			if err != nil {
 				logger.PrintError("Error uploading snapshot: %s", err)
 				continue
 			}
-			if testRun {
+			if opts.TestRun {
 				continue
 			}
 
@@ -92,7 +92,7 @@ func summarizeCounts(counts map[string]uint8) string {
 	return details
 }
 
-func uploadViaWebsocketOrHttp(ctx context.Context, server *state.Server, logger *util.Logger, testRun bool, data []byte, snapshotUUID string, collectedAt time.Time, compactSnapshot bool) error {
+func uploadViaWebsocketOrHttp(ctx context.Context, server *state.Server, logger *util.Logger, opts state.CollectionOpts, data []byte, snapshotUUID string, collectedAt time.Time, compactSnapshot bool) error {
 	var compressedData bytes.Buffer
 	w := zlib.NewWriter(&compressedData)
 	w.Write(data)
@@ -108,7 +108,7 @@ func uploadViaWebsocketOrHttp(ctx context.Context, server *state.Server, logger 
 		if err != nil {
 			return err
 		}
-		submitSnapshot(ctx, server, testRun, logger, s3Location, collectedAt, compactSnapshot)
+		submitSnapshot(ctx, server, opts, logger, s3Location, collectedAt, compactSnapshot)
 	}
 	return nil
 }

--- a/output/upload_http_legacy.go
+++ b/output/upload_http_legacy.go
@@ -106,10 +106,10 @@ func uploadToS3(ctx context.Context, httpClient *http.Client, S3URL string, S3Fi
 	return s3Resp.Key, nil
 }
 
-func submitSnapshot(ctx context.Context, server *state.Server, testRun bool, logger *util.Logger, s3Location string, collectedAt time.Time, compact bool) error {
+func submitSnapshot(ctx context.Context, server *state.Server, opts state.CollectionOpts, logger *util.Logger, s3Location string, collectedAt time.Time, compact bool) error {
 	requestURL := server.Config.APIBaseURL + "/v2/snapshots"
 
-	if testRun {
+	if opts.TestRun {
 		requestURL = server.Config.APIBaseURL + "/v2/snapshots/test"
 	} else if compact {
 		requestURL = server.Config.APIBaseURL + "/v2/snapshots/compact"
@@ -125,7 +125,7 @@ func submitSnapshot(ctx context.Context, server *state.Server, testRun bool, log
 		return err
 	}
 
-	req.Header = config.APIHeaders(server.Config, testRun)
+	req.Header = config.APIHeaders(server.Config, opts.TestRun, opts.StartedAt)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("Accept", "application/json,text/plain")
 
@@ -144,7 +144,7 @@ func submitSnapshot(ctx context.Context, server *state.Server, testRun bool, log
 		return fmt.Errorf("Error when submitting: %s\n", body)
 	}
 
-	if testRun {
+	if opts.TestRun {
 		contentType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 		if err != nil {
 			return fmt.Errorf("Error decoding response: %s\n", err)

--- a/runner/websocket.go
+++ b/runner/websocket.go
@@ -23,7 +23,9 @@ func SetupWebsocketForAllServers(ctx context.Context, servers []*state.Server, o
 		prefixedLogger := logger.WithPrefixAndRememberErrors(server.Config.SectionName)
 		server.WebSocket = util.NewReconnectingSocket(
 			ctx, prefixedLogger,
-			config.CreateWebSocketDialer(server.Config), server.Config.WebSocketUrl, config.APIHeaders(server.Config, opts.TestRun),
+			config.CreateWebSocketDialer(server.Config),
+			server.Config.WebSocketUrl,
+			config.APIHeaders(server.Config, opts.TestRun, opts.StartedAt),
 			1*time.Minute, 8*time.Minute,
 		)
 


### PR DESCRIPTION
This adds a `Pganalyze-Collector-Started-At` HTTP header to all requests to the pganalyze server, allowing us to know if the websocket connection is unreliable because of network issues, or if the collector itself is restarting.