### PR TITLE
Avoid disrupting snapshot collection when uploads are slow/delayed

### DIFF
--- a/output/compact.go
+++ b/output/compact.go
@@ -39,7 +39,11 @@ func uploadAndSubmitCompactSnapshot(ctx context.Context, s *pganalyze_collector.
 		return nil
 	}
 
-	server.CompactSnapshotUpload <- s
+	select {
+	case server.CompactSnapshotUpload <- s:
+	default:
+		return fmt.Errorf("skipping compact %s snapshot, upload queue is full (previous snapshot uploads may be slow or stuck)", kindFromCompactSnapshot(s))
+	}
 
 	return nil
 }

--- a/output/full.go
+++ b/output/full.go
@@ -65,7 +65,11 @@ func submitFull(ctx context.Context, s *snapshot.FullSnapshot, server *state.Ser
 		return nil
 	}
 
-	server.FullSnapshotUpload <- s
+	select {
+	case server.FullSnapshotUpload <- s:
+	default:
+		return fmt.Errorf("skipping full snapshot, upload queue is full (previous snapshot uploads may be slow or stuck)")
+	}
 
 	return nil
 }

--- a/output/upload.go
+++ b/output/upload.go
@@ -108,7 +108,7 @@ func uploadViaWebsocketOrHttp(ctx context.Context, server *state.Server, logger 
 		if err != nil {
 			return err
 		}
-		submitSnapshot(ctx, server, opts, logger, s3Location, collectedAt, compactSnapshot)
+		return submitSnapshot(ctx, server, opts, logger, s3Location, collectedAt, compactSnapshot)
 	}
 	return nil
 }

--- a/output/upload.go
+++ b/output/upload.go
@@ -23,6 +23,12 @@ func SetupSnapshotUploadForAllServers(ctx context.Context, servers []*state.Serv
 	}
 }
 
+// Maximum time a legacy HTTP snapshot upload may take before it is abandoned,
+// so a slow or unreachable server does not indefinitely stall the per-server
+// upload queue (and with it all snapshot types, since uploads run sequentially)
+const fullSnapshotUploadTimeout = 1 * time.Minute
+const compactSnapshotUploadTimeout = 20 * time.Second
+
 func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *util.Logger, opts state.CollectionOpts) {
 	var compactLogTime time.Time
 	compactLogStats := make(map[string]uint8)
@@ -37,7 +43,7 @@ func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *
 				continue
 			}
 
-			err = uploadViaWebsocketOrHttp(ctx, server, logger, opts, data, s.SnapshotUuid, s.CollectedAt.AsTime(), false)
+			err = uploadViaWebsocketOrHttp(ctx, server, logger, opts, data, s.SnapshotUuid, s.CollectedAt.AsTime(), false, fullSnapshotUploadTimeout)
 			if err != nil {
 				logger.PrintError("Error uploading snapshot: %s", err)
 			} else if !opts.TestRun {
@@ -50,7 +56,7 @@ func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *
 				continue
 			}
 
