### PR TITLE
WebSocket: Detect dead connections via write deadlines and ping/pong

### DIFF
--- a/output/upload.go
+++ b/output/upload.go
@@ -100,7 +100,10 @@ func uploadViaWebsocketOrHttp(ctx context.Context, server *state.Server, logger 
 
 	if server.WebSocket.Connected() {
 		logger.PrintVerbose("Uploading snapshot to websocket")
-		server.WebSocket.Write <- compressedData.Bytes()
+		err := server.WebSocket.WriteMessage(ctx, compressedData.Bytes())
+		if err != nil {
+			return fmt.Errorf("Error writing to websocket: %w", err)
+		}
 	} else if server.Config.APIRequireWebsocket {
 		return errors.New("Error uploading snapshot: WebSocket not connected")
 	} else {

--- a/util/reconnecting_socket.go
+++ b/util/reconnecting_socket.go
@@ -11,9 +11,12 @@ import (
 )
 
 type ReconnectingSocket struct {
-	// Channels shared with the caller
-	Read  chan []byte
-	Write chan []byte
+	// Channel shared with the caller for incoming messages
+	Read chan []byte
+
+	// Channel for handing outgoing messages to the writer goroutine
+	// (use WriteMessage to send out messages)
+	write chan socketWrite
 
 	// Initial arguments
 	dialer  websocket.Dialer
@@ -30,7 +33,17 @@ type ReconnectingSocket struct {
 	shutdown  chan struct{}
 }
 
+// socketWrite - A single outgoing message, together with the channel used to
+// hand the write's outcome back to the caller
+type socketWrite struct {
+	data []byte
+	// Must be buffered (capacity 1), so the writer goroutine never blocks
+	// handing back the result to a caller that has stopped waiting
+	result chan error
+}
+
 var ErrorConnectRateLimited = errors.New("Skipping connection attempt because of previous 4XX error")
+var ErrorWriteNotAccepted = errors.New("Timeout waiting for websocket connection to accept message")
 
 // Timeouts to detect dead connections (e.g. a NAT/firewall silently dropping
 // the TCP session), which would otherwise only fail after the kernel's TCP
@@ -51,7 +64,7 @@ const (
 func NewReconnectingSocket(ctx context.Context, logger *Logger, dialer websocket.Dialer, url string, headers map[string][]string, reconnectInterval time.Duration, clientErrorTimeout time.Duration) *ReconnectingSocket {
 	w := &ReconnectingSocket{
 		Read:      make(chan []byte),
-		Write:     make(chan []byte),
+		write:     make(chan socketWrite),
 		ctx:       ctx,
 		dialer:    dialer,
 		url:       url,
@@ -138,6 +151,41 @@ func (w *ReconnectingSocket) Connect() error {
 	}
 }
 
+// WriteMessage - Sends the given data over the WebSocket, waiting for the write
+// to actually complete.
+//
+// Returns an error if the write failed, or if no connection was available to
+// take the message in time. If the context is canceled while waiting, ctx.Err()
+// is returned and the message may or may not have been sent.
+func (w *ReconnectingSocket) WriteMessage(ctx context.Context, data []byte) error {
+	// Must be buffered with capacity 1, see socketWrite definition
+	result := make(chan error, 1)
+
+	// A healthy writer goroutine picks the message up right away. Waiting longer
+	// than a single write deadline means there is no writer goroutine to take it
+	// (e.g. the connection was torn down after the caller checked Connected()).
+	// Give up in that case, instead of blocking until the next reconnect and then
+	// sending data that is stale by then.
+	timeout := time.NewTimer(socketWriteTimeout)
+	defer timeout.Stop()
+
+	select {
+	case w.write <- socketWrite{data: data, result: result}:
+	case <-timeout.C:
+		return ErrorWriteNotAccepted
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	// Wait on the message send, bounded by the write deadline set by the writer goroutine
+	select {
+	case err := <-result:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // Disconnect - Shuts down the WebSocket connection
 //
 // Does nothing if the WebSocket is already disconnected. If needed the WebSocket
@@ -171,11 +219,11 @@ func (w *ReconnectingSocket) connect(ctx context.Context) (int, error) {
 			case <-connCtx.Done():
 				w.closeConnection()
 				return
-			case data := <-w.Write:
+			case msg := <-w.write:
 				conn.SetWriteDeadline(time.Now().Add(socketWriteTimeout))
-				err := conn.WriteMessage(websocket.BinaryMessage, data)
+				err := conn.WriteMessage(websocket.BinaryMessage, msg.data)
+				msg.result <- err
 				if err != nil {
-					w.logger.PrintError("Error writing to websocket: %s", err)
 					w.closeConnection()
 					return
 				}

--- a/util/reconnecting_socket.go
+++ b/util/reconnecting_socket.go
@@ -32,6 +32,19 @@ type ReconnectingSocket struct {
 
 var ErrorConnectRateLimited = errors.New("Skipping connection attempt because of previous 4XX error")
 
+// Timeouts to detect dead connections (e.g. a NAT/firewall silently dropping
+// the TCP session), which would otherwise only fail after the kernel's TCP
+// retransmission timeout (which can exceed 15 minutes)
+const (
+	// Time allowed to write a message to the peer before considering the connection dead
+	socketWriteTimeout = 30 * time.Second
+	// Interval at which pings are sent when the connection is otherwise idle
+	socketPingInterval = 30 * time.Second
+	// Time allowed to receive any message (including pong replies) from the
+	// peer; must exceed socketPingInterval
+	socketPongTimeout = 70 * time.Second
+)
+
 // NewReconnectingSocket - Initializes a new reconnecting WebSocket
 //
 // The passed context must eventually be canceled in order for internal Goroutines to be stopped.
@@ -151,15 +164,26 @@ func (w *ReconnectingSocket) connect(ctx context.Context) (int, error) {
 	w.conn.Store(conn)
 	// Writer goroutine
 	go func() {
+		ticker := time.NewTicker(socketPingInterval)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-connCtx.Done():
 				w.closeConnection()
 				return
 			case data := <-w.Write:
-				err = conn.WriteMessage(websocket.BinaryMessage, data)
+				conn.SetWriteDeadline(time.Now().Add(socketWriteTimeout))
+				err := conn.WriteMessage(websocket.BinaryMessage, data)
 				if err != nil {
 					w.logger.PrintError("Error writing to websocket: %s", err)
+					w.closeConnection()
+					return
+				}
+			case <-ticker.C:
+				conn.SetWriteDeadline(time.Now().Add(socketWriteTimeout))
+				err := conn.WriteMessage(websocket.PingMessage, nil)
+				if err != nil {
+					w.logger.PrintWarning("Error sending websocket ping: %s", err)
 					w.closeConnection()
 					return
 				}
@@ -167,6 +191,10 @@ func (w *ReconnectingSocket) connect(ctx context.Context) (int, error) {
 		}
 	}()
 	// Reader goroutine
+	conn.SetReadDeadline(time.Now().Add(socketPongTimeout))
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(socketPongTimeout))
+	})
 	go func() {
 		for {
 			_, data, err := conn.ReadMessage()
@@ -179,6 +207,7 @@ func (w *ReconnectingSocket) connect(ctx context.Context) (int, error) {
 				cancelConn()
 				return
 			}
+			conn.SetReadDeadline(time.Now().Add(socketPongTimeout))
 
 			w.Read <- data
 		}

--- a/util/reconnecting_socket.go
+++ b/util/reconnecting_socket.go
@@ -94,9 +94,7 @@ func NewReconnectingSocket(ctx context.Context, logger *Logger, dialer websocket
 					w.startWait <- ErrorConnectRateLimited
 				}
 			case <-w.shutdown:
-				if w.Connected() {
-					w.closeConnection()
-				}
+				w.closeConnection(w.conn.Load())
 			}
 		}
 	}()
@@ -217,14 +215,14 @@ func (w *ReconnectingSocket) connect(ctx context.Context) (int, error) {
 		for {
 			select {
 			case <-connCtx.Done():
-				w.closeConnection()
+				w.closeConnection(conn)
 				return
 			case msg := <-w.write:
 				conn.SetWriteDeadline(time.Now().Add(socketWriteTimeout))
 				err := conn.WriteMessage(websocket.BinaryMessage, msg.data)
 				msg.result <- err
 				if err != nil {
-					w.closeConnection()
+					w.closeConnection(conn)
 					return
 				}
 			case <-ticker.C:
@@ -232,7 +230,7 @@ func (w *ReconnectingSocket) connect(ctx context.Context) (int, error) {
 				err := conn.WriteMessage(websocket.PingMessage, nil)
 				if err != nil {
 					w.logger.PrintWarning("Error sending websocket ping: %s", err)
-					w.closeConnection()
+					w.closeConnection(conn)
 					return
 				}
 			}
@@ -263,12 +261,17 @@ func (w *ReconnectingSocket) connect(ctx context.Context) (int, error) {
 	return connectStatus, nil
 }
 
-func (w *ReconnectingSocket) closeConnection() {
-	conn := w.conn.Swap(nil)
-	if conn != nil {
-		err := conn.Close()
-		if err != nil {
-			w.logger.PrintWarning("Error closing websocket: %s", err)
-		}
+// closeConnection - Closes the given connection, unless it was already closed,
+// or a newer connection has been established in the meantime
+//
+// Callers pass the connection they are working with, so a lingering goroutine
+// from an earlier connection can't tear down its replacement.
+func (w *ReconnectingSocket) closeConnection(conn *websocket.Conn) {
+	if conn == nil || !w.conn.CompareAndSwap(conn, nil) {
+		return
+	}
+	err := conn.Close()
+	if err != nil {
+		w.logger.PrintWarning("Error closing websocket: %s", err)
 	}
 }

--- a/util/reconnecting_socket_test.go
+++ b/util/reconnecting_socket_test.go
@@ -97,3 +97,93 @@ func TestSocketConnectReturnsAfterContextCancel(t *testing.T) {
 		t.Fatal("TestSocketConnectReturnsAfterContextCancel: Connect() blocked indefinitely after context cancellation")
 	}
 }
+
+// Verifies that WriteMessage() only returns once the message has actually been
+// written to the socket, so callers don't report success for a write that is
+// still in flight (or about to fail)
+func TestSocketWriteMessage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	received := make(chan []byte, 1)
+	serverMux := http.NewServeMux()
+	serverMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		_, data, err := c.ReadMessage()
+		if err != nil {
+			return
+		}
+		received <- data
+		<-ctx.Done()
+	})
+	s := &http.Server{Addr: "localhost:9125", Handler: serverMux}
+	ln, err := net.Listen("tcp", s.Addr)
+	if err != nil {
+		t.Fatalf("TestSocketWriteMessage: failed to start socket: %v", err)
+	}
+	go s.Serve(ln)
+	defer s.Shutdown(context.Background())
+
+	socket := util.NewReconnectingSocket(
+		ctx, &util.Logger{Destination: log.New(os.Stderr, "", 0)},
+		websocket.Dialer{}, "ws://localhost:9125", make(map[string][]string),
+		1*time.Second,
+		1*time.Second,
+	)
+
+	err = socket.Connect()
+	if err != nil {
+		t.Fatalf("TestSocketWriteMessage: failed initial socket connection: %v", err)
+	}
+
+	err = socket.WriteMessage(ctx, []byte("test message"))
+	if err != nil {
+		t.Fatalf("TestSocketWriteMessage: unexpected write error: %v", err)
+	}
+
+	// Since WriteMessage() waits for the write to complete, the data must already
+	// be on its way, and the server must see it without further delay
+	select {
+	case data := <-received:
+		if string(data) != "test message" {
+			t.Errorf("TestSocketWriteMessage: expected: %q; actual: %q", "test message", data)
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("TestSocketWriteMessage: server did not receive the message")
+	}
+}
+
+// Verifies that WriteMessage() does not block forever when there is no writer
+// goroutine to take the message (e.g. the connection went away after the caller
+// checked Connected(), or the socket's context was canceled)
+func TestSocketWriteMessageReturnsAfterContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	socket := util.NewReconnectingSocket(
+		ctx, &util.Logger{Destination: log.New(os.Stderr, "", 0)},
+		websocket.Dialer{}, "ws://localhost:9126", make(map[string][]string),
+		1*time.Second,
+		1*time.Second,
+	)
+
+	cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- socket.WriteMessage(ctx, []byte("test message"))
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Error("TestSocketWriteMessageReturnsAfterContextCancel: expected an error for a message that was never written")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("TestSocketWriteMessageReturnsAfterContextCancel: WriteMessage() blocked indefinitely after context cancellation")
+	}
+}


### PR DESCRIPTION
Previously the WebSocket had no write deadline and no keepalive, so a silently dropped TCP session (e.g. by a NAT or firewall) would block the writer in WriteMessage until the kernel's TCP retransmission timeout (possibly 15+ minutes), stalling snapshot uploads while the connection still reported as connected.

Set a 30 second write deadline on all writes, send a ping every 30 seconds when idle, and require any message from the server within 70 seconds (the pganalyze server sends a keepalive Pong every 20 seconds, which now also refreshes this deadline).

Effectively this causes a dead connection to be closed within about a minute, letting uploads fall back to legacy HTTP and the existing reconnect logic re-establish the WebSocket.