### PR TITLE
Reconnecting socket: Add missing context cancellation checks

### DIFF
--- a/util/reconnecting_socket.go
+++ b/util/reconnecting_socket.go
@@ -22,6 +22,7 @@ type ReconnectingSocket struct {
 	logger  *Logger
 
 	// Internal state
+	ctx       context.Context
 	requested atomic.Bool
 	conn      atomic.Pointer[websocket.Conn]
 	start     chan struct{}
@@ -38,6 +39,7 @@ func NewReconnectingSocket(ctx context.Context, logger *Logger, dialer websocket
 	w := &ReconnectingSocket{
 		Read:      make(chan []byte),
 		Write:     make(chan []byte),
+		ctx:       ctx,
 		dialer:    dialer,
 		url:       url,
 		headers:   headers,
@@ -81,8 +83,16 @@ func NewReconnectingSocket(ctx context.Context, logger *Logger, dialer websocket
 				return
 			case <-time.After(reconnectInterval):
 				if !w.Connected() && w.requested.Load() {
-					w.start <- struct{}{}
-					<-w.startWait
+					select {
+					case w.start <- struct{}{}:
+					case <-ctx.Done():
+						return
+					}
+					select {
+					case <-w.startWait:
+					case <-ctx.Done():
+						return
+					}
 				}
 			}
 		}
@@ -99,11 +109,20 @@ func (w *ReconnectingSocket) Connected() bool {
 // Does nothing if the WebSocket is already connected
 func (w *ReconnectingSocket) Connect() error {
 	w.requested.Store(true)
-	if !w.Connected() {
-		w.start <- struct{}{}
-		return <-w.startWait
+	if w.Connected() {
+		return nil
 	}
-	return nil
+	select {
+	case w.start <- struct{}{}:
+	case <-w.ctx.Done():
+		return w.ctx.Err()
+	}
+	select {
+	case err := <-w.startWait:
+		return err
+	case <-w.ctx.Done():
+		return w.ctx.Err()
+	}
 }
 
 // Disconnect - Shuts down the WebSocket connection

--- a/util/reconnecting_socket_test.go
+++ b/util/reconnecting_socket_test.go
@@ -62,3 +62,38 @@ func TestSocketReconnect(t *testing.T) {
 		t.Errorf("TestSocketReconnect: expected: 2+ connects; actual: %d", connectsReceived)
 	}
 }
+
+// Verifies that Connect() does not block forever once the socket's context has
+// been canceled (e.g. during a SIGHUP config reload). Regression test for a hang
+// where the internal manager goroutine exited on its <-ctx.Done() branch while a
+// Connect() call was left blocked forever on the startWait channel. That blocked
+// Connect() (reached via EnsureGrant during activity collection) holds a WaitGroup
+// entry, so the reload's wg.Wait() never returns and the collector wedges.
+func TestSocketConnectReturnsAfterContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	socket := util.NewReconnectingSocket(
+		ctx, &util.Logger{Destination: log.New(os.Stderr, "", 0)},
+		websocket.Dialer{}, "ws://localhost:9124", make(map[string][]string),
+		1*time.Second,
+		1*time.Second,
+	)
+
+	// Cancel the context and give the internal manager goroutine time to take its
+	// <-ctx.Done() branch and exit. After this, no goroutine is left to answer a
+	// Connect() request.
+	cancel()
+	time.Sleep(100 * time.Millisecond)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- socket.Connect()
+	}()
+
+	select {
+	case <-done:
+		// Connect() returned (with or without an error) instead of hanging.
+	case <-time.After(5 * time.Second):
+		t.Fatal("TestSocketConnectReturnsAfterContextCancel: Connect() blocked indefinitely after context cancellation")
+	}
+}


### PR DESCRIPTION
Both connect and reconnect functionality could get stuck on Go channels not being ready, causing reload to get stuck.