### PR TITLE
Fix unbound memory issue in multi-line log stitching

### DIFF
--- a/logs/parse.go
+++ b/logs/parse.go
@@ -462,8 +462,7 @@ func ParseAndAnalyzeBuffer(logStream LineReader, linesNewerThan time.Time, serve
 	}
 
 	// Continuation lines (lines that don't parse as a new log line) are stitched onto
-	// the previous kept line. We accumulate them in a strings.Builder and materialize
-	// once, so a single entry spanning many lines is O(n) rather than O(n^2) copies.
+	// the previous kept line.
 	var additionalLines strings.Builder
 	parentLine := -1
 	additionalLinesExceeded := false

--- a/logs/parse.go
+++ b/logs/parse.go
@@ -447,12 +447,33 @@ type LineReader interface {
 	ReadString(delim byte) (string, error)
 }
 
+// maxAdditionalLinesBytes bounds how much continuation content we append to a single
+// log line. Multi-line entries (e.g. auto_explain JSON plans) are stitched onto their
+// primary line; without a bound, a single very large entry can grow one Content string
+// without limit and OOM the collector. It is a var so tests can lower it.
+var maxAdditionalLinesBytes = 10 * 1024 * 1024
+
 func ParseAndAnalyzeBuffer(logStream LineReader, linesNewerThan time.Time, server *state.Server, opts state.CollectionOpts, logger *util.Logger) ([]state.LogLine, []state.PostgresQuerySample) {
 	var logLines []state.LogLine
 	var currentByteStart int64 = 0
 	parser := server.GetLogParser()
 	if parser == nil {
 		return []state.LogLine{}, []state.PostgresQuerySample{}
+	}
+
+	// Continuation lines (lines that don't parse as a new log line) are stitched onto
+	// the previous kept line. We accumulate them in a strings.Builder and materialize
+	// once, so a single entry spanning many lines is O(n) rather than O(n^2) copies.
+	var additionalLines strings.Builder
+	parentLine := -1
+	additionalLinesExceeded := false
+	flushAdditionalLines := func() {
+		if parentLine >= 0 && additionalLines.Len() > 0 {
+			logLines[parentLine].Content += additionalLines.String()
+		}
+		additionalLines.Reset()
+		parentLine = -1
+		additionalLinesExceeded = false
 	}
 
 	for {
@@ -474,8 +495,21 @@ func ParseAndAnalyzeBuffer(logStream LineReader, linesNewerThan time.Time, serve
 			// Assume that a parsing error in a follow-on line means that we actually
 			// got additional data for the previous line
 			if len(logLines) > 0 && logLine.Content != "" {
-				logLines[len(logLines)-1].Content += logLine.Content
-				logLines[len(logLines)-1].ByteEnd += int64(len(logLine.Content))
+				lastLine := len(logLines) - 1
+				if parentLine != lastLine {
+					// The last kept line changed since we last stitched; finalize it.
+					flushAdditionalLines()
+					parentLine = lastLine
+				}
+				logLines[lastLine].ByteEnd += int64(len(logLine.Content))
+				if additionalLines.Len()+len(logLine.Content) <= maxAdditionalLinesBytes {
+					additionalLines.WriteString(logLine.Content)
+				} else if !additionalLinesExceeded {
+					additionalLinesExceeded = true
+					logger.PrintWarning("Log line continuation exceeded %d bytes and was truncated; "+
+						"a single log entry (e.g. an auto_explain JSON plan) is larger than the "+
+						"collector will stitch together", maxAdditionalLinesBytes)
+				}
 			}
 			continue
 		}
@@ -513,8 +547,12 @@ func ParseAndAnalyzeBuffer(logStream LineReader, linesNewerThan time.Time, serve
 			continue
 		}
 
+		// Finalize the previous kept line's additional lines before this new
+		// line becomes the stitch target.
+		flushAdditionalLines()
 		logLines = append(logLines, logLine)
 	}
+	flushAdditionalLines()
 
 	newLogLines, newSamples := AnalyzeLogLines(logLines)
 	return newLogLines, newSamples

--- a/logs/parse.go
+++ b/logs/parse.go
@@ -480,7 +480,6 @@ func ParseAndAnalyzeBuffer(logStream LineReader, linesNewerThan time.Time, serve
 			// Assume that a parsing error in a follow-on line means that we actually
 			// got additional data for the previous line
 			if pending != nil && logLine.Content != "" {
-				pending.ByteEnd += int64(len(logLine.Content))
 				additionalLines.Append(logLine.Content)
 			}
 			continue
@@ -520,6 +519,7 @@ func ParseAndAnalyzeBuffer(logStream LineReader, linesNewerThan time.Time, serve
 		}
 
 		if pending != nil {
+			pending.ByteEnd += int64(additionalLines.Len())
 			pending.Content += additionalLines.String()
 			additionalLines.Reset()
 			logLines = append(logLines, *pending)
@@ -528,6 +528,7 @@ func ParseAndAnalyzeBuffer(logStream LineReader, linesNewerThan time.Time, serve
 	}
 
 	if pending != nil {
+		pending.ByteEnd += int64(additionalLines.Len())
 		pending.Content += additionalLines.String()
 		logLines = append(logLines, *pending)
 	}

--- a/logs/parse.go
+++ b/logs/parse.go
@@ -455,17 +455,11 @@ func ParseAndAnalyzeBuffer(logStream LineReader, linesNewerThan time.Time, serve
 		return []state.LogLine{}, []state.PostgresQuerySample{}
 	}
 
-	// Continuation lines (lines that don't parse as a new log line) are stitched onto
-	// the previous kept line.
+	// Each regular line is held back as the stitch target for continuation
+	// lines (lines that don't parse as a new log line), and only appended to
+	// logLines once the next regular line arrives (or at EOF).
+	var pending *state.LogLine
 	additionalLines := NewStitchBuffer(logger)
-	parentLine := -1
-	flushAdditionalLines := func() {
-		if parentLine >= 0 && additionalLines.Len() > 0 {
-			logLines[parentLine].Content += additionalLines.String()
-		}
-		additionalLines.Reset()
-		parentLine = -1
-	}
 
 	for {
 		line, err := logStream.ReadString('\n')
@@ -485,14 +479,8 @@ func ParseAndAnalyzeBuffer(logStream LineReader, linesNewerThan time.Time, serve
 		if !ok {
 			// Assume that a parsing error in a follow-on line means that we actually
 			// got additional data for the previous line
-			if len(logLines) > 0 && logLine.Content != "" {
-				lastLine := len(logLines) - 1
-				if parentLine != lastLine {
-					// The last kept line changed since we last stitched; finalize it.
-					flushAdditionalLines()
-					parentLine = lastLine
-				}
-				logLines[lastLine].ByteEnd += int64(len(logLine.Content))
+			if pending != nil && logLine.Content != "" {
+				pending.ByteEnd += int64(len(logLine.Content))
 				additionalLines.Append(logLine.Content)
 			}
 			continue
@@ -531,12 +519,18 @@ func ParseAndAnalyzeBuffer(logStream LineReader, linesNewerThan time.Time, serve
 			continue
 		}
 
-		// Finalize the previous kept line's additional lines before this new
-		// line becomes the stitch target.
-		flushAdditionalLines()
-		logLines = append(logLines, logLine)
+		if pending != nil {
+			pending.Content += additionalLines.String()
+			additionalLines.Reset()
+			logLines = append(logLines, *pending)
+		}
+		pending = &logLine
 	}
-	flushAdditionalLines()
+
+	if pending != nil {
+		pending.Content += additionalLines.String()
+		logLines = append(logLines, *pending)
+	}
 
 	newLogLines, newSamples := AnalyzeLogLines(logLines)
 	return newLogLines, newSamples

--- a/logs/parse.go
+++ b/logs/parse.go
@@ -447,12 +447,6 @@ type LineReader interface {
 	ReadString(delim byte) (string, error)
 }
 
-// maxAdditionalLinesBytes bounds how much continuation content we append to a single
-// log line. Multi-line entries (e.g. auto_explain JSON plans) are stitched onto their
-// primary line; without a bound, a single very large entry can grow one Content string
-// without limit and OOM the collector. It is a var so tests can lower it.
-var maxAdditionalLinesBytes = 10 * 1024 * 1024
-
 func ParseAndAnalyzeBuffer(logStream LineReader, linesNewerThan time.Time, server *state.Server, opts state.CollectionOpts, logger *util.Logger) ([]state.LogLine, []state.PostgresQuerySample) {
 	var logLines []state.LogLine
 	var currentByteStart int64 = 0
@@ -463,16 +457,14 @@ func ParseAndAnalyzeBuffer(logStream LineReader, linesNewerThan time.Time, serve
 
 	// Continuation lines (lines that don't parse as a new log line) are stitched onto
 	// the previous kept line.
-	var additionalLines strings.Builder
+	additionalLines := NewStitchBuffer(logger)
 	parentLine := -1
-	additionalLinesExceeded := false
 	flushAdditionalLines := func() {
 		if parentLine >= 0 && additionalLines.Len() > 0 {
 			logLines[parentLine].Content += additionalLines.String()
 		}
 		additionalLines.Reset()
 		parentLine = -1
-		additionalLinesExceeded = false
 	}
 
 	for {
@@ -501,14 +493,7 @@ func ParseAndAnalyzeBuffer(logStream LineReader, linesNewerThan time.Time, serve
 					parentLine = lastLine
 				}
 				logLines[lastLine].ByteEnd += int64(len(logLine.Content))
-				if additionalLines.Len()+len(logLine.Content) <= maxAdditionalLinesBytes {
-					additionalLines.WriteString(logLine.Content)
-				} else if !additionalLinesExceeded {
-					additionalLinesExceeded = true
-					logger.PrintWarning("Log line continuation exceeded %d bytes and was truncated; "+
-						"a single log entry (e.g. an auto_explain JSON plan) is larger than the "+
-						"collector will stitch together", maxAdditionalLinesBytes)
-				}
+				additionalLines.Append(logLine.Content)
 			}
 			continue
 		}

--- a/logs/parse_stitch_test.go
+++ b/logs/parse_stitch_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/pganalyze/collector/util"
 )
 
-const stitchTestPrefix = "2018-03-11 20:00:02 UTC:1.1.1.1(2):a@b:[3]:LOG:  "
+const stitchTestPrefix = "2026-07-12 20:00:02 UTC:1.1.1.1(2):a@b:[3]:LOG:  "
 
 func parseStitchBuffer(input string) []state.LogLine {
 	reader := bufio.NewReader(strings.NewReader(input))
@@ -27,35 +27,36 @@ func parseStitchBuffer(input string) []state.LogLine {
 // A multi-line entry (e.g. an auto_explain plan) whose follow-on lines don't parse as
 // new log lines must be stitched back onto its primary line's Content, in order.
 func TestParseAndAnalyzeBufferStitchesMultiLine(t *testing.T) {
-	input := stitchTestPrefix + "duration: 1.000 ms  plan:\n" +
-		"  \"Node\": \"a\",\n" +
-		"  \"Node\": \"b\",\n" +
-		"  \"Node\": \"c\"\n"
+	multilineLog := `duration: 1.000 ms  plan:
+			"Node": "a",
+			"Node": "b",
+			"Node": "c"
+`
 
-	logLines := parseStitchBuffer(input)
+	logLines := parseStitchBuffer(stitchTestPrefix + multilineLog)
 
 	if len(logLines) != 1 {
 		t.Fatalf("expected 1 stitched log line, got %d", len(logLines))
 	}
-	want := "duration: 1.000 ms  plan:\n  \"Node\": \"a\",\n  \"Node\": \"b\",\n  \"Node\": \"c\"\n"
-	if logLines[0].Content != want {
-		t.Errorf("stitched content mismatch:\n got: %q\nwant: %q", logLines[0].Content, want)
+	if logLines[0].Content != multilineLog {
+		t.Errorf("stitched content mismatch:\n got: %q\nmultilineLog: %q", logLines[0].Content, multilineLog)
 	}
 }
 
-// A pathologically large multi-line entry (a runaway plan, or a log_line_prefix
-// mismatch that makes every line look like a continuation) must not grow the stitched
-// Content without bound; it is capped at maxAdditionalLinesBytes.
+// A multi-line entry that's larger than the cap when stitched together, typically a large JSON EXPLAIN plan,
+// must be bound by maxAdditionalLinesBytes.
 func TestParseAndAnalyzeBufferCapsRunawayStitch(t *testing.T) {
 	orig := maxAdditionalLinesBytes
 	maxAdditionalLinesBytes = 4096
 	defer func() { maxAdditionalLinesBytes = orig }()
 
+	primary := "duration: 1.000 ms  plan:\n"
+	additionalLine := strings.Repeat("x", 1000) + "\n"
+
 	var b strings.Builder
-	b.WriteString(stitchTestPrefix + "duration: 1.000 ms  plan:\n")
-	contLine := strings.Repeat("x", 1000) + "\n"
-	for i := 0; i < 200; i++ { // ~200 KB of continuation, far above the 4 KB cap
-		b.WriteString(contLine)
+	b.WriteString(stitchTestPrefix + primary)
+	for i := 0; i < 5; i++ { // ~5 KB of continuation, just over the 4 KB cap
+		b.WriteString(additionalLine)
 	}
 
 	logLines := parseStitchBuffer(b.String())
@@ -63,9 +64,9 @@ func TestParseAndAnalyzeBufferCapsRunawayStitch(t *testing.T) {
 	if len(logLines) != 1 {
 		t.Fatalf("expected 1 log line, got %d", len(logLines))
 	}
-	// Content should be bounded near the cap (primary line + up to the cap of
-	// continuation), not the full ~200 KB of input.
-	if got := len(logLines[0].Content); got > maxAdditionalLinesBytes+len(contLine) {
-		t.Errorf("expected stitched content capped near %d bytes, got %d", maxAdditionalLinesBytes, got)
+	// Content is the primary line plus the additional lines
+	maxContentBytes := len(primary) + maxAdditionalLinesBytes
+	if totalLogLineBytes := len(logLines[0].Content); totalLogLineBytes > maxContentBytes {
+		t.Errorf("expected stitched content capped at %d bytes, got %d", maxContentBytes, totalLogLineBytes)
 	}
 }

--- a/logs/parse_stitch_test.go
+++ b/logs/parse_stitch_test.go
@@ -1,0 +1,71 @@
+package logs
+
+import (
+	"bufio"
+	"io"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pganalyze/collector/config"
+	"github.com/pganalyze/collector/state"
+	"github.com/pganalyze/collector/util"
+)
+
+const stitchTestPrefix = "2018-03-11 20:00:02 UTC:1.1.1.1(2):a@b:[3]:LOG:  "
+
+func parseStitchBuffer(input string) []state.LogLine {
+	reader := bufio.NewReader(strings.NewReader(input))
+	server := state.MakeServer(config.ServerConfig{}, false)
+	server.LogParser = NewLogParser(LogPrefixAmazonRds, nil, false)
+	logger := &util.Logger{Destination: log.New(io.Discard, "", 0)}
+	logLines, _ := ParseAndAnalyzeBuffer(reader, time.Time{}, server, state.CollectionOpts{}, logger)
+	return logLines
+}
+
+// A multi-line entry (e.g. an auto_explain plan) whose follow-on lines don't parse as
+// new log lines must be stitched back onto its primary line's Content, in order.
+func TestParseAndAnalyzeBufferStitchesMultiLine(t *testing.T) {
+	input := stitchTestPrefix + "duration: 1.000 ms  plan:\n" +
+		"  \"Node\": \"a\",\n" +
+		"  \"Node\": \"b\",\n" +
+		"  \"Node\": \"c\"\n"
+
+	logLines := parseStitchBuffer(input)
+
+	if len(logLines) != 1 {
+		t.Fatalf("expected 1 stitched log line, got %d", len(logLines))
+	}
+	want := "duration: 1.000 ms  plan:\n  \"Node\": \"a\",\n  \"Node\": \"b\",\n  \"Node\": \"c\"\n"
+	if logLines[0].Content != want {
+		t.Errorf("stitched content mismatch:\n got: %q\nwant: %q", logLines[0].Content, want)
+	}
+}
+
+// A pathologically large multi-line entry (a runaway plan, or a log_line_prefix
+// mismatch that makes every line look like a continuation) must not grow the stitched
+// Content without bound; it is capped at maxAdditionalLinesBytes.
+func TestParseAndAnalyzeBufferCapsRunawayStitch(t *testing.T) {
+	orig := maxAdditionalLinesBytes
+	maxAdditionalLinesBytes = 4096
+	defer func() { maxAdditionalLinesBytes = orig }()
+
+	var b strings.Builder
+	b.WriteString(stitchTestPrefix + "duration: 1.000 ms  plan:\n")
+	contLine := strings.Repeat("x", 1000) + "\n"
+	for i := 0; i < 200; i++ { // ~200 KB of continuation, far above the 4 KB cap
+		b.WriteString(contLine)
+	}
+
+	logLines := parseStitchBuffer(b.String())
+
+	if len(logLines) != 1 {
+		t.Fatalf("expected 1 log line, got %d", len(logLines))
+	}
+	// Content should be bounded near the cap (primary line + up to the cap of
+	// continuation), not the full ~200 KB of input.
+	if got := len(logLines[0].Content); got > maxAdditionalLinesBytes+len(contLine) {
+		t.Errorf("expected stitched content capped near %d bytes, got %d", maxAdditionalLinesBytes, got)
+	}
+}

--- a/logs/parse_stitch_test.go
+++ b/logs/parse_stitch_test.go
@@ -44,11 +44,11 @@ func TestParseAndAnalyzeBufferStitchesMultiLine(t *testing.T) {
 }
 
 // A multi-line entry that's larger than the cap when stitched together, typically a large JSON EXPLAIN plan,
-// must be bound by maxAdditionalLinesBytes.
+// must be bound by MaxStitchedContentBytes.
 func TestParseAndAnalyzeBufferCapsRunawayStitch(t *testing.T) {
-	orig := maxAdditionalLinesBytes
-	maxAdditionalLinesBytes = 4096
-	defer func() { maxAdditionalLinesBytes = orig }()
+	orig := MaxStitchedContentBytes
+	MaxStitchedContentBytes = 4096
+	defer func() { MaxStitchedContentBytes = orig }()
 
 	primary := "duration: 1.000 ms  plan:\n"
 	additionalLine := strings.Repeat("x", 1000) + "\n"
@@ -65,7 +65,7 @@ func TestParseAndAnalyzeBufferCapsRunawayStitch(t *testing.T) {
 		t.Fatalf("expected 1 log line, got %d", len(logLines))
 	}
 	// Content is the primary line plus the additional lines
-	maxContentBytes := len(primary) + maxAdditionalLinesBytes
+	maxContentBytes := len(primary) + MaxStitchedContentBytes
 	if totalLogLineBytes := len(logLines[0].Content); totalLogLineBytes > maxContentBytes {
 		t.Errorf("expected stitched content capped at %d bytes, got %d", maxContentBytes, totalLogLineBytes)
 	}

--- a/logs/stitch.go
+++ b/logs/stitch.go
@@ -1,0 +1,62 @@
+package logs
+
+import (
+	"strings"
+
+	"github.com/pganalyze/collector/util"
+)
+
+// MaxStitchedContentBytes bounds how much continuation content is stitched onto a single
+// log line. Multi-line entries (e.g. auto_explain JSON plans) are stitched onto their
+// primary line, and a log_line_prefix mismatch can likewise make every follow-on line
+// look like a continuation. Without a bound, a single Content string can grow without
+// limit and OOM the collector. It is a var so tests can lower it.
+var MaxStitchedContentBytes = 10 * 1024 * 1024
+
+// StitchBuffer accumulates continuation-line content destined for a single parent log
+// line, capped at MaxStitchedContentBytes. Content beyond the cap is dropped, with a
+// single warning emitted per buffer lifetime (until Reset).
+type StitchBuffer struct {
+	builder   strings.Builder
+	truncated bool
+	logger    *util.Logger
+}
+
+func NewStitchBuffer(logger *util.Logger) *StitchBuffer {
+	return &StitchBuffer{logger: logger}
+}
+
+// Grow hints the expected total content size, bounded by the cap so a pathologically
+// long run of continuation lines can't trigger a large up-front allocation.
+func (s *StitchBuffer) Grow(n int) {
+	s.builder.Grow(min(n, MaxStitchedContentBytes))
+}
+
+// Append adds continuation content, dropping it (and warning once) if it would grow the
+// buffer past MaxStitchedContentBytes.
+func (s *StitchBuffer) Append(content string) {
+	if s.builder.Len()+len(content) > MaxStitchedContentBytes {
+		if !s.truncated {
+			s.truncated = true
+			s.logger.PrintWarning("Log line continuation exceeded %d bytes and was truncated; "+
+				"a single log entry (e.g. an auto_explain JSON plan) or a log_line_prefix "+
+				"mismatch is producing more continuation content than the collector will "+
+				"stitch together", MaxStitchedContentBytes)
+		}
+		return
+	}
+	s.builder.WriteString(content)
+}
+
+func (s *StitchBuffer) Len() int {
+	return s.builder.Len()
+}
+
+func (s *StitchBuffer) String() string {
+	return s.builder.String()
+}
+
+func (s *StitchBuffer) Reset() {
+	s.builder.Reset()
+	s.truncated = false
+}

--- a/logs/stitch.go
+++ b/logs/stitch.go
@@ -26,12 +26,6 @@ func NewStitchBuffer(logger *util.Logger) *StitchBuffer {
 	return &StitchBuffer{logger: logger}
 }
 
-// Grow hints the expected total content size, bounded by the cap so a pathologically
-// long run of continuation lines can't trigger a large up-front allocation.
-func (s *StitchBuffer) Grow(n int) {
-	s.builder.Grow(min(n, MaxStitchedContentBytes))
-}
-
 // Append adds continuation content, dropping it (and warning once) if it would grow the
 // buffer past MaxStitchedContentBytes.
 func (s *StitchBuffer) Append(content string) {

--- a/logs/stitch_test.go
+++ b/logs/stitch_test.go
@@ -1,0 +1,48 @@
+package logs
+
+import (
+	"io"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/pganalyze/collector/util"
+)
+
+func discardLogger() *util.Logger {
+	return &util.Logger{Destination: log.New(io.Discard, "", 0)}
+}
+
+func TestStitchBufferAppends(t *testing.T) {
+	s := NewStitchBuffer(discardLogger())
+	s.Append("a")
+	s.Append("b")
+	s.Append("c")
+
+	if got := s.String(); got != "abc" {
+		t.Errorf("expected %q, got %q", "abc", got)
+	}
+}
+
+// Content beyond MaxStitchedContentBytes is dropped rather than growing the buffer
+// without bound, and Reset clears the accumulated content.
+func TestStitchBufferCapsAndResets(t *testing.T) {
+	orig := MaxStitchedContentBytes
+	MaxStitchedContentBytes = 4096
+	defer func() { MaxStitchedContentBytes = orig }()
+
+	s := NewStitchBuffer(discardLogger())
+	chunk := strings.Repeat("x", 1000)
+	for i := 0; i < 5; i++ { // ~5 KB of content, just over the 4 KB cap
+		s.Append(chunk)
+	}
+
+	if got := s.Len(); got > MaxStitchedContentBytes {
+		t.Errorf("expected buffer capped at %d bytes, got %d", MaxStitchedContentBytes, got)
+	}
+
+	s.Reset()
+	if got := s.Len(); got != 0 {
+		t.Errorf("expected empty buffer after Reset, got %d bytes", got)
+	}
+}

--- a/logs/stream/stitch_test.go
+++ b/logs/stream/stitch_test.go
@@ -1,0 +1,41 @@
+package stream
+
+import (
+	"io"
+	"log"
+	"testing"
+
+	"github.com/pganalyze/collector/output/pganalyze_collector"
+	"github.com/pganalyze/collector/state"
+	"github.com/pganalyze/collector/util"
+)
+
+func discardLogger() *util.Logger {
+	return &util.Logger{Destination: log.New(io.Discard, "", 0)}
+}
+
+// Continuation lines (LogLevel UNKNOWN) must be stitched back onto the preceding
+// analyzable line's Content, in order.
+func TestStitchLogLinesConcatenatesContinuations(t *testing.T) {
+	readyLogLines := []state.LogLine{
+		{LogLevel: pganalyze_collector.LogLineInformation_LOG, Content: `duration: 1.000 ms  plan:
+`},
+		{LogLevel: pganalyze_collector.LogLineInformation_UNKNOWN, Content: `  "Node": "a",
+`},
+		{LogLevel: pganalyze_collector.LogLineInformation_UNKNOWN, Content: `  "Node": "b"
+`},
+	}
+
+	out := stitchLogLines(readyLogLines, discardLogger())
+
+	if len(out) != 1 {
+		t.Fatalf("expected 1 stitched log line, got %d", len(out))
+	}
+	want := `duration: 1.000 ms  plan:
+  "Node": "a",
+  "Node": "b"
+`
+	if out[0].Content != want {
+		t.Errorf("stitched content mismatch:\n got: %q\nwant: %q", out[0].Content, want)
+	}
+}

--- a/logs/stream/stream.go
+++ b/logs/stream/stream.go
@@ -3,7 +3,6 @@ package stream
 import (
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/pganalyze/collector/logs"
@@ -200,10 +199,23 @@ func handleLogAnalysis(analyzableLogLines []state.LogLine) ([]state.LogLine, []s
 	return logLinesOut, querySamples
 }
 
-func stitchLogLines(readyLogLines []state.LogLine) (analyzableLogLines []state.LogLine) {
+func stitchLogLines(readyLogLines []state.LogLine, logger *util.Logger) (analyzableLogLines []state.LogLine) {
 	var linesToAppend []int
 	var linesToAppendLenSum int
-	var b strings.Builder
+	additionalLines := logs.NewStitchBuffer(logger)
+	flush := func() {
+		if linesToAppendLenSum == 0 {
+			return
+		}
+		additionalLines.Grow(linesToAppendLenSum)
+		for _, logIdx := range linesToAppend {
+			additionalLines.Append(readyLogLines[logIdx].Content)
+		}
+		analyzableLogLines[len(analyzableLogLines)-1].Content += additionalLines.String()
+		additionalLines.Reset()
+		linesToAppend = nil
+		linesToAppendLenSum = 0
+	}
 	for idx, logLine := range readyLogLines {
 		if logLine.LogLevel == pganalyze_collector.LogLineInformation_UNKNOWN {
 			if len(analyzableLogLines) > 0 {
@@ -211,27 +223,11 @@ func stitchLogLines(readyLogLines []state.LogLine) (analyzableLogLines []state.L
 				linesToAppendLenSum = linesToAppendLenSum + len(logLine.Content)
 			}
 		} else {
-			if linesToAppendLenSum > 0 {
-				b.Grow(linesToAppendLenSum)
-				for _, logIdx := range linesToAppend {
-					b.WriteString(readyLogLines[logIdx].Content)
-				}
-				analyzableLogLines[len(analyzableLogLines)-1].Content += b.String()
-				b.Reset()
-				linesToAppend = nil
-				linesToAppendLenSum = 0
-			}
+			flush()
 			analyzableLogLines = append(analyzableLogLines, logLine)
 		}
 	}
-	if linesToAppendLenSum > 0 {
-		b.Grow(linesToAppendLenSum)
-		for _, logIdx := range linesToAppend {
-			b.WriteString(readyLogLines[logIdx].Content)
-		}
-		analyzableLogLines[len(analyzableLogLines)-1].Content += b.String()
-		b.Reset()
-	}
+	flush()
 	return
 }
 
@@ -290,7 +286,7 @@ func AnalyzeStreamInGroups(logLines []state.LogLine, now time.Time, server *stat
 	//
 	// Since we already sorted by PID earlier, it is safe for us to concatenate lines before grouping. In fact,
 	// this is required for cases where unknown log lines don't have PIDs associated
-	stitchedLogLines := stitchLogLines(readyLogLines)
+	stitchedLogLines := stitchLogLines(readyLogLines, logger)
 
 	var analyzableLogLines []state.LogLine
 	for _, logLine := range stitchedLogLines {

--- a/logs/stream/stream.go
+++ b/logs/stream/stream.go
@@ -200,34 +200,33 @@ func handleLogAnalysis(analyzableLogLines []state.LogLine) ([]state.LogLine, []s
 }
 
 func stitchLogLines(readyLogLines []state.LogLine, logger *util.Logger) (analyzableLogLines []state.LogLine) {
-	var linesToAppend []int
-	var linesToAppendLenSum int
+	// Each regular line is held back as the stitch target for continuation
+	// lines (lines that don't parse as a new log line, marked as log level
+	// UNKNOWN), and only appended to logLines once the next regular line
+	// arrives (or at EOF).
+	var pending *state.LogLine
 	additionalLines := logs.NewStitchBuffer(logger)
-	flush := func() {
-		if linesToAppendLenSum == 0 {
-			return
-		}
-		additionalLines.Grow(linesToAppendLenSum)
-		for _, logIdx := range linesToAppend {
-			additionalLines.Append(readyLogLines[logIdx].Content)
-		}
-		analyzableLogLines[len(analyzableLogLines)-1].Content += additionalLines.String()
-		additionalLines.Reset()
-		linesToAppend = nil
-		linesToAppendLenSum = 0
-	}
-	for idx, logLine := range readyLogLines {
+
+	for _, logLine := range readyLogLines {
 		if logLine.LogLevel == pganalyze_collector.LogLineInformation_UNKNOWN {
-			if len(analyzableLogLines) > 0 {
-				linesToAppend = append(linesToAppend, idx)
-				linesToAppendLenSum = linesToAppendLenSum + len(logLine.Content)
+			if pending != nil {
+				additionalLines.Append(logLine.Content)
 			}
 		} else {
-			flush()
-			analyzableLogLines = append(analyzableLogLines, logLine)
+			if pending != nil {
+				pending.Content += additionalLines.String()
+				additionalLines.Reset()
+				analyzableLogLines = append(analyzableLogLines, *pending)
+			}
+			pending = &logLine
 		}
 	}
-	flush()
+
+	if pending != nil {
+		pending.Content += additionalLines.String()
+		analyzableLogLines = append(analyzableLogLines, *pending)
+	}
+
 	return
 }
 


### PR DESCRIPTION
I've been working for multiple weeks with a customer that had consistent, ongoing crash loops of the collector in their environment. Part of the problem was tackled in #830 - the full snapshot was taking 2-3 minutes in most cases which increased memory usage and delayed data.

However, there was still periodic crash looping that couldn't be tied to a specific time period (full snapshot, time of day). In one testing run the process (running separately and not bound by `systemctl` `MaxMemory`) climbed to over 11GB in the span of a few minutes and had to be killed.

We ended up doing multiple remote sessions with different debug builds to get the `.mprof` dump when memory was climbing. Ultimately, we identified that they were getting significantly large JSON EXPLAIN plans (4MB or more) and the line-continuation path was using the inefficient `+=` on a string which reallocates the memory each time over thousands and thousands of lines. In a short 3-minute test run, a few EXPLAIN plans generated over 30GB of internal memory work on these reallocations.

After changing this section of code, the results on the next test run were immediate and dramatic. There was a contributing factor of a very stale and large state file that needs to be discussed separately. For now, the very old, stale file was deleted to free up the resources on next restart.

| Metric | Before | After |
|---|---|---|
| `relation_stats` query | ~112 s | ~0.5 s |
| Full snapshot | > 2 min | ~30 s |
| Collector live heap (`inuse_space`) | 4,364 MB | **56 MB** |
| Allocation churn (`alloc_space`) | 44.2 GB | 2.2 GB |
| Log-parse allocation churn | 38.6 GB | 0.44 GB |
| State-file decode at startup | 1.69 GB / 27M objects | ~16.8 MB |
| Stability | crash-loop, no full snapshots (weeks) | 5+ hours |

Aside from using a StringBuilder, there is currently an added cap of 10MB for any single log line. In this case we only pull 10MB from AWS so that single line cap shouldn't be reached, but the log size and content size were not actually bound together and, in theory, the log line could exceed the current cap if not specifically tested for. This will cause a warning message and the additional log line data to be dropped. Open to discussion.

Note: Customer is running this over the weekend and we are monitoring it. However, I wanted to get this PR opened as we potentially approach a new collector release to begin discussions. I can provide `.mprof` files if helpful.