### PR TITLE
Update go-tail library to avoid data race issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -116,4 +116,4 @@ require (
 
 go 1.26
 
-replace github.com/papertrail/go-tail => github.com/pganalyze/go-tail v0.0.0-20260708205228-8fab800841f3
+replace github.com/papertrail/go-tail => github.com/pganalyze/go-tail v0.0.0-20260713192021-82ac8bcb98c1

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/microsoft/go-mssqldb v1.8.0 h1:7cyZ/AT7ycDsEoWPIXibd+aVKFtteUNhDGf3ao
 github.com/microsoft/go-mssqldb v1.8.0/go.mod h1:6znkekS3T2vp0waiMhen4GPU1BiAsrP+iXHcE7a7rFo=
 github.com/ogier/pflag v0.0.0-20160129220114-45c278ab3607 h1:db+rES1EpSjP45xOU3hgS41oawQiZzqfnl6dUgBdFjY=
 github.com/ogier/pflag v0.0.0-20160129220114-45c278ab3607/go.mod h1:zkFki7tvTa0tafRvTBIZTvzYyAu6kQhPZFnshFFPE+g=
-github.com/pganalyze/go-tail v0.0.0-20260708205228-8fab800841f3 h1:B/hNceRye79VJbKTHfolrqWeNNxEGWNs6M3hL16mFFY=
-github.com/pganalyze/go-tail v0.0.0-20260708205228-8fab800841f3/go.mod h1:aUf8RteFEultHEEQ5zPUnFIs/hLoI2z8vJHmn0rcuEk=
+github.com/pganalyze/go-tail v0.0.0-20260713192021-82ac8bcb98c1 h1:zFey6vCvalZn0LBiUiC3l922tJQGRs/HQ4EeScLRh50=
+github.com/pganalyze/go-tail v0.0.0-20260713192021-82ac8bcb98c1/go.mod h1:aUf8RteFEultHEEQ5zPUnFIs/hLoI2z8vJHmn0rcuEk=
 github.com/pganalyze/pg_query_go/v6 v6.2.2 h1:O0L6zMC226R82RF3X5n0Ki6HjytDsoAzuzp4ATVAHNo=
 github.com/pganalyze/pg_query_go/v6 v6.2.2/go.mod h1:Cn6+j4870kJz3iYNsb0VsNG04vpSWgEvBwc590J4qD0=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/vendor/github.com/papertrail/go-tail/follower/follower.go
+++ b/vendor/github.com/papertrail/go-tail/follower/follower.go
@@ -40,16 +40,17 @@ type Config struct {
 }
 
 type Follower struct {
-	once     sync.Once
-	file     *os.File
-	filename string
-	lines    chan Line
-	err      error
-	config   Config
-	reader   *bufio.Reader
-	watcher  *fsnotify.Watcher
-	offset   int64
-	closeCh  chan struct{}
+	once      sync.Once
+	file      *os.File
+	filename  string
+	lines     chan Line
+	err       error
+	config    Config
+	reader    *bufio.Reader
+	watcher   *fsnotify.Watcher
+	offset    int64
+	closeCh   chan struct{}
+	closeOnce sync.Once
 }
 
 func New(filename string, config Config) (*Follower, error) {
@@ -57,7 +58,7 @@ func New(filename string, config Config) (*Follower, error) {
 		filename: filename,
 		lines:    make(chan Line),
 		config:   config,
-		closeCh:  make(chan struct{}, 1),
+		closeCh:  make(chan struct{}),
 	}
 
 	err := t.reopen()
@@ -79,10 +80,7 @@ func (t *Follower) Err() error {
 }
 
 func (t *Follower) Close() {
-	if t.file != nil {
-		t.file.Close()
-	}
-	t.closeCh <- struct{}{}
+	t.closeOnce.Do(func() { close(t.closeCh) })
 }
 
 func (t *Follower) run() {
@@ -152,7 +150,10 @@ func (t *Follower) follow() error {
 				break
 			}
 
-			t.sendLine(s, discarded)
+			if !t.sendLine(s, discarded) {
+				t.watcher.Remove(t.filename)
+				return nil
+			}
 		}
 
 		// we're now at EOF, so wait for changes
@@ -246,7 +247,16 @@ func (t *Follower) follow() error {
 
 func (t *Follower) rewatch() error {
 	t.watcher.Remove(t.filename)
-	if err := t.reopen(); err != nil {
+
+	// After a rename the new file may not exist yet, retry for up to 1 minute
+	var err error
+	for i := 0; i < 20; i++ {
+		if err = t.reopen(); err == nil || !os.IsNotExist(err) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
 		return err
 	}
 
@@ -281,8 +291,13 @@ func (t *Follower) close(err error) {
 	close(t.lines)
 }
 
-func (t *Follower) sendLine(l []byte, d int) {
-	t.lines <- Line{l[:len(l)-1], d}
+func (t *Follower) sendLine(l []byte, d int) bool {
+	select {
+	case t.lines <- Line{l[:len(l)-1], d}:
+		return true
+	case <-t.closeCh:
+		return false
+	}
 }
 
 func (t *Follower) watchFileEvents(eventChan chan fsnotify.Event, errChan chan error) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -384,7 +384,7 @@ github.com/mgutz/ansi
 # github.com/ogier/pflag v0.0.0-20160129220114-45c278ab3607
 ## explicit
 github.com/ogier/pflag
-# github.com/papertrail/go-tail v0.0.0-20180509224916-973c153b0431 => github.com/pganalyze/go-tail v0.0.0-20260708205228-8fab800841f3
+# github.com/papertrail/go-tail v0.0.0-20180509224916-973c153b0431 => github.com/pganalyze/go-tail v0.0.0-20260713192021-82ac8bcb98c1
 ## explicit; go 1.19
 github.com/papertrail/go-tail/follower
 # github.com/pganalyze/pg_query_go/v6 v6.2.2
@@ -820,4 +820,4 @@ gopkg.in/mcuadros/go-syslog.v2/format
 gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser
 gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc3164
 gopkg.in/mcuadros/go-syslog.v2/internal/syslogparser/rfc5424
-# github.com/papertrail/go-tail => github.com/pganalyze/go-tail v0.0.0-20260708205228-8fab800841f3
+# github.com/papertrail/go-tail => github.com/pganalyze/go-tail v0.0.0-20260713192021-82ac8bcb98c1


### PR DESCRIPTION
As seen in the test failures in #827, the recent go-tail changes made CI fail sometimes due to the Go race detector being unhappy about the early file closure. Instead, utilize different mechanisms to increase the reliability of the channel-style closure, and avoid the eager closure. See https://github.com/pganalyze/go-tail/pull/1

---

FWIW, I got a bit confused why #827 triggered this, since the base branch the author was using did not yet have the commit (da9c28aef9004b329090521d7d45fb1962fb3341) in question. Turns out, GitHub actually tests the merge branch in our GitHub actions set up (see [docs](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#how-the-merge-branch-affects-your-workflow)), so it first does a merge commit between main and the changes before running CI. That explains why an earlier run on that PR didn't trigger the failure, but a later run (after the go-tail commit was merged into main) did trigger it, despite that PR author not yet rebasing.