### PR TITLE
Test run: Check for pg_stat_statements.track = none

### DIFF
--- a/input/postgres/statements.go
+++ b/input/postgres/statements.go
@@ -318,6 +318,13 @@ func getStatementSource(ctx context.Context, c *Collection, db *sql.DB, showtext
 			c.SelfTest.MarkCollectionAspectWarning(state.CollectionAspectPgStatStatements, "%s", pgssMsg)
 			c.SelfTest.HintCollectionAspect(state.CollectionAspectPgStatStatements, "To update run `ALTER EXTENSION pg_stat_statements UPDATE`")
 		}
+
+		track, trackErr := GetPostgresSetting(ctx, db, "pg_stat_statements.track")
+		if trackErr == nil && track == "none" {
+			c.Logger.PrintError("pg_stat_statements.track is set to \"none\", no query statistics are being collected")
+			c.SelfTest.MarkCollectionAspectError(state.CollectionAspectPgStatStatements, "pg_stat_statements.track is set to \"none\", no query statistics are being collected")
+			c.SelfTest.HintCollectionAspect(state.CollectionAspectPgStatStatements, "Set pg_stat_statements.track to \"top\" (the default) or \"all\" to track query statistics.")
+		}
 	}
 
 	if c.HelperExists("get_stat_statements", []string{"boolean"}) || (showtext && c.HelperExists("get_stat_statements", nil)) {

--- a/selftest/summary.go
+++ b/selftest/summary.go
@@ -338,6 +338,9 @@ func getQueryPerformanceStatus(status *state.SelfTestResult) (icon string, msg s
 		return RedX, "database connection required", ""
 	}
 	if s := status.GetCollectionAspectStatus(state.CollectionAspectPgStatStatements); s == nil || s.State != state.CollectionStateOkay {
+		if s != nil && s.State == state.CollectionStateError {
+			return RedX, "not available due to pg_stat_statements error; see above", ""
+		}
 		return RedX, "pg_stat_statements required", ""
 	}
 	return GreenCheck, "ok", ""


### PR DESCRIPTION
This helps find the root cause when no query statistics are coming through, where previously the test summary output would have shown a green checkmark.