### PR TITLE
Fix config array parsing

### DIFF
--- a/input/postgres/functions.go
+++ b/input/postgres/functions.go
@@ -5,7 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/guregu/null"
+	"github.com/lib/pq"
 	"github.com/pganalyze/collector/state"
 	"github.com/pganalyze/collector/util"
 )
@@ -87,7 +87,7 @@ func GetFunctions(ctx context.Context, logger *util.Logger, db *sql.DB, postgres
 
 	for rows.Next() {
 		var row state.PostgresFunction
-		var config null.String
+		var config pq.StringArray
 
 		err := rows.Scan(&row.Oid, &row.SchemaName, &row.FunctionName, &row.Language, &row.Source,
 			&row.SourceBin, &config, &row.Arguments, &row.Result, &row.Kind,
@@ -111,7 +111,7 @@ func GetFunctions(ctx context.Context, logger *util.Logger, db *sql.DB, postgres
 		}
 
 		row.DatabaseOid = currentDatabaseOid
-		row.Config = unpackPostgresStringArray(config)
+		row.Config = config
 
 		functions = append(functions, row)
 	}

--- a/input/postgres/helpers.go
+++ b/input/postgres/helpers.go
@@ -25,16 +25,6 @@ func unpackPostgresOidArray(input null.String) (result []state.Oid) {
 	return
 }
 
-func unpackPostgresStringArray(input null.String) (result []string) {
-	if !input.Valid {
-		return
-	}
-
-	result = strings.Split(strings.Trim(input.String, "{}"), ",")
-
-	return
-}
-
 const resolveToastSQL string = `
 SELECT n.nspname, c.relname
   FROM pg_catalog.pg_class c

--- a/input/postgres/roles.go
+++ b/input/postgres/roles.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 
 	"github.com/guregu/null"
+	"github.com/lib/pq"
 	"github.com/pganalyze/collector/state"
 )
 
@@ -49,7 +50,8 @@ func getRoles(ctx context.Context, db *sql.DB, systemType string) ([]state.Postg
 
 	for rows.Next() {
 		var r state.PostgresRole
-		var config, memberOf null.String
+		var config pq.StringArray
+		var memberOf null.String
 
 		err := rows.Scan(&r.Oid, &r.Name, &r.Inherit, &r.Login, &r.CreateRole, &r.CreateDb, &r.SuperUser,
 			&r.CloudSuperUser, &r.MonitoringUser, &r.Replication, &r.ConnectionLimit, &r.PasswordValidUntil,
@@ -58,7 +60,7 @@ func getRoles(ctx context.Context, db *sql.DB, systemType string) ([]state.Postg
 			return nil, err
 		}
 
-		r.Config = unpackPostgresStringArray(config)
+		r.Config = config
 		r.MemberOf = unpackPostgresOidArray(memberOf)
 
 		roles = append(roles, r)

--- a/input/postgres/roles_test.go
+++ b/input/postgres/roles_test.go
@@ -1,0 +1,66 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"testing"
+
+	_ "github.com/lib/pq"
+	"github.com/pganalyze/collector/state"
+)
+
+// A multi-schema search_path (e.g. ALTER ROLE ... SET search_path = bluebox, public)
+// is stored by Postgres as a single, quoted rolconfig element:
+//
+//	{"search_path=bluebox, public"}
+//
+// This makes sure we parse it back into one element with the surrounding quotes
+// stripped, rather than naively splitting on the comma (which used to produce
+// ["\"search_path=bluebox", " public\""]).
+func TestGetRolesParsesMultiSchemaSearchPath(t *testing.T) {
+	testDatabaseUrl := os.Getenv("TEST_DATABASE_URL")
+	if testDatabaseUrl == "" {
+		t.Skipf("Skipping test requiring database connection since TEST_DATABASE_URL is not set")
+	}
+
+	db, err := sql.Open("postgres", testDatabaseUrl)
+	if err != nil {
+		t.Fatalf("Could not connect to test database: %s", err)
+	}
+	defer db.Close()
+
+	const roleName = "pganalyze_test_search_path_role"
+	if _, err := db.Exec("DROP ROLE IF EXISTS " + roleName); err != nil {
+		t.Fatalf("Could not drop pre-existing role: %s", err)
+	}
+	if _, err := db.Exec("CREATE ROLE " + roleName); err != nil {
+		t.Fatalf("Could not create role: %s", err)
+	}
+	defer db.Exec("DROP ROLE IF EXISTS " + roleName)
+
+	if _, err := db.Exec("ALTER ROLE " + roleName + " SET search_path = bluebox, public"); err != nil {
+		t.Fatalf("Could not set search_path: %s", err)
+	}
+
+	roles, err := getRoles(context.Background(), db, "")
+	if err != nil {
+		t.Fatalf("getRoles returned error: %s", err)
+	}
+
+	var found *state.PostgresRole
+	for i := range roles {
+		if roles[i].Name == roleName {
+			found = &roles[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("role %s not returned by getRoles", roleName)
+	}
+
+	expected := []string{"search_path=bluebox, public"}
+	if len(found.Config) != 1 || found.Config[0] != expected[0] {
+		t.Errorf("expected Config %v, got %v", expected, found.Config)
+	}
+}

--- a/input/postgres/roles_test.go
+++ b/input/postgres/roles_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/pganalyze/collector/state"
 )
 
-// A multi-schema search_path (e.g. ALTER ROLE ... SET search_path = bluebox, public)
+// A multi-schema search_path (e.g. ALTER ROLE ... SET search_path = pg_catalog, public)
 // is stored by Postgres as a single, quoted rolconfig element:
 //
-//	{"search_path=bluebox, public"}
+//	{"search_path=pg_catalog, public"}
 //
 // This makes sure we parse it back into one element with the surrounding quotes
 // stripped, rather than naively splitting on the comma (which used to produce
-// ["\"search_path=bluebox", " public\""]).
+// ["\"search_path=pg_catalog", " public\""]).
 func TestGetRolesParsesMultiSchemaSearchPath(t *testing.T) {
 	testDatabaseUrl := os.Getenv("TEST_DATABASE_URL")
 	if testDatabaseUrl == "" {
@@ -39,7 +39,7 @@ func TestGetRolesParsesMultiSchemaSearchPath(t *testing.T) {
 	}
 	defer db.Exec("DROP ROLE IF EXISTS " + roleName)
 
-	if _, err := db.Exec("ALTER ROLE " + roleName + " SET search_path = bluebox, public"); err != nil {
+	if _, err := db.Exec("ALTER ROLE " + roleName + " SET search_path = pg_catalog, public"); err != nil {
 		t.Fatalf("Could not set search_path: %s", err)
 	}
 
@@ -59,7 +59,7 @@ func TestGetRolesParsesMultiSchemaSearchPath(t *testing.T) {
 		t.Fatalf("role %s not returned by getRoles", roleName)
 	}
 
-	expected := []string{"search_path=bluebox, public"}
+	expected := []string{"search_path=pg_catalog, public"}
 	if len(found.Config) != 1 || found.Config[0] != expected[0] {
 		t.Errorf("expected Config %v, got %v", expected, found.Config)
 	}


### PR DESCRIPTION
A companion pganalyze change enabled Query Analysis to prefer a role-defined search_path, but it couldn't work if more than one schema was specified because the collector had stored the underlying config incorrectly.

unpackPostgresStringArray split text[] values on every comma and ignored Postgres array-literal quoting. A multi-schema search_path is stored as one quoted element ({"search_path=pg_catalog, public"}), which got mangled into:

["\"search_path=pg_catalog", " public\""]   # before
["search_path=pg_catalog, public"]          # after

This affected rolconfig and proconfig. Fixed by scanning with lib/pq's pq.StringArray (correct quoting/escaping); dropped the now-unused helper and added a gated regression test.

ATM there is no backfill fix associated with either change. `search_path` will only get fixed as the updated collector is deployed.