### PR TITLE
Fix WaitGroup Add/Wait race in scheduler

### DIFF
--- a/runner/run.go
+++ b/runner/run.go
@@ -282,10 +282,8 @@ func Run(ctx context.Context, wg *sync.WaitGroup, opts state.CollectionOpts, log
 		return
 	}
 
-	scheduler.TenMinute.Schedule(ctx, func(ctx context.Context) {
-		wg.Add(1)
+	scheduler.TenMinute.Schedule(ctx, wg, func(ctx context.Context) {
 		CollectAllServers(ctx, servers, opts, logger)
-		wg.Done()
 	}, logger, "full snapshot of all servers")
 
 	if hasAnyLogsEnabled {
@@ -296,18 +294,14 @@ func Run(ctx context.Context, wg *sync.WaitGroup, opts state.CollectionOpts, log
 	}
 
 	if hasAnyActivityEnabled {
-		scheduler.TenSecond.Schedule(ctx, func(ctx context.Context) {
-			wg.Add(1)
+		scheduler.TenSecond.Schedule(ctx, wg, func(ctx context.Context) {
 			CollectActivityFromAllServers(ctx, servers, opts, logger)
-			wg.Done()
 		}, logger, "activity snapshot of all servers")
 	}
 
 	// This captures stats every minute, except for minute 10 when full snapshot collection takes over
-	scheduler.OneMinute.ScheduleSecondary(ctx, scheduler.TenMinute, func(ctx context.Context) {
-		wg.Add(1)
+	scheduler.OneMinute.ScheduleSecondary(ctx, scheduler.TenMinute, wg, func(ctx context.Context) {
 		Gather1minStatsFromAllServers(ctx, servers, opts, logger)
-		wg.Done()
 	}, logger, "high frequency statistics of all servers")
 
 	SetupWebsocketForAllServers(ctx, servers, opts, logger)

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gorhill/cronexpr"
@@ -42,8 +43,10 @@ type Schedule struct {
 	interval *cronexpr.Expression
 }
 
-func (schedule Schedule) Schedule(ctx context.Context, runner func(context.Context), logger *util.Logger, logName string) {
+func (schedule Schedule) Schedule(ctx context.Context, wg *sync.WaitGroup, runner func(context.Context), logger *util.Logger, logName string) {
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
 			nextExecutions := schedule.interval.NextN(time.Now(), 2)
 			delay := time.Until(nextExecutions[0])
@@ -73,8 +76,10 @@ func (schedule Schedule) Schedule(ctx context.Context, runner func(context.Conte
 
 // ScheduleSecondary - Behaves almost like Schedule, but ignores the point in time
 // where the primary schedule also has a run (to avoid overlapping statistics)
-func (schedule Schedule) ScheduleSecondary(ctx context.Context, primarySchedule Schedule, runner func(context.Context), logger *util.Logger, logName string) {
+func (schedule Schedule) ScheduleSecondary(ctx context.Context, primarySchedule Schedule, wg *sync.WaitGroup, runner func(context.Context), logger *util.Logger, logName string) {
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for {
 			timeNow := time.Now()
 			delay := schedule.interval.Next(timeNow).Sub(timeNow)


### PR DESCRIPTION
On reload (`SIGHUP`) and exit, `main.go` does `cancel(); wg.Wait()`. The purpose of this `WaitGroup` is simply to wait for the scheduler goroutines to finish winding down before reloading config / exiting.

Currently, each scheduled job registered itself on the WaitGroup inside its per-tick callback, so `wg.Add(1)` only ran when a timer happened to fire (aka when a job actually start running).

```go
scheduler.TenMinute.Schedule(ctx, func(ctx context.Context) {
    wg.Add(1)
    CollectAllServers(...)
    wg.Done()
}, ...)
```

In the current setup, there is a race where `Add` can happen at the same moment `main` reached `wg.Wait()`. However, `sync.WaitGroup` requires that an `Add` from a zero counter *happens-before* any `Wait`.

> Note that calls with a positive delta that occur when the counter is zero must happen before a Wait.
> https://pkg.go.dev/sync#WaitGroup.Add

To fix this, move the WaitGroup bookkeeping out of the per-tick callback and into the scheduler, so `Add(1)` runs once at setup (before `main` can reach `wg.Wait()`) and `Done()` fires when the goroutine exits. Since `Add` now always happens-before `Wait`, there's no `Add` left to race.

This changes what the counter tracks (prev: job is executing v.s. current: scheduler is running), but it's safe to change: the only consumer is `wg.Wait()` in `main`, which is only ever called after `cancel()` to wait for the schedulers to drain. This also matches the existing convention used by the log-collection goroutines (`runner/logs.go`), which already hold their WaitGroup slot for the goroutine's full lifetime.

The race must be really rare, and when anyone hits this, they either observe the collector crash, or actually don't see anything noticable.

----

Note: this is a latent correctness bug, **not** the reload hang we were investigating. That hang has a separate root cause, which Lukas is working on it with the `fix-socket-reconnection-stall-on-reload` branch.