### PR TITLE
Prevent invalid UTF-8 values in Postgres settings or other protobuf snapshot data from dropping entire snapshot

### DIFF
--- a/input/postgres/backend_counts.go
+++ b/input/postgres/backend_counts.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/pganalyze/collector/state"
+	"github.com/pganalyze/collector/util"
 )
 
 const backendCountsSQL string = `
@@ -45,10 +46,10 @@ func GetBackendCounts(ctx context.Context, c *Collection, db *sql.DB) ([]state.P
 			return nil, err
 		}
 
-		// Special case to avoid errors for certain backends with weird names
-		if c.Config.SystemType == "azure_database" {
-			row.BackendType = strings.ToValidUTF8(row.BackendType, "")
-		}
+		// backend_type can contain invalid UTF-8 on some platforms (e.g. Azure
+		// management backends, Supabase's Supavisor), which would fail snapshot
+		// marshaling; scrub it uniformly to the replacement character.
+		row.BackendType = strings.ToValidUTF8(row.BackendType, util.InvalidUTF8Replacement)
 
 		backendCounts = append(backendCounts, row)
 	}

--- a/input/postgres/backends.go
+++ b/input/postgres/backends.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/pganalyze/collector/state"
+	"github.com/pganalyze/collector/util"
 )
 
 const pgBlockingPidsField = `
@@ -69,9 +70,11 @@ func GetBackends(ctx context.Context, c *Collection, db *sql.DB) ([]state.Postgr
 			return nil, err
 		}
 
