### PR TITLE
Use SHA-256 digests for RPM packages, to enable installation on FIPS systems

### DIFF
--- a/packages/src/Dockerfile.build.rpm-systemd
+++ b/packages/src/Dockerfile.build.rpm-systemd
@@ -64,7 +64,11 @@ COPY --from=build $CODE_DIR/packages $CODE_DIR/packages
 
 # Build the package
 WORKDIR $ROOT_DIR
+
 # Use xz payload compression so the RPM remains installable on Amazon Linux 2 / RPM 4.11.
+#
+# Use SHA-256 file digests (instead of fpm's MD5 default) so the RPM installs on FIPS-enabled
+# systems, which reject MD5. SHA-256 digests are supported since RPM 4.6 (2009).
 RUN fpm \
   -n $NAME -v ${VERSION} -t rpm --rpm-os linux --rpm-compression xz --rpm-digest sha256 \
   --config-files /etc/pganalyze-collector.conf \

--- a/packages/src/Dockerfile.build.rpm-systemd
+++ b/packages/src/Dockerfile.build.rpm-systemd
@@ -66,7 +66,7 @@ COPY --from=build $CODE_DIR/packages $CODE_DIR/packages
 WORKDIR $ROOT_DIR
 # Use xz payload compression so the RPM remains installable on Amazon Linux 2 / RPM 4.11.
 RUN fpm \
-  -n $NAME -v ${VERSION} -t rpm --rpm-os linux --rpm-compression xz \
+  -n $NAME -v ${VERSION} -t rpm --rpm-os linux --rpm-compression xz --rpm-digest sha256 \
   --config-files /etc/pganalyze-collector.conf \
   --after-install $CODE_DIR/packages/src/rpm-systemd/post.sh \
   --before-remove $CODE_DIR/packages/src/rpm-systemd/preun.sh \


### PR DESCRIPTION
follow on for https://github.com/pganalyze/collector/issues/826 https://github.com/pganalyze/collector/pull/827

the payload digest are sha256 and look good on a FIPS AL2023 instance: 
```sh
$ rpm -Kv /tmp/pganalyze-collector-0.71.0-1.x86_64.rpm
/tmp/pganalyze-collector-0.71.0-1.x86_64.rpm:
    Header V4 RSA/SHA256 Signature, key ID a2b5f2f9: OK
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    V4 RSA/SHA256 Signature, key ID a2b5f2f9: OK
```

but installation fails:
```sh
$ sudo rpm --upgrade /tmp/pganalyze-collector-0.71.0-1.x86_64.rpm
error: unpacking of archive failed on file /etc/pganalyze-collector.conf;6a6a3ee4: cpio: Digest mismatch
error: pganalyze-collector-0.71.0-1.x86_64: install failed
```

there is apparently another digest at play here and according to the fpm docs, it seems to default to md5 (which is blocked when the crypto policies are in FIPS mode)
https://github.com/jordansissel/fpm/blob/f51ba16fe8659cf2a4996a8e2b2e6a142bbc5b99/lib/fpm/package/rpm.rb#L66

confirmed by:
```sh
$ rpm -qp --qf '%{FILEDIGESTALGO}\n' /tmp/pganalyze-collector-0.71.0-1.x86_64.rpm
(none)
```