### PR TITLE
Fix log line ordering in log analysis

### DIFF
--- a/logs/analyze.go
+++ b/logs/analyze.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -1195,6 +1196,11 @@ func AnalyzeLogLines(logLinesIn []state.LogLine) (logLinesOut []state.LogLine, s
 		logLinesOut = append(logLinesOut, backendLogLinesOut...)
 		samples = append(samples, backendSamples...)
 	}
+
+	// Restore the original order of the lines, which the grouping above lost (Go randomizes
+	// map iteration order). Callers rely on the byte offsets still describing the log file,
+	// in particular for its ByteSize - pganalyze discards log lines that end past that.
+	sort.SliceStable(logLinesOut, func(i, j int) bool { return logLinesOut[i].ByteStart < logLinesOut[j].ByteStart })
 
 	return
 }

--- a/logs/analyze_test.go
+++ b/logs/analyze_test.go
@@ -1,6 +1,7 @@
 package logs_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -4710,6 +4711,37 @@ func TestAnalyzeLogLinesHeroku(t *testing.T) {
 			if !line.ReviewedForSecrets && line.LogLevel != pganalyze_collector.LogLineInformation_STATEMENT && line.LogLevel != pganalyze_collector.LogLineInformation_QUERY {
 				t.Errorf("Missing secret review for:\n%s %s\n", pair.logLinesIn[idx].LogLevel, pair.logLinesIn[idx].Content)
 			}
+		}
+	}
+}
+
+// Log analysis groups the lines by backend PID to get the right context, but callers
+// depend on getting them back in the order they passed them in: the byte offsets, and with
+// them the log file's byte_size, only describe the file as long as the order holds.
+func TestAnalyzeLogLinesPreservesOrder(t *testing.T) {
+	lineCount := 16
+	var logLinesIn []state.LogLine
+	var byteStart int64
+	for idx := range lineCount {
+		content := fmt.Sprintf("duplicate key value violates unique constraint \"index_%d\"\n", idx)
+		logLinesIn = append(logLinesIn, state.LogLine{
+			Content:    content,
+			LogLevel:   pganalyze_collector.LogLineInformation_ERROR,
+			BackendPid: int32(1000 + idx), // one backend per line, to maximize regrouping
+			ByteStart:  byteStart,
+			ByteEnd:    byteStart + int64(len(content)),
+		})
+		byteStart += int64(len(content))
+	}
+
+	logLinesOut, _ := logs.AnalyzeLogLines(logLinesIn)
+
+	if len(logLinesOut) != lineCount {
+		t.Fatalf("expected %d log lines, got %d", lineCount, len(logLinesOut))
+	}
+	for idx, logLine := range logLinesOut {
+		if logLine.ByteStart != logLinesIn[idx].ByteStart {
+			t.Errorf("log line %d out of order: expected byte_start %d, got %d", idx, logLinesIn[idx].ByteStart, logLine.ByteStart)
 		}
 	}
 }

--- a/logs/stream/stream.go
+++ b/logs/stream/stream.go
@@ -178,27 +178,6 @@ func createLogFile(readyLogLines []state.LogLine, logger *util.Logger) (state.Lo
 	return logFile, nil
 }
 
-// handleLogAnalysis - Performs log analysis on submitted log lines on a per-backend basis
-func handleLogAnalysis(analyzableLogLines []state.LogLine) ([]state.LogLine, []state.PostgresQuerySample) {
-	// Split log lines by backend to ensure we have the right context
-	backendLogLines := make(map[int32][]state.LogLine)
-
-	for _, logLine := range analyzableLogLines {
-		backendLogLines[logLine.BackendPid] = append(backendLogLines[logLine.BackendPid], logLine)
-	}
-
-	var logLinesOut []state.LogLine
-	var querySamples []state.PostgresQuerySample
-
-	for _, analyzableLogLines := range backendLogLines {
-		backendLogLinesOut, backendSamples := logs.AnalyzeBackendLogLines(analyzableLogLines)
-		logLinesOut = append(logLinesOut, backendLogLinesOut...)
-		querySamples = append(querySamples, backendSamples...)
-	}
-
-	return logLinesOut, querySamples
-}
-
 func stitchLogLines(readyLogLines []state.LogLine, logger *util.Logger) (analyzableLogLines []state.LogLine) {
 	// Each regular line is held back as the stitch target for continuation
 	// lines (lines that don't parse as a new log line, marked as log level
@@ -306,7 +285,7 @@ func AnalyzeStreamInGroups(logLines []state.LogLine, now time.Time, server *stat
 	}
 
 	logState := state.TransientLogState{CollectedAt: now}
-	logFile.LogLines, logState.QuerySamples = handleLogAnalysis(analyzableLogLines)
+	logFile.LogLines, logState.QuerySamples = logs.AnalyzeLogLines(analyzableLogLines)
 
 	return logState, logFile, tooFreshLogLines, nil
 }