-		// Special case to avoid errors for certain backends with weird names
-		if c.Config.SystemType == "azure_database" && row.BackendType.Valid {
-			row.BackendType.String = strings.ToValidUTF8(row.BackendType.String, "")
+		// backend_type can contain invalid UTF-8 on some platforms (e.g. Azure
+		// management backends, Supabase's Supavisor), which would fail snapshot
+		// marshaling; scrub it uniformly to the replacement character.
+		if row.BackendType.Valid {
+			row.BackendType.String = strings.ToValidUTF8(row.BackendType.String, util.InvalidUTF8Replacement)
 		}
 
 		activities = append(activities, row)

--- a/output/transform/postgres.go
+++ b/output/transform/postgres.go
@@ -2,11 +2,25 @@ package transform
 
 import (
 	"time"
+	"unicode/utf8"
 
 	snapshot "github.com/pganalyze/collector/output/pganalyze_collector"
 	"github.com/pganalyze/collector/state"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// when a setting value isn't valid UTF-8 (originally hit on pgsodium "boot_val") and therefore
+// can't be marshalled in a protobuf string field, replace with this consistent placeholder value
+// so that the snapshot can still be sent and we don't trigger value change logic every time
+// the non-UTF8 value changes.
+const settingValueNonUTF8 = "<non-utf8 value>"
+
+func settingValue(v string) string {
+	if !utf8.ValidString(v) {
+		return settingValueNonUTF8
+	}
+	return v
+}
 
 type OidToIdx map[state.Oid]int32
 
@@ -123,16 +137,16 @@ func transformPostgresConfig(s snapshot.FullSnapshot, transientState state.Trans
 		info := snapshot.Setting{Name: setting.Name}
 
 		if setting.CurrentValue.Valid {
-			info.CurrentValue = setting.CurrentValue.String
+			info.CurrentValue = settingValue(setting.CurrentValue.String)
 		}
 		if setting.Unit.Valid {
 			info.Unit = &snapshot.NullString{Valid: true, Value: setting.Unit.String}
 		}
 		if setting.BootValue.Valid {
-			info.BootValue = &snapshot.NullString{Valid: true, Value: setting.BootValue.String}
+			info.BootValue = &snapshot.NullString{Valid: true, Value: settingValue(setting.BootValue.String)}
 		}
 		if setting.ResetValue.Valid {
-			info.ResetValue = &snapshot.NullString{Valid: true, Value: setting.ResetValue.String}
+			info.ResetValue = &snapshot.NullString{Valid: true, Value: settingValue(setting.ResetValue.String)}
 		}
 		if setting.Source.Valid {
 			info.Source = &snapshot.NullString{Valid: true, Value: setting.Source.String}

--- a/output/transform/postgres.go
+++ b/output/transform/postgres.go
@@ -9,13 +9,26 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// when a setting value isn't valid UTF-8 (originally hit on pgsodium "boot_val") and therefore
-// can't be marshalled in a protobuf string field, replace with this consistent placeholder value
-// so that the snapshot can still be sent and we don't trigger value change logic every time
-// the non-UTF8 value changes.
+// maskedSettingNames lists GUCs whose values are known to be unstable or not
+// meaningfully representable; their values are always replaced with a constant,
+// regardless of the current bytes. Masking by name keeps the value from flipping
+// snapshot-to-snapshot (which would churn config-change tracking) and avoids
+// shipping unstable data and increased noise. Add others here as we run into them.
+var maskedSettingNames = map[string]bool{
+	"pgsodium.getkey_script": true,
+}
+
+const settingValueMasked = "<masked value>"
+
+// settingValueNonUTF8 is the fallback for any *other* setting value that isn't valid
+// UTF-8 (and so can't be put in a protobuf string field), so the snapshot can still be
+// sent rather than dropped.
 const settingValueNonUTF8 = "<non-utf8 value>"
 
-func settingValue(v string) string {
+func settingValue(name, v string) string {
+	if maskedSettingNames[name] {
+		return settingValueMasked
+	}
 	if !utf8.ValidString(v) {
 		return settingValueNonUTF8
 	}
@@ -137,16 +150,16 @@ func transformPostgresConfig(s snapshot.FullSnapshot, transientState state.Trans
 		info := snapshot.Setting{Name: setting.Name}
 
 		if setting.CurrentValue.Valid {
-			info.CurrentValue = settingValue(setting.CurrentValue.String)
+			info.CurrentValue = settingValue(setting.Name, setting.CurrentValue.String)
 		}
 		if setting.Unit.Valid {
 			info.Unit = &snapshot.NullString{Valid: true, Value: setting.Unit.String}
 		}
 		if setting.BootValue.Valid {
-			info.BootValue = &snapshot.NullString{Valid: true, Value: settingValue(setting.BootValue.String)}
+			info.BootValue = &snapshot.NullString{Valid: true, Value: settingValue(setting.Name, setting.BootValue.String)}
 		}
 		if setting.ResetValue.Valid {
-			info.ResetValue = &snapshot.NullString{Valid: true, Value: settingValue(setting.ResetValue.String)}
+			info.ResetValue = &snapshot.NullString{Valid: true, Value: settingValue(setting.Name, setting.ResetValue.String)}
 		}
 		if setting.Source.Valid {
 			info.Source = &snapshot.NullString{Valid: true, Value: setting.Source.String}

--- a/output/transform/postgres_config_test.go
+++ b/output/transform/postgres_config_test.go
@@ -8,11 +8,15 @@ import (
 	"github.com/pganalyze/collector/state"
 )
 
-func TestTransformPostgresConfigMarksNonUTF8SettingValues(t *testing.T) {
+func TestTransformPostgresConfigMasksAndMarksSettingValues(t *testing.T) {
 	ts := state.TransientState{
 		Settings: []state.PostgresSetting{
-			// The real pgsodium case: a binary boot_val that isn't valid UTF-8.
-			{Name: "pgsodium.getkey_script", BootValue: null.StringFrom("p;\xd3\xf3DY")},
+			// Denylisted GUC: masked regardless of UTF-8 validity. Its boot_val here is
+			// invalid UTF-8 while its current value is *valid* UTF-8 garbage - both must
+			// be masked so the value doesn't flip snapshot-to-snapshot.
+			{Name: "pgsodium.getkey_script", CurrentValue: null.StringFrom("Zm9vYmFy"), BootValue: null.StringFrom("p;\xd3\xf3DY")},
+			// Not denylisted but invalid UTF-8: falls back to the generic marker.
+			{Name: "some_ext.blob", BootValue: null.StringFrom("x\xffy")},
 			// A normal setting must pass through untouched.
 			{Name: "work_mem", CurrentValue: null.StringFrom("4MB"), BootValue: null.StringFrom("4MB")},
 		},
@@ -25,9 +29,18 @@ func TestTransformPostgresConfigMarksNonUTF8SettingValues(t *testing.T) {
 		byName[st.Name] = st
 	}
 
-	if got := byName["pgsodium.getkey_script"].BootValue.Value; got != settingValueNonUTF8 {
+	// Denylisted: both value fields masked, including the valid-UTF-8 one.
+	if got := byName["pgsodium.getkey_script"].BootValue.Value; got != settingValueMasked {
+		t.Errorf("denylisted boot value = %q, want mask %q", got, settingValueMasked)
+	}
+	if got := byName["pgsodium.getkey_script"].CurrentValue; got != settingValueMasked {
+		t.Errorf("denylisted current value (valid UTF-8) = %q, want mask %q", got, settingValueMasked)
+	}
+	// Not denylisted but invalid UTF-8: generic marker.
+	if got := byName["some_ext.blob"].BootValue.Value; got != settingValueNonUTF8 {
 		t.Errorf("non-UTF-8 boot value = %q, want marker %q", got, settingValueNonUTF8)
 	}
+	// Normal setting untouched.
 	if got := byName["work_mem"].BootValue.Value; got != "4MB" {
 		t.Errorf("valid boot value should be untouched, got %q", got)
 	}

--- a/output/transform/postgres_config_test.go
+++ b/output/transform/postgres_config_test.go
@@ -1,0 +1,37 @@
+package transform
+
+import (
+	"testing"
+
+	"github.com/guregu/null"
+	snapshot "github.com/pganalyze/collector/output/pganalyze_collector"
+	"github.com/pganalyze/collector/state"
+)
+
+func TestTransformPostgresConfigMarksNonUTF8SettingValues(t *testing.T) {
+	ts := state.TransientState{
+		Settings: []state.PostgresSetting{
+			// The real pgsodium case: a binary boot_val that isn't valid UTF-8.
+			{Name: "pgsodium.getkey_script", BootValue: null.StringFrom("p;\xd3\xf3DY")},
+			// A normal setting must pass through untouched.
+			{Name: "work_mem", CurrentValue: null.StringFrom("4MB"), BootValue: null.StringFrom("4MB")},
+		},
+	}
+
+	s := transformPostgresConfig(snapshot.FullSnapshot{}, ts)
+
+	byName := map[string]*snapshot.Setting{}
+	for _, st := range s.Settings {
+		byName[st.Name] = st
+	}
+
+	if got := byName["pgsodium.getkey_script"].BootValue.Value; got != settingValueNonUTF8 {
+		t.Errorf("non-UTF-8 boot value = %q, want marker %q", got, settingValueNonUTF8)
+	}
+	if got := byName["work_mem"].BootValue.Value; got != "4MB" {
+		t.Errorf("valid boot value should be untouched, got %q", got)
+	}
+	if got := byName["work_mem"].CurrentValue; got != "4MB" {
+		t.Errorf("valid current value should be untouched, got %q", got)
+	}
+}

--- a/output/upload.go
+++ b/output/upload.go
@@ -7,11 +7,14 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/pganalyze/collector/state"
 	"github.com/pganalyze/collector/util"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 func SetupSnapshotUploadForAllServers(ctx context.Context, servers []*state.Server, opts state.CollectionOpts, logger *util.Logger) {
@@ -31,9 +34,9 @@ func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *
 		case <-ctx.Done():
 			return
 		case s := <-server.FullSnapshotUpload:
-			data, err := proto.Marshal(s)
+			data, err := marshalSnapshot(s, logger)
 			if err != nil {
-				logger.PrintError("Error marshaling protocol buffers")
+				logger.PrintError("Error marshaling protocol buffers: %s", err)
 				continue
 			}
 
@@ -44,9 +47,9 @@ func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *
 				logger.PrintInfo("Submitted full snapshot successfully")
 			}
 		case s := <-server.CompactSnapshotUpload:
-			data, err := proto.Marshal(s)
+			data, err := marshalSnapshot(s, logger)
 			if err != nil {
-				logger.PrintError("Error marshaling protocol buffers")
+				logger.PrintError("Error marshaling protocol buffers: %s", err)
 				continue
 			}
 
@@ -72,6 +75,98 @@ func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *
 				compactLogTime = time.Now().Truncate(time.Minute)
 				compactLogStats = make(map[string]uint8)
 			}
+		}
+	}
+}
+
+// The Unicode replacement character (U+FFFD) substituted for runs
+// of invalid bytes, so an unrepresentable field becomes a valid (if lossy) string.
+const utf8Replacement = "\uFFFD"
+
+// Marshal a snapshot. If it fails due to invalid UTF-8 in a string field, scrub
+// the offending bytes and retry once.
+func marshalSnapshot(m proto.Message, logger *util.Logger) ([]byte, error) {
+	data, err := proto.Marshal(m)
+	if err != nil {
+		sanitizeInvalidUTF8(m.ProtoReflect())
+		data, err = proto.Marshal(m)
+		if err == nil {
+			logger.PrintVerbose("Sanitized invalid UTF-8 in a snapshot string field before marshaling")
+		}
+	}
+	return data, err
+}
+
+// Recursively replaces invalid UTF-8 in every string field, list element, and map key/value
+// of a proto message. Mutations to scalar string fields are deferred until after the range,
+// since protoreflect only permits mutating the current field's own value during iteration.
+func sanitizeInvalidUTF8(msg protoreflect.Message) {
+	var fixFds []protoreflect.FieldDescriptor
+	var fixVals []string
+	msg.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		switch {
+		case fd.IsList():
+			sanitizeUTF8List(fd, v.List())
+		case fd.IsMap():
+			sanitizeUTF8Map(fd, v.Map())
+		case fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind:
+			sanitizeInvalidUTF8(v.Message())
+		case fd.Kind() == protoreflect.StringKind:
+			if s := v.String(); !utf8.ValidString(s) {
+				fixFds = append(fixFds, fd)
+				fixVals = append(fixVals, strings.ToValidUTF8(s, utf8Replacement))
+			}
+		}
+		return true
+	})
+	for i, fd := range fixFds {
+		msg.Set(fd, protoreflect.ValueOfString(fixVals[i]))
+	}
+}
+
+func sanitizeUTF8List(fd protoreflect.FieldDescriptor, list protoreflect.List) {
+	switch fd.Kind() {
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		for i := 0; i < list.Len(); i++ {
+			sanitizeInvalidUTF8(list.Get(i).Message())
+		}
+	case protoreflect.StringKind:
+		for i := 0; i < list.Len(); i++ {
+			if s := list.Get(i).String(); !utf8.ValidString(s) {
+				list.Set(i, protoreflect.ValueOfString(strings.ToValidUTF8(s, utf8Replacement)))
+			}
+		}
+	}
+}
+
+func sanitizeUTF8Map(fd protoreflect.FieldDescriptor, m protoreflect.Map) {
+	valFd := fd.MapValue()
+	valIsMessage := valFd.Kind() == protoreflect.MessageKind || valFd.Kind() == protoreflect.GroupKind
+	valIsString := valFd.Kind() == protoreflect.StringKind
+	keyIsString := fd.MapKey().Kind() == protoreflect.StringKind
+
+	var fixKeys []protoreflect.MapKey
+	m.Range(func(mk protoreflect.MapKey, mv protoreflect.Value) bool {
+		if valIsMessage {
+			sanitizeInvalidUTF8(mv.Message())
+		}
+		badVal := valIsString && !utf8.ValidString(mv.String())
+		badKey := keyIsString && !utf8.ValidString(mk.String())
+		if badVal || badKey {
+			fixKeys = append(fixKeys, mk)
+		}
+		return true
+	})
+	for _, mk := range fixKeys {
+		val := m.Get(mk)
+		if valIsString && !utf8.ValidString(val.String()) {
+			val = protoreflect.ValueOfString(strings.ToValidUTF8(val.String(), utf8Replacement))
+		}
+		if keyIsString && !utf8.ValidString(mk.String()) {
+			m.Clear(mk)
+			m.Set(protoreflect.ValueOfString(strings.ToValidUTF8(mk.String(), utf8Replacement)).MapKey(), val)
+		} else {
+			m.Set(mk, val)
 		}
 	}
 }

--- a/output/upload.go
+++ b/output/upload.go
@@ -79,42 +79,46 @@ func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *
 	}
 }
 
-// The Unicode replacement character (U+FFFD) substituted for runs
-// of invalid bytes, so an unrepresentable field becomes a valid (if lossy) string.
-const utf8Replacement = "\uFFFD"
+const utf8Replacement = util.InvalidUTF8Replacement
 
-// Marshal a snapshot. If it fails due to invalid UTF-8 in a string field, scrub
-// the offending bytes and retry once.
+// Marshal a snapshot. If it fails due to invalid UTF-8 in a string field, scrub the
+// offending bytes and retry once, logging which field(s) were affected. Reporting the
+// paths keeps this from silently masking problems: an unexpected field showing up here
+// is a signal to handle it tactically (e.g. add the setting to the denylist).
 func marshalSnapshot(m proto.Message, logger *util.Logger) ([]byte, error) {
 	data, err := proto.Marshal(m)
 	if err != nil {
-		sanitizeInvalidUTF8(m.ProtoReflect())
+		fixed := sanitizeInvalidUTF8("", m.ProtoReflect())
 		data, err = proto.Marshal(m)
-		if err == nil {
-			logger.PrintVerbose("Sanitized invalid UTF-8 in a snapshot string field before marshaling")
+		if err == nil && len(fixed) > 0 {
+			logger.PrintWarning("Replaced invalid UTF-8 to allow snapshot marshaling; affected field(s): %s", strings.Join(fixed, ", "))
 		}
 	}
 	return data, err
 }
 
-// Recursively replaces invalid UTF-8 in every string field, list element, and map key/value
-// of a proto message. Mutations to scalar string fields are deferred until after the range,
-// since protoreflect only permits mutating the current field's own value during iteration.
-func sanitizeInvalidUTF8(msg protoreflect.Message) {
+// Recursively replaces invalid UTF-8 in every string field, list element, and map
+// key/value of a proto message, returning the paths it fixed. Mutations to scalar string
+// fields are deferred until after the range, since protoreflect only permits mutating the
+// current field's own value during iteration.
+func sanitizeInvalidUTF8(prefix string, msg protoreflect.Message) []string {
+	var fixed []string
 	var fixFds []protoreflect.FieldDescriptor
 	var fixVals []string
 	msg.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		name := prefix + string(fd.Name())
 		switch {
 		case fd.IsList():
-			sanitizeUTF8List(fd, v.List())
+			fixed = append(fixed, sanitizeUTF8List(name, fd, v.List())...)
 		case fd.IsMap():
-			sanitizeUTF8Map(fd, v.Map())
+			fixed = append(fixed, sanitizeUTF8Map(name, fd, v.Map())...)
 		case fd.Kind() == protoreflect.MessageKind || fd.Kind() == protoreflect.GroupKind:
-			sanitizeInvalidUTF8(v.Message())
+			fixed = append(fixed, sanitizeInvalidUTF8(name+".", v.Message())...)
 		case fd.Kind() == protoreflect.StringKind:
 			if s := v.String(); !utf8.ValidString(s) {
 				fixFds = append(fixFds, fd)
 				fixVals = append(fixVals, strings.ToValidUTF8(s, utf8Replacement))
+				fixed = append(fixed, name)
 			}
 		}
 		return true
@@ -122,24 +126,29 @@ func sanitizeInvalidUTF8(msg protoreflect.Message) {
 	for i, fd := range fixFds {
 		msg.Set(fd, protoreflect.ValueOfString(fixVals[i]))
 	}
+	return fixed
 }
 
-func sanitizeUTF8List(fd protoreflect.FieldDescriptor, list protoreflect.List) {
+func sanitizeUTF8List(name string, fd protoreflect.FieldDescriptor, list protoreflect.List) []string {
+	var fixed []string
 	switch fd.Kind() {
 	case protoreflect.MessageKind, protoreflect.GroupKind:
 		for i := 0; i < list.Len(); i++ {
-			sanitizeInvalidUTF8(list.Get(i).Message())
+			fixed = append(fixed, sanitizeInvalidUTF8(fmt.Sprintf("%s[%d].", name, i), list.Get(i).Message())...)
 		}
 	case protoreflect.StringKind:
 		for i := 0; i < list.Len(); i++ {
 			if s := list.Get(i).String(); !utf8.ValidString(s) {
 				list.Set(i, protoreflect.ValueOfString(strings.ToValidUTF8(s, utf8Replacement)))
+				fixed = append(fixed, fmt.Sprintf("%s[%d]", name, i))
 			}
 		}
 	}
+	return fixed
 }
 
-func sanitizeUTF8Map(fd protoreflect.FieldDescriptor, m protoreflect.Map) {
+func sanitizeUTF8Map(name string, fd protoreflect.FieldDescriptor, m protoreflect.Map) []string {
+	var fixed []string
 	valFd := fd.MapValue()
 	valIsMessage := valFd.Kind() == protoreflect.MessageKind || valFd.Kind() == protoreflect.GroupKind
 	valIsString := valFd.Kind() == protoreflect.StringKind
@@ -148,7 +157,7 @@ func sanitizeUTF8Map(fd protoreflect.FieldDescriptor, m protoreflect.Map) {
 	var fixKeys []protoreflect.MapKey
 	m.Range(func(mk protoreflect.MapKey, mv protoreflect.Value) bool {
 		if valIsMessage {
-			sanitizeInvalidUTF8(mv.Message())
+			fixed = append(fixed, sanitizeInvalidUTF8(fmt.Sprintf("%s[%v].", name, mk.Interface()), mv.Message())...)
 		}
 		badVal := valIsString && !utf8.ValidString(mv.String())
 		badKey := keyIsString && !utf8.ValidString(mk.String())
@@ -161,14 +170,17 @@ func sanitizeUTF8Map(fd protoreflect.FieldDescriptor, m protoreflect.Map) {
 		val := m.Get(mk)
 		if valIsString && !utf8.ValidString(val.String()) {
 			val = protoreflect.ValueOfString(strings.ToValidUTF8(val.String(), utf8Replacement))
+			fixed = append(fixed, fmt.Sprintf("%s[%v]", name, mk.Interface()))
 		}
 		if keyIsString && !utf8.ValidString(mk.String()) {
+			fixed = append(fixed, fmt.Sprintf("%s[key %q]", name, mk.String()))
 			m.Clear(mk)
 			m.Set(protoreflect.ValueOfString(strings.ToValidUTF8(mk.String(), utf8Replacement)).MapKey(), val)
 		} else {
 			m.Set(mk, val)
 		}
 	}
+	return fixed
 }
 
 func summarizeCounts(counts map[string]uint8) string {

--- a/output/upload_utf8_test.go
+++ b/output/upload_utf8_test.go
@@ -3,6 +3,7 @@ package output
 import (
 	"log"
 	"os"
+	"strings"
 	"testing"
 	"unicode/utf8"
 
@@ -49,10 +50,13 @@ func TestSanitizeInvalidUTF8Map(t *testing.T) {
 		t.Fatal("expected raw proto.Marshal to reject the invalid UTF-8 map entry")
 	}
 
-	sanitizeInvalidUTF8(si.ProtoReflect())
+	fixed := sanitizeInvalidUTF8("", si.ProtoReflect())
 
 	if _, err := proto.Marshal(si); err != nil {
 		t.Fatalf("marshal should succeed after scrub, got: %v", err)
+	}
+	if len(fixed) == 0 || !containsPathPrefix(fixed, "resource_tags") {
+		t.Errorf("expected reported paths to include resource_tags, got %v", fixed)
 	}
 	if len(si.ResourceTags) != 2 {
 		t.Errorf("expected 2 map entries after scrub, got %d", len(si.ResourceTags))
@@ -65,4 +69,25 @@ func TestSanitizeInvalidUTF8Map(t *testing.T) {
 			t.Errorf("map value still invalid: %q", v)
 		}
 	}
+}
+
+func TestSanitizeInvalidUTF8ReportsNestedPath(t *testing.T) {
+	fs := &snapshot.FullSnapshot{
+		Settings: []*snapshot.Setting{
+			{Name: "pgsodium.getkey_script", BootValue: &snapshot.NullString{Valid: true, Value: bad}},
+		},
+	}
+	fixed := sanitizeInvalidUTF8("", fs.ProtoReflect())
+	if !containsPathPrefix(fixed, "settings[0].boot_value.value") {
+		t.Errorf("expected reported path settings[0].boot_value.value, got %v", fixed)
+	}
+}
+
+func containsPathPrefix(paths []string, prefix string) bool {
+	for _, p := range paths {
+		if strings.HasPrefix(p, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/output/upload_utf8_test.go
+++ b/output/upload_utf8_test.go
@@ -1,0 +1,68 @@
+package output
+
+import (
+	"log"
+	"os"
+	"testing"
+	"unicode/utf8"
+
+	snapshot "github.com/pganalyze/collector/output/pganalyze_collector"
+	"github.com/pganalyze/collector/util"
+	"google.golang.org/protobuf/proto"
+)
+
+// bad is the exact invalid-UTF-8 value observed in pgsodium.getkey_script's boot_val
+// on a live Supabase instance.
+const bad = "p;\xd3\xf3DY"
+
+func TestMarshalSnapshotRecoversNestedInvalidUTF8(t *testing.T) {
+	// The real case: FullSnapshot -> repeated Setting -> BootValue (message) -> Value.
+	fs := &snapshot.FullSnapshot{
+		Settings: []*snapshot.Setting{
+			{Name: "pgsodium.getkey_script", BootValue: &snapshot.NullString{Valid: true, Value: bad}},
+		},
+	}
+
+	if _, err := proto.Marshal(fs); err == nil {
+		t.Fatal("expected raw proto.Marshal to reject the invalid UTF-8")
+	}
+
+	logger := &util.Logger{Destination: log.New(os.Stderr, "", log.LstdFlags)}
+	data, err := marshalSnapshot(fs, logger)
+	if err != nil {
+		t.Fatalf("marshalSnapshot should recover, got: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected non-empty marshaled data")
+	}
+	if v := fs.Settings[0].BootValue.Value; !utf8.ValidString(v) {
+		t.Errorf("boot value still invalid after scrub: %q", v)
+	}
+}
+
+func TestSanitizeInvalidUTF8Map(t *testing.T) {
+	// Map with both a bad value and a bad key.
+	si := &snapshot.SystemInformation{
+		ResourceTags: map[string]string{"good-key": bad, bad: "good-value"},
+	}
+	if _, err := proto.Marshal(si); err == nil {
+		t.Fatal("expected raw proto.Marshal to reject the invalid UTF-8 map entry")
+	}
+
+	sanitizeInvalidUTF8(si.ProtoReflect())
+
+	if _, err := proto.Marshal(si); err != nil {
+		t.Fatalf("marshal should succeed after scrub, got: %v", err)
+	}
+	if len(si.ResourceTags) != 2 {
+		t.Errorf("expected 2 map entries after scrub, got %d", len(si.ResourceTags))
+	}
+	for k, v := range si.ResourceTags {
+		if !utf8.ValidString(k) {
+			t.Errorf("map key still invalid: %q", k)
+		}
+		if !utf8.ValidString(v) {
+			t.Errorf("map value still invalid: %q", v)
+		}
+	}
+}

--- a/util/utf8.go
+++ b/util/utf8.go
@@ -1,0 +1,7 @@
+package util
+
+// InvalidUTF8Replacement is the Unicode replacement character (U+FFFD). The collector
+// substitutes it for runs of invalid bytes so a value that isn't valid UTF-8 can still
+// be carried in a protobuf string field (proto3 strings must be valid UTF-8). Shared so
+// every place that scrubs invalid bytes does so identically.
+const InvalidUTF8Replacement = "\uFFFD"


### PR DESCRIPTION
After releasing support for Supabase, a pre-existing database that monitoring had been working on stopped mysteriously submitting snapshots. Tests actually came back OK, but mixed in with the test output was "Error marshaling protocol buffers".

Eventually, with some help, I tracked it down to a GUC setting for `pgsodium`, a Supabase cryptography extension. It appears that the encryption key (maybe?) changed since I last had monitoring working and now contained invalid UTF-8 data. Therefore, the protobuf data couldn't be marshalled.

After a few iterations, this is the solution I settled on. At the very least, we need to guard against non-UTF8 data in settings (it appears to also have happened with backend types for Azure previously). But, potentially overkill, I also added a "catch all" to attempt and scrub data if the protobuf fails to marshall other data.

For settings, I thought following a similar principle to something like "\<truncated query\>" or "\<missing query text\>" was appropriate since we don't really know what the data is anyway and printing it has little value in my opinion (initially at least).

Replacing it in the snapshot also has the added benefit of not triggering any "settings have changed" logic that we might be planning if data like this changes periodically but the user has no control over it.

<img width="2124" height="129" alt="image" src="https://github.com/user-attachments/assets/bcf8f896-a72c-42ef-883a-4ee2c72dac0c" />