-			err = uploadViaWebsocketOrHttp(ctx, server, logger, opts, data, s.SnapshotUuid, s.CollectedAt.AsTime(), false)
+			err = uploadViaWebsocketOrHttp(ctx, server, logger, opts, data, s.SnapshotUuid, s.CollectedAt.AsTime(), false, compactSnapshotUploadTimeout)
 			if err != nil {
 				logger.PrintError("Error uploading snapshot: %s", err)
 				continue
@@ -92,7 +98,7 @@ func summarizeCounts(counts map[string]uint8) string {
 	return details
 }
 
-func uploadViaWebsocketOrHttp(ctx context.Context, server *state.Server, logger *util.Logger, opts state.CollectionOpts, data []byte, snapshotUUID string, collectedAt time.Time, compactSnapshot bool) error {
+func uploadViaWebsocketOrHttp(ctx context.Context, server *state.Server, logger *util.Logger, opts state.CollectionOpts, data []byte, snapshotUUID string, collectedAt time.Time, compactSnapshot bool, httpUploadTimeout time.Duration) error {
 	var compressedData bytes.Buffer
 	w := zlib.NewWriter(&compressedData)
 	w.Write(data)
@@ -104,11 +110,13 @@ func uploadViaWebsocketOrHttp(ctx context.Context, server *state.Server, logger 
 	} else if server.Config.APIRequireWebsocket {
 		return errors.New("Error uploading snapshot: WebSocket not connected")
 	} else {
-		s3Location, err := uploadSnapshot(ctx, server.Config.HTTPClientWithRetry, server.Grant.Load(), logger, compressedData.Bytes(), snapshotUUID)
+		uploadCtx, cancel := context.WithTimeout(ctx, httpUploadTimeout)
+		defer cancel()
+		s3Location, err := uploadSnapshot(uploadCtx, server.Config.HTTPClientWithRetry, server.Grant.Load(), logger, compressedData.Bytes(), snapshotUUID)
 		if err != nil {
 			return err
 		}
-		return submitSnapshot(ctx, server, opts, logger, s3Location, collectedAt, compactSnapshot)
+		return submitSnapshot(uploadCtx, server, opts, logger, s3Location, collectedAt, compactSnapshot)
 	}
 	return nil
 }

--- a/output/upload.go
+++ b/output/upload.go
@@ -26,8 +26,7 @@ func SetupSnapshotUploadForAllServers(ctx context.Context, servers []*state.Serv
 // Maximum time a legacy HTTP snapshot upload may take before it is abandoned,
 // so a slow or unreachable server does not indefinitely stall the per-server
 // upload queue (and with it all snapshot types, since uploads run sequentially)
-const fullSnapshotUploadTimeout = 1 * time.Minute
-const compactSnapshotUploadTimeout = 20 * time.Second
+const snapshotUploadTimeout = 1 * time.Minute
 
 func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *util.Logger, opts state.CollectionOpts) {
 	var compactLogTime time.Time
@@ -43,7 +42,7 @@ func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *
 				continue
 			}
 
-			err = uploadViaWebsocketOrHttp(ctx, server, logger, opts, data, s.SnapshotUuid, s.CollectedAt.AsTime(), false, fullSnapshotUploadTimeout)
+			err = uploadViaWebsocketOrHttp(ctx, server, logger, opts, data, s.SnapshotUuid, s.CollectedAt.AsTime(), false, snapshotUploadTimeout)
 			if err != nil {
 				logger.PrintError("Error uploading snapshot: %s", err)
 			} else if !opts.TestRun {
@@ -56,7 +55,7 @@ func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *
 				continue
 			}
 
-			err = uploadViaWebsocketOrHttp(ctx, server, logger, opts, data, s.SnapshotUuid, s.CollectedAt.AsTime(), false, compactSnapshotUploadTimeout)
+			err = uploadViaWebsocketOrHttp(ctx, server, logger, opts, data, s.SnapshotUuid, s.CollectedAt.AsTime(), false, snapshotUploadTimeout)
 			if err != nil {
 				logger.PrintError("Error uploading snapshot: %s", err)
 				continue

--- a/state/state.go
+++ b/state/state.go
@@ -340,8 +340,11 @@ func MakeServer(config config.ServerConfig, testRun bool) *Server {
 		ActivityStateMutex:    &sync.Mutex{},
 		HighFreqStateMutex:    &sync.Mutex{},
 		CollectionStatusMutex: &sync.Mutex{},
-		FullSnapshotUpload:    make(chan *pganalyze_collector.FullSnapshot),
-		CompactSnapshotUpload: make(chan *pganalyze_collector.CompactSnapshot),
+		// Buffered so a slow upload does not immediately block the collection
+		// runners (and with them the collection schedulers); when the buffer is
+		// full, new snapshots are discarded with an error instead of blocking
+		FullSnapshotUpload:    make(chan *pganalyze_collector.FullSnapshot, 2),
+		CompactSnapshotUpload: make(chan *pganalyze_collector.CompactSnapshot, 10),
 		InitialConfigReceived: make(chan struct{}, 1),
 		QueryRuns:             make(map[int64]*QueryRun),
 		QueryRunsMutex:        &sync.Mutex{},


### PR DESCRIPTION
This is mainly focused on the legacy HTTP upload mechanism (see first two commits) but also includes a change for shared snapshot processing path to make the snapshot channel buffered (with a small retention of max 2 full snapshots, 10 compact snapshots) instead of unbuffered, and explicitly drop the snapshot if we block beyond that, which is very unlikely. We likely want to integrate that last change with the work in #822 / consider the totality of those two changes together.