### PR TITLE
🤖(amp): Accept fractional Actual Rows in PostgreSQL 18 EXPLAIN JSON

### DIFF
--- a/logs/querysample/normalize.go
+++ b/logs/querysample/normalize.go
@@ -23,7 +23,7 @@ type planNodeGroupingSet struct {
 
 type planNode struct {
 	ActualLoops                 *int64                   `json:"Actual Loops,omitempty"`
-	ActualRows                  *int64                   `json:"Actual Rows,omitempty"`
+	ActualRows                  *float64                 `json:"Actual Rows,omitempty"` // PostgreSQL 18+ reports fractional rows
 	ActualStartupTime           *float64                 `json:"Actual Startup Time,omitempty"`
 	ActualTotalTime             *float64                 `json:"Actual Total Time,omitempty"`
 	Alias                       *string                  `json:"Alias,omitempty"` // does not need normalize (table alias as specified in the query)

--- a/logs/querysample/normalize_test.go
+++ b/logs/querysample/normalize_test.go
@@ -214,3 +214,39 @@ func TestAutoExplainQuerySample(t *testing.T) {
 		}
 	}
 }
+
+func TestNormalizeExplainJSONPostgres18ActualRows(t *testing.T) {
+	tests := []struct {
+		name       string
+		actualRows string
+		want       float64
+	}{
+		{"fractional", "4.60", 4.6},
+		{"decimal integer", "1.00", 1},
+		{"decimal zero", "0.00", 0},
+		{"integer", "1", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			explain := &state.ExplainPlanContainer{
+				Plan: json.RawMessage(`{"Actual Rows": ` + tt.actualRows + `}`),
+			}
+
+			normalized, err := querysample.NormalizeExplainJSON(explain)
+			if err != nil {
+				t.Fatalf("Error normalizing PostgreSQL 18 Actual Rows value %s: %s", tt.actualRows, err)
+			}
+
+			var plan struct {
+				ActualRows float64 `json:"Actual Rows"`
+			}
+			if err := json.Unmarshal(normalized.Plan, &plan); err != nil {
+				t.Fatalf("Error unmarshaling normalized plan: %s", err)
+			}
+			if plan.ActualRows != tt.want {
+				t.Errorf("Actual Rows = %v, want %v", plan.ActualRows, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🤖(amp):

## Summary

- accept fractional `Actual Rows` values while normalizing EXPLAIN JSON
- retain compatibility with integer row counts from earlier PostgreSQL versions
- cover PostgreSQL 18 values such as `4.60`, `1.00`, and `0.00`

## Context

PostgreSQL 18 changed `Actual Rows` in EXPLAIN output to always use two fractional digits for executed nodes. The collector currently decodes this field as `int64`, so Go rejects values such as `1.00` during query sample normalization.

Only `Actual Rows` is widened: `Actual Loops` and `Rows Removed by ...` continue to be emitted with zero fractional digits.

PostgreSQL change: https://github.com/postgres/postgres/commit/95dbd827f2edc4d10bebd7e840a0bd6782cf69b7

## Verification

- `go test ./logs/querysample/...`
- `make test`