### PR TITLE
Require WebSocket connection by default

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -414,6 +414,8 @@ func getDefaultConfig() *ServerConfig {
 	}
 	if apiRequireWebSocket := os.Getenv("API_REQUIRE_WEBSOCKET"); apiRequireWebSocket != "" {
 		config.APIRequireWebsocket = parseConfigBool(apiRequireWebSocket)
+	} else {
+		config.APIRequireWebsocket = true
 	}
 
 	return config


### PR DESCRIPTION
Followup to #745, this requires that the WebSocket API is always used by default. If after upgrading your collector isn't able to maintain a long-lived WebSocket connection to the pganalyze server, you may have a network proxy whose configuration needs to be updated. As a temporary measure you can set the `api_require_websocket` / `API_REQUIRE_WEBSOCKET` setting to `off`, but a future release will remove the legacy API, so network issues will need to be resolved.