--- a/logs/stream/stream_test.go
+++ b/logs/stream/stream_test.go
@@ -3,7 +3,6 @@ package stream_test
 import (
 	"log"
 	"os"
-	"sort"
 	"testing"
 	"time"
 
@@ -370,12 +369,6 @@ func TestAnalyzeStreamInGroups(t *testing.T) {
 		if diff := cfg.Compare(pair.TransientLogState, TransientLogState); diff != "" {
 			t.Errorf("For %v: log state diff: (-want +got)\n%s", pair.TransientLogState, diff)
 		}
-		sort.SliceStable(pair.logFile.LogLines, func(i, j int) bool {
-			return pair.logFile.LogLines[i].ByteStart < pair.logFile.LogLines[j].ByteStart
-		})
-		sort.SliceStable(logFile.LogLines, func(i, j int) bool {
-			return logFile.LogLines[i].ByteStart < logFile.LogLines[j].ByteStart
-		})
 		logFileContent := ""
 		for idx, logLine := range logFile.LogLines {
 			logFileContent += logLine.Content

--- a/output/transform/logs_test.go
+++ b/output/transform/logs_test.go
@@ -1,0 +1,73 @@
+package transform_test
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pganalyze/collector/config"
+	"github.com/pganalyze/collector/logs"
+	"github.com/pganalyze/collector/output/transform"
+	"github.com/pganalyze/collector/state"
+	"github.com/pganalyze/collector/util"
+)
+
+// A log snapshot has to describe the log data it carries: the log file's byte_size is where
+// the file ends, and its log lines have to tile the file in order for their byte offsets to
+// mean anything. pganalyze discards log lines that end past byte_size, so a byte_size that
+// falls short of the lines means silently dropped log lines.
+func TestLogSnapshotByteSizeMatchesLogLines(t *testing.T) {
+	lineCount := 16
+	server := state.MakeServer(config.ServerConfig{}, false)
+	server.LogParser = logs.NewLogParser(logs.LogPrefixSimple, nil, false)
+	logger := &util.Logger{Destination: log.New(os.Stderr, "", log.LstdFlags)}
+
+	var content strings.Builder
+	occurredAt := time.Date(2026, time.August, 3, 19, 37, 19, 0, time.UTC)
+	for idx := range lineCount {
+		// One backend per line, since log analysis groups the lines by backend PID
+		fmt.Fprintf(&content, "%s [%d] ERROR:  duplicate key value violates unique constraint \"index_%d\"\n",
+			occurredAt.Add(time.Duration(idx)*time.Second).Format("2006-01-02 15:04:05.000 MST"), 1000+idx, idx)
+	}
+
+	logLines, _ := logs.ParseAndAnalyzeBuffer(
+		bufio.NewReader(strings.NewReader(content.String())), time.Time{}, server, state.CollectionOpts{}, logger,
+	)
+	if len(logLines) != lineCount {
+		t.Fatalf("expected %d parsed log lines, got %d", lineCount, len(logLines))
+	}
+
+	logFile, err := state.NewLogFile("postgresql.log")
+	if err != nil {
+		t.Fatalf("could not initialize log file: %s", err)
+	}
+	logFile.LogLines = logLines
+	logFile.UpdateByteSize()
+
+	s, _ := transform.LogStateToLogSnapshot(server, state.TransientLogState{
+		CollectedAt: occurredAt,
+		LogFiles:    []state.LogFile{logFile},
+	})
+
+	byteSize := s.LogFileReferences[0].ByteSize
+	if byteSize != int64(content.Len()) {
+		t.Errorf("byte_size %d does not match the %d bytes of log lines in the snapshot", byteSize, content.Len())
+	}
+
+	var byteEnd int64
+	for idx, logLine := range s.LogLineInformations {
+		if logLine.ByteStart != byteEnd {
+			t.Errorf("log line %d does not continue the previous one: byte_start %d, previous byte_end %d",
+				idx, logLine.ByteStart, byteEnd)
+		}
+		byteEnd = logLine.ByteEnd
+
+		if logLine.ByteEnd > byteSize {
+			t.Errorf("log line %d ends past the file: byte_end %d, byte_size %d", idx, logLine.ByteEnd, byteSize)
+		}
+	}
+}

--- a/runner/logs.go
+++ b/runner/logs.go
@@ -334,7 +334,7 @@ func postprocessAndSendLogs(ctx context.Context, server *state.Server, opts stat
 		logFile := &transientLogState.LogFiles[idx]
 		if len(logFile.LogLines) > 0 {
 			logsExist = true
-			logFile.ByteSize = int64(logFile.LogLines[len(logFile.LogLines)-1].ByteEnd)
+			logFile.UpdateByteSize()
 		}
 		if len(logFile.FilterLogSecret) > 0 {
 			logs.ReplaceSecrets(logFile.LogLines, logFile.FilterLogSecret)

--- a/state/logs.go
+++ b/state/logs.go
@@ -169,6 +169,18 @@ type LogLine struct {
 	SecretMarkers      []LogSecretMarker
 }
 
+// UpdateByteSize sets ByteSize to where the log file's content ends, i.e. the end of its
+// last log line
+//
+// This relies on the log lines being in byte order, which log analysis guarantees. An
+// understated ByteSize loses data: pganalyze discards log lines that end past it.
+func (logFile *LogFile) UpdateByteSize() {
+	if len(logFile.LogLines) == 0 {
+		return
+	}
+	logFile.ByteSize = logFile.LogLines[len(logFile.LogLines)-1].ByteEnd
+}
+
 func NewLogFile(originalName string) (LogFile, error) {
 	uuid, err := uuid.NewV7()
 	if err != nil {


### PR DESCRIPTION
Our log line handling inadvertently reorders log lines during
analysis, but we rely on order to calculate byte offsets and log file
sizes. We use file sizes during snapshot processing.

See individual commits:
 - Add test showing that log line order is not preserved in analysis
 - Add test showing byte offset handling can lead to wrong log file size
 - Fix log line ordering issues by resorting
