### PR TITLE
Share DNS resolution between a server's snapshot connections

### DIFF
--- a/input/postgres/establish_connection.go
+++ b/input/postgres/establish_connection.go
@@ -3,23 +3,33 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
+	"net"
 
-	"github.com/pganalyze/collector/config"
+	"github.com/lib/pq"
 	"github.com/pganalyze/collector/state"
 	"github.com/pganalyze/collector/util"
 )
 
 func EstablishConnection(ctx context.Context, server *state.Server, logger *util.Logger, opts state.CollectionOpts, databaseName string) (connection *sql.DB, err error) {
-	connection, err = connectToDb(ctx, server.Config, opts, databaseName)
+	connection, err = connectToDb(ctx, server, logger, opts, databaseName)
 	if err != nil {
 		if err.Error() == "pq: SSL is not enabled on the server" && (server.Config.DbSslMode == "prefer" || server.Config.DbSslMode == "") {
 			server.Config.DbSslModePreferFailed = true
-			connection, err = connectToDb(ctx, server.Config, opts, databaseName)
+			connection, err = connectToDb(ctx, server, logger, opts, databaseName)
 		}
 	}
 
 	if err != nil {
+		// The pinned address may be the reason we couldn't connect (the instance
+		// went away, or was replaced), so let the next attempt resolve again. Only
+		// network-level errors say anything about the address: a bad password or a
+		// missing database must not drop the pin, since that could move later
+		// connections onto a different instance.
+		if addressRelatedError(err) {
+			server.ResolvedHost.Invalidate()
+		}
 		return
 	}
 
@@ -38,10 +48,12 @@ func EstablishConnection(ctx context.Context, server *state.Server, logger *util
 	return
 }
 
-func connectToDb(ctx context.Context, config config.ServerConfig, opts state.CollectionOpts, databaseName string) (*sql.DB, error) {
+func connectToDb(ctx context.Context, server *state.Server, logger *util.Logger, opts state.CollectionOpts, databaseName string) (*sql.DB, error) {
 	var db *sql.DB
 	var iamParams iamConnectionParams
 	var err error
+
+	config := server.Config
 
 	driverName := "postgres"
 	if config.DbUseIamAuth {
@@ -57,7 +69,7 @@ func connectToDb(ctx context.Context, config config.ServerConfig, opts state.Col
 	}
 	connectString += " application_name=" + opts.CollectorApplicationName
 
-	db, err = sql.Open(driverName, connectString)
+	db, err = openConnection(server, logger, driverName, connectString)
 	if err != nil {
 		return nil, err
 	}
@@ -71,6 +83,38 @@ func connectToDb(ctx context.Context, config config.ServerConfig, opts state.Col
 	}
 
 	return db, nil
+}
+
+// openConnection - Opens the connection pool, routing its dials through the
+// address this server is pinned to when we're connecting over the network
+// ourselves. Resolution happens at dial time (see pinnedDialer), so the pool
+// follows the pin for as long as it lives.
+//
+// Only the lib/pq driver is handled here. The Cloud SQL and AlloyDB drivers
+// connect through a connector that is given an instance name rather than a
+// hostname, so there is no DNS result of ours to share in the first place.
+func openConnection(server *state.Server, logger *util.Logger, driverName string, connectString string) (*sql.DB, error) {
+	host := server.Config.GetDbHost()
+	if driverName != "postgres" || !canPinHost(host) {
+		return sql.Open(driverName, connectString)
+	}
+
+	connector, err := pq.NewConnector(connectString)
+	if err != nil {
+		return nil, err
+	}
+	connector.Dialer(pinnedDialer{resolved: server.ResolvedHost, hostname: host, logger: logger})
+
+	return sql.OpenDB(connector), nil
+}
+
+// addressRelatedError - Returns whether a connection error could plausibly be the
+// fault of the address we dialed, as opposed to something the server told us over
+// a working connection. Network-level failures and timeouts qualify; errors the
+// Postgres protocol produced (authentication, a missing database) do not.
+func addressRelatedError(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr)
 }
 
 func validateConnectionCount(ctx context.Context, connection *sql.DB, logger *util.Logger, maxCollectorConnections int, opts state.CollectionOpts) error {

--- a/input/postgres/establish_connection_test.go
+++ b/input/postgres/establish_connection_test.go
@@ -1,0 +1,116 @@
+package postgres_test
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/pganalyze/collector/config"
+	"github.com/pganalyze/collector/input/postgres"
+	"github.com/pganalyze/collector/state"
+	"github.com/pganalyze/collector/util"
+)
+
+// setupPinTest - Builds a server pointed at TEST_DATABASE_URL over TCP, which is
+// what the address pinning applies to. A URL without a hostname (a Unix socket)
+// has nothing to pin, so there would be nothing to assert.
+func setupPinTest(t *testing.T) (*state.Server, state.CollectionOpts, string) {
+	testDatabaseUrl := os.Getenv("TEST_DATABASE_URL")
+	if testDatabaseUrl == "" {
+		t.Skipf("Skipping test requiring database connection since TEST_DATABASE_URL is not set")
+	}
+	u, err := url.Parse(testDatabaseUrl)
+	if err != nil {
+		t.Fatalf("Could not parse TEST_DATABASE_URL: %s", err)
+	}
+	hostname := u.Hostname()
+	if hostname == "" {
+		t.Skipf("Skipping test since TEST_DATABASE_URL does not connect over TCP")
+	}
+
+	server := state.MakeServer(config.ServerConfig{
+		DbURL:                   testDatabaseUrl,
+		MaxCollectorConnections: 10,
+	}, false)
+
+	return server, state.CollectionOpts{CollectorApplicationName: "pganalyze_test"}, hostname
+}
+
+// Every snapshot type opens its own connection, and they must all reach the same
+// instance so that the cumulative counters they diff remain comparable.
+func TestEstablishConnectionSharesResolvedAddress(t *testing.T) {
+	server, opts, _ := setupPinTest(t)
+	ctx := context.Background()
+	logger := &util.Logger{}
+
+	first, err := postgres.EstablishConnection(ctx, server, logger, opts, "")
+	if err != nil {
+		t.Fatalf("Could not connect to test database: %s", err)
+	}
+	defer first.Close()
+
+	pinned := server.ResolvedHost.Current()
+	if pinned == "" {
+		t.Fatalf("expected the resolved address to be recorded on the server")
+	}
+
+	second, err := postgres.EstablishConnection(ctx, server, logger, opts, "")
+	if err != nil {
+		t.Fatalf("Could not open a second connection: %s", err)
+	}
+	defer second.Close()
+
+	if server.ResolvedHost.Current() != pinned {
+		t.Errorf("expected the second connection to reuse the pinned address\nexpected %s\nactual %s\n", pinned, server.ResolvedHost.Current())
+	}
+
+	// Both connections went to the same instance, so their identities agree and a
+	// diff between statistics collected over them is valid
+	firstIdentity, err := postgres.GetInstanceIdentity(ctx, first)
+	if err != nil {
+		t.Fatalf("Could not determine instance identity: %s", err)
+	}
+	if firstIdentity.IsZero() {
+		t.Errorf("expected a non-zero instance identity")
+	}
+	if firstIdentity.ServerAddr == "" {
+		t.Errorf("expected inet_server_addr() to be available over a TCP connection")
+	}
+
+	secondIdentity, err := postgres.GetInstanceIdentity(ctx, second)
+	if err != nil {
+		t.Fatalf("Could not determine instance identity for the second connection: %s", err)
+	}
+	if !firstIdentity.Matches(secondIdentity) {
+		t.Errorf("expected both connections to report the same instance\nfirst %+v\nsecond %+v\n", firstIdentity, secondIdentity)
+	}
+}
+
+// A pinned instance that went away costs one failed dial attempt, not a failed
+// snapshot: the dialer falls back to a freshly resolved address within the same
+// connection attempt and moves the pin to what actually connected.
+func TestEstablishConnectionRecoversFromStalePin(t *testing.T) {
+	server, opts, hostname := setupPinTest(t)
+	// The deadline is what bounds the attempt against the unroutable address
+	// before the dialer moves on to the fallbacks
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	logger := &util.Logger{}
+
+	// 192.0.2.0/24 is reserved for documentation and is not routable, so this
+	// stands in for an instance that has gone away
+	server.ResolvedHost.Pin(hostname, "192.0.2.1")
+
+	connection, err := postgres.EstablishConnection(ctx, server, logger, opts, "")
+	if err != nil {
+		t.Fatalf("expected the dialer to fall back to a freshly resolved address, got: %s", err)
+	}
+	defer connection.Close()
+
+	pinned := server.ResolvedHost.Current()
+	if pinned == "" || pinned == "192.0.2.1" {
+		t.Errorf("expected the pin to move to the address that actually connected, have %q", pinned)
+	}
+}

--- a/input/postgres/pinned_dialer.go
+++ b/input/postgres/pinned_dialer.go
@@ -1,0 +1,121 @@
+package postgres
+
+import (
+	"context"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/pganalyze/collector/state"
+	"github.com/pganalyze/collector/util"
+)
+
+// pinnedDialer - Dials the address this server's connections are pinned to
+// instead of resolving the hostname pq was configured with.
+//
+// pq derives the address to dial and the name used for TLS verification from the
+// same "host" connection parameter, but it takes the address through the dialer
+// while reading the name directly out of the parameters (see tlsConf.ServerName
+// in lib/pq's ssl.go). Replacing the address here therefore leaves sslmode
+// verify-full, SNI and certificate hostname checks working against the
+// configured hostname.
+//
+// The shared ResolvedHost is consulted at dial time rather than capturing an
+// address when the pool is opened, so long-lived pools reconnect through the
+// current pin instead of freezing whatever was pinned when they were created.
+// The address that actually connects is reported back, which is what makes the
+// pin "the instance we talk to" rather than "the first address of a lookup".
+type pinnedDialer struct {
+	dialer   net.Dialer
+	resolved *state.ResolvedHost
+	// The hostname from the connection parameters, which the pin applies to
+	hostname string
+	logger   *util.Logger
+}
+
+// fallbackDialTimeout - Bounds a dial attempt that still has fallback addresses
+// behind it when there is no connection deadline (from connect_timeout or the
+// context) to divide up, so that a blackholed pinned address cannot starve the
+// fallbacks. The last address gets all remaining time, like a dial without
+// pinning would.
+const fallbackDialTimeout = 15 * time.Second
+
+func (d pinnedDialer) Dial(network, address string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, address)
+}
+
+func (d pinnedDialer) DialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return d.DialContext(ctx, network, address)
+}
+
+func (d pinnedDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	// pq builds a socket path rather than a host:port pair for Unix sockets, and
+	// should not happen here (see canPinHost), but pass it through untouched
+	if network == "unix" {
+		return d.dialer.DialContext(ctx, network, address)
+	}
+	_, port, err := net.SplitHostPort(address)
+	if err != nil {
+		// Should not happen, but we would rather dial what pq asked for than
+		// produce a malformed address
+		return d.dialer.DialContext(ctx, network, address)
+	}
+
+	addrs, err := d.resolved.Get(ctx, d.hostname)
+	if err != nil {
+		// Fall back to letting the network stack resolve the hostname itself, so
+		// that a problem in our own lookup can't stop collection outright
+		d.logger.PrintVerbose("Could not resolve %s, leaving address resolution to the network: %s", d.hostname, err)
+		return d.dialer.DialContext(ctx, network, address)
+	}
+
+	// Try the pinned address first, then the fallbacks from the latest lookup, so
+	// a dead pinned instance costs one failed attempt inside this dial rather
+	// than a failed snapshot
+	var firstErr error
+	for i, addr := range addrs {
+		conn, err := d.dialAttempt(ctx, network, net.JoinHostPort(addr, port), len(addrs)-i)
+		if err == nil {
+			if d.resolved.Confirm(addr) {
+				d.logger.PrintVerbose("Pinned address %s for host %s", addr, d.hostname)
+			}
+			return conn, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+		if ctx.Err() != nil {
+			break
+		}
+	}
+	return nil, firstErr
+}
+
+// dialAttempt - Dials one address. An attempt with more addresses behind it only
+// gets a share of the remaining time (mirroring net.Dialer's partial deadlines),
+// so that an address that swallows packets can't use up the whole connection
+// deadline before the fallbacks get their chance.
+func (d pinnedDialer) dialAttempt(ctx context.Context, network, address string, remaining int) (net.Conn, error) {
+	if remaining > 1 {
+		timeout := fallbackDialTimeout
+		if deadline, ok := ctx.Deadline(); ok {
+			timeout = time.Until(deadline) / time.Duration(remaining)
+		}
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	return d.dialer.DialContext(ctx, network, address)
+}
+
+// canPinHost - Returns whether pinning a resolved address makes sense for this
+// host. There is nothing to pin for Unix sockets or hosts that are already
+// written as an IP address.
+func canPinHost(host string) bool {
+	if host == "" || strings.HasPrefix(host, "/") {
+		return false
+	}
+	return net.ParseIP(host) == nil
+}

--- a/input/postgres/pinned_dialer_test.go
+++ b/input/postgres/pinned_dialer_test.go
@@ -1,0 +1,124 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/pganalyze/collector/state"
+	"github.com/pganalyze/collector/util"
+)
+
+var canPinHostTests = []struct {
+	host     string
+	expected bool
+}{
+	{"prd-uswest2-core0-canary-db-cluster.cluster-ro-cvdyfnmmcfzd.us-west-2.rds.amazonaws.com", true},
+	{"db.example.com", true},
+	{"localhost", true},
+	// Already an address, so there is no lookup result to share
+	{"10.1.16.97", false},
+	{"::1", false},
+	{"127.0.0.1", false},
+	// Unix socket directory
+	{"/var/run/postgresql", false},
+	// Nothing configured, pq falls back to localhost on its own
+	{"", false},
+}
+
+func TestCanPinHost(t *testing.T) {
+	for _, test := range canPinHostTests {
+		actual := canPinHost(test.host)
+		if actual != test.expected {
+			t.Errorf("canPinHost(%q)\nexpected %t\nactual %t\n", test.host, test.expected, actual)
+		}
+	}
+}
+
+// listen - Starts a listener standing in for a Postgres instance, and returns it
+// along with its address and port.
+func listen(t *testing.T) (net.Listener, string, string) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("could not start listener: %s", err)
+	}
+	t.Cleanup(func() { listener.Close() })
+	addr, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatalf("could not split listener address: %s", err)
+	}
+	return listener, addr, port
+}
+
+// The core behavior: pq asks for the configured hostname, and the dial goes to
+// the pinned address instead, keeping the port pq derived from the connection
+// parameters. The hostname here doesn't resolve at all (like a resolver outage),
+// which also proves an established pin survives failed lookups.
+func TestPinnedDialerDialsPin(t *testing.T) {
+	_, addr, port := listen(t)
+
+	resolved := &state.ResolvedHost{}
+	resolved.Pin("db.invalid", addr)
+	d := pinnedDialer{resolved: resolved, hostname: "db.invalid", logger: &util.Logger{}}
+
+	conn, err := d.DialContext(context.Background(), "tcp", net.JoinHostPort("db.invalid", port))
+	if err != nil {
+		t.Fatalf("expected the dial to be redirected to the pinned address, got: %s", err)
+	}
+	conn.Close()
+}
+
+// A pinned address that stopped accepting connections costs one failed attempt
+// within the dial, not a failed connection: the fallbacks from the latest lookup
+// are tried next, and the pin moves to the address that actually connected.
+func TestPinnedDialerFallsBackAndRepins(t *testing.T) {
+	_, addr, port := listen(t)
+
+	resolved := &state.ResolvedHost{}
+	// 192.0.2.0/24 is reserved for documentation and is not routable, so this
+	// stands in for an instance that has gone away
+	resolved.Pin("localhost", "192.0.2.1")
+	d := pinnedDialer{resolved: resolved, hostname: "localhost", logger: &util.Logger{}}
+
+	// The deadline is divided among the attempts, so the unroutable address can
+	// only burn its share of it before the fallbacks get their chance
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := d.DialContext(ctx, "tcp", net.JoinHostPort("localhost", port))
+	if err != nil {
+		t.Fatalf("expected the dial to fall back to a resolved address, got: %s", err)
+	}
+	conn.Close()
+
+	if resolved.Current() != addr {
+		t.Errorf("expected the pin to move to the address that connected\nexpected %s\nactual %s\n", addr, resolved.Current())
+	}
+}
+
+var addressRelatedErrorTests = []struct {
+	name     string
+	err      error
+	expected bool
+}{
+	// Dial failures and timeouts are the pin's business
+	{"net.OpError", &net.OpError{Op: "dial", Err: errors.New("connection refused")}, true},
+	{"context.DeadlineExceeded", context.DeadlineExceeded, true},
+	{"wrapped net error", &net.DNSError{Err: "no such host", Name: "db.example.com"}, true},
+	// The server answered, so the address was fine
+	{"pq auth error", errors.New("pq: password authentication failed for user \"pganalyze\""), false},
+	{"missing database", errors.New("pq: database \"nope\" does not exist"), false},
+	{"context.Canceled", context.Canceled, false},
+}
+
+func TestAddressRelatedError(t *testing.T) {
+	for _, test := range addressRelatedErrorTests {
+		actual := addressRelatedError(test.err)
+		if actual != test.expected {
+			t.Errorf("%s: addressRelatedError(%v)\nexpected %t\nactual %t\n", test.name, test.err, test.expected, actual)
+		}
+	}
+}

--- a/state/resolved_host.go
+++ b/state/resolved_host.go
@@ -1,0 +1,213 @@
+package state
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"slices"
+	"sync"
+	"time"
+)
+
+// resolvedHostRecheckInterval - How often the hostname is looked up again while a
+// pin is in place, to check that it still points at the pinned address.
+//
+// Lookups only hit the local resolver, but once a minute is enough: it matches the
+// fastest snapshot cadence, and it means the burst of per-database schema
+// connections within one full snapshot shares a single answer instead of each
+// taking its own draw from a rotating endpoint.
+const resolvedHostRecheckInterval = time.Minute
+
+// resolvedHostEvictAfterMisses - How many consecutive lookups may omit the pinned
+// address before the pin is dropped.
+//
+// This is the backstop for a pinned instance that still accepts connections but is
+// no longer what the hostname points at - after an Aurora failover, the old writer
+// keeps serving connections in its new reader role. Endpoints that return a stable
+// answer (a writer endpoint, a reader endpoint with a single reader) contradict a
+// stale pin on every lookup, so a moved hostname is noticed within about
+// resolvedHostEvictAfterMisses * resolvedHostRecheckInterval. Requiring several
+// consecutive misses matters for reader endpoints with multiple readers, which
+// rotate a single record: a healthy pin is missing from any one answer, and
+// evicting it would needlessly move our connections to a different instance.
+const resolvedHostEvictAfterMisses = 10
+
+// ResolvedHost - Caches the address a server's hostname resolved to, so that
+// every connection the collector makes to one server reaches the same instance.
+//
+// The collector opens a separate connection for each kind of snapshot (full,
+// query statistics, activity, logs) and closes it again afterwards, which means
+// each one resolves the hostname independently. For a hostname that maps to a
+// single instance that is fine, but an Aurora reader endpoint round-robins
+// across readers and follows failovers, so consecutive connections can land on
+// different instances. Since cumulative statistics are per-instance, we want
+// separate connections - they run expensive queries and shouldn't queue behind
+// each other - but a shared view of where those connections go.
+//
+// The pinned address is the one a connection last actually succeeded to (see
+// Confirm), not merely the first address of a lookup. It is kept as long as the
+// hostname keeps resolving to it, dropped when connecting through it fails (see
+// Invalidate callers), and evicted when enough consecutive lookups stop including
+// it. A resolver outage leaves an established pin untouched. The rest of the most
+// recent answer is kept as dial fallbacks, so a dead pinned instance costs one
+// failed dial attempt rather than a failed snapshot.
+//
+// A stale pin cannot corrupt statistics on its own: the reference point for
+// every diff is checked against PostgresInstanceIdentity, so an instance change
+// costs one interval of data rather than producing a bogus spike.
+type ResolvedHost struct {
+	mutex    sync.Mutex
+	hostname string
+	// The address a connection last succeeded to, empty if none
+	addr string
+	// The most recent lookup answer, used for dial fallbacks and to judge whether
+	// the hostname still points at the pinned address
+	lastAnswer   []string
+	lastLookupAt time.Time
+	// Consecutive lookups whose answer did not include the pinned address
+	lookupMisses int
+}
+
+// Get - Returns the addresses to dial for the given hostname, in order: the
+// pinned address first, then the rest of the most recent lookup answer as
+// fallbacks.
+//
+// The returned addresses are only meant for dialing. Callers must keep passing
+// the hostname to the Postgres driver so that TLS verification, SNI and anything
+// else hostname-derived continue to use it.
+//
+// The mutex is deliberately held across the lookup: concurrent connections that
+// arrive while no answer is cached should share one answer rather than each
+// taking their own draw from a rotating endpoint.
+func (r *ResolvedHost) Get(ctx context.Context, hostname string) ([]string, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.hostname != hostname {
+		r.resetLocked()
+		r.hostname = hostname
+	}
+
+	var lookupErr error
+	if time.Since(r.lastLookupAt) >= resolvedHostRecheckInterval {
+		lookupErr = r.lookupLocked(ctx)
+	}
+
+	addrs := r.dialOrderLocked()
+	if len(addrs) == 0 {
+		if lookupErr != nil {
+			return nil, lookupErr
+		}
+		return nil, fmt.Errorf("no addresses found for host %q", hostname)
+	}
+	return addrs, nil
+}
+
+// lookupLocked - Resolves the hostname and folds the answer into the pin's
+// evidence: an answer that includes the pinned address re-confirms it, and enough
+// consecutive answers without it evict it, since the hostname has moved on even
+// if the pinned instance still accepts our connections. A failed lookup leaves
+// the pin and the cached answer untouched, so a resolver outage cannot take down
+// a working pin.
+func (r *ResolvedHost) lookupLocked(ctx context.Context) error {
+	// Advance the clock even on failure, so a broken resolver delays at most one
+	// connection per recheck interval
+	r.lastLookupAt = time.Now()
+
+	addrs, err := net.DefaultResolver.LookupHost(ctx, r.hostname)
+	if err != nil {
+		return err
+	}
+	if len(addrs) == 0 {
+		return fmt.Errorf("no addresses found for host %q", r.hostname)
+	}
+
+	r.lastAnswer = addrs
+
+	if r.addr == "" {
+		return nil
+	}
+	if slices.Contains(addrs, r.addr) {
+		r.lookupMisses = 0
+	} else {
+		r.lookupMisses++
+		if r.lookupMisses >= resolvedHostEvictAfterMisses {
+			r.addr = ""
+			r.lookupMisses = 0
+		}
+	}
+	return nil
+}
+
+// dialOrderLocked - The pinned address first, then the rest of the most recent
+// answer as fallbacks.
+func (r *ResolvedHost) dialOrderLocked() []string {
+	addrs := make([]string, 0, len(r.lastAnswer)+1)
+	if r.addr != "" {
+		addrs = append(addrs, r.addr)
+	}
+	for _, addr := range r.lastAnswer {
+		if addr != r.addr {
+			addrs = append(addrs, addr)
+		}
+	}
+	return addrs
+}
+
+// Confirm - Records the address a connection actually succeeded to, making it the
+// pin that later connections dial first. Returns whether this changed the pin.
+//
+// Pinning what connected rather than what resolved first matters when a host
+// resolves to addresses we cannot all reach - with IPv6 ordered first on an
+// IPv4-only network, pinning the lookup result would wedge every connection on an
+// unreachable address.
+func (r *ResolvedHost) Confirm(addr string) bool {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.addr == addr {
+		return false
+	}
+	r.addr = addr
+	r.lookupMisses = 0
+	return true
+}
+
+// Pin - Records the address to use for a hostname without connecting, as a
+// subsequent Confirm for that same hostname would have. Used by tests to set up a
+// specific pin.
+func (r *ResolvedHost) Pin(hostname string, addr string) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.resetLocked()
+	r.hostname = hostname
+	r.addr = addr
+}
+
+// Invalidate - Drops the current pin and cached answer, so the next Get resolves
+// the hostname again. Called when connecting fails with a network-level error,
+// since the instance the pin pointed at may be gone.
+func (r *ResolvedHost) Invalidate() {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.resetLocked()
+}
+
+func (r *ResolvedHost) resetLocked() {
+	r.hostname = ""
+	r.addr = ""
+	r.lastAnswer = nil
+	r.lastLookupAt = time.Time{}
+	r.lookupMisses = 0
+}
+
+// Current - Returns the currently pinned address, or an empty string if there is
+// none. For logging and tests.
+func (r *ResolvedHost) Current() string {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	return r.addr
+}

--- a/state/resolved_host_test.go
+++ b/state/resolved_host_test.go
@@ -1,0 +1,207 @@
+package state
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+)
+
+// forceRecheck - Ages the last lookup past the recheck interval, so the next Get
+// resolves again. Standing in for the passage of time in tests.
+func forceRecheck(r *ResolvedHost) {
+	r.mutex.Lock()
+	r.lastLookupAt = time.Now().Add(-resolvedHostRecheckInterval - time.Second)
+	r.mutex.Unlock()
+}
+
+func TestResolvedHostSharesAnswerBetweenConnections(t *testing.T) {
+	ctx := context.Background()
+	r := &ResolvedHost{}
+
+	first, err := r.Get(ctx, "localhost")
+	if err != nil {
+		t.Fatalf("could not resolve localhost: %s", err)
+	}
+	if len(first) == 0 {
+		t.Fatalf("expected at least one resolved address")
+	}
+
+	// Poison the cached answer with an address that could not have come from a
+	// lookup, to prove the second call reuses it rather than resolving again. This
+	// is the whole purpose of the type: the full, query statistics and activity
+	// snapshots each open their own connection and must all reach the same
+	// instance, so within the recheck interval they must share one answer.
+	r.mutex.Lock()
+	r.lastAnswer = []string{"192.0.2.1"}
+	r.mutex.Unlock()
+
+	second, err := r.Get(ctx, "localhost")
+	if err != nil {
+		t.Fatalf("unexpected error on second lookup: %s", err)
+	}
+	if len(second) != 1 || second[0] != "192.0.2.1" {
+		t.Errorf("expected the cached answer to be reused\nexpected [192.0.2.1]\nactual %v\n", second)
+	}
+}
+
+func TestResolvedHostConfirmPinsFirst(t *testing.T) {
+	ctx := context.Background()
+	r := &ResolvedHost{}
+
+	if _, err := r.Get(ctx, "localhost"); err != nil {
+		t.Fatalf("could not resolve localhost: %s", err)
+	}
+
+	// A connection succeeded to this address, so later connections dial it first
+	if changed := r.Confirm("192.0.2.1"); !changed {
+		t.Errorf("expected the first Confirm to change the pin")
+	}
+	if changed := r.Confirm("192.0.2.1"); changed {
+		t.Errorf("expected confirming the same address again to change nothing")
+	}
+
+	addrs, err := r.Get(ctx, "localhost")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if addrs[0] != "192.0.2.1" {
+		t.Errorf("expected the pinned address to be dialed first\nexpected 192.0.2.1\nactual %s\n", addrs[0])
+	}
+}
+
+func TestResolvedHostKeepsPinWhileAnswerContainsIt(t *testing.T) {
+	ctx := context.Background()
+	r := &ResolvedHost{}
+
+	first, err := r.Get(ctx, "localhost")
+	if err != nil {
+		t.Fatalf("could not resolve localhost: %s", err)
+	}
+	r.Confirm(first[0])
+
+	// The hostname keeps resolving to the pinned address, so no amount of
+	// rechecking may evict it - unlike a fixed TTL, which would re-roll a
+	// perfectly healthy pin
+	for i := 0; i < 2*resolvedHostEvictAfterMisses; i++ {
+		forceRecheck(r)
+		if _, err := r.Get(ctx, "localhost"); err != nil {
+			t.Fatalf("unexpected error on recheck %d: %s", i, err)
+		}
+	}
+	if r.Current() != first[0] {
+		t.Errorf("expected a re-confirmed pin to stay\nexpected %s\nactual %s\n", first[0], r.Current())
+	}
+}
+
+func TestResolvedHostEvictsPinAfterConsecutiveMisses(t *testing.T) {
+	ctx := context.Background()
+	r := &ResolvedHost{}
+
+	if _, err := r.Get(ctx, "localhost"); err != nil {
+		t.Fatalf("could not resolve localhost: %s", err)
+	}
+	// An address the lookups will never return again: the hostname has moved on,
+	// even though the instance behind the pin may still accept connections (after
+	// an Aurora failover, the demoted writer keeps serving in its reader role)
+	r.Confirm("192.0.2.1")
+
+	for i := 0; i < resolvedHostEvictAfterMisses; i++ {
+		if r.Current() != "192.0.2.1" {
+			t.Fatalf("expected the pin to survive %d misses, gone after %d", resolvedHostEvictAfterMisses, i)
+		}
+		forceRecheck(r)
+		if _, err := r.Get(ctx, "localhost"); err != nil {
+			t.Fatalf("unexpected error on recheck %d: %s", i, err)
+		}
+	}
+
+	if r.Current() != "" {
+		t.Errorf("expected the pin to be evicted after %d consecutive misses, still have %s", resolvedHostEvictAfterMisses, r.Current())
+	}
+	addrs, err := r.Get(ctx, "localhost")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if slices.Contains(addrs, "192.0.2.1") {
+		t.Errorf("expected only freshly resolved addresses after eviction, got %v", addrs)
+	}
+}
+
+func TestResolvedHostKeepsPinThroughResolverFailure(t *testing.T) {
+	ctx := context.Background()
+	r := &ResolvedHost{}
+
+	// .invalid never resolves (RFC 6761), standing in for a resolver outage. A
+	// working pin must survive it: the lookups are only evidence gathering, and
+	// no evidence is not evidence of a change.
+	r.Pin("db.invalid", "192.0.2.1")
+
+	addrs, err := r.Get(ctx, "db.invalid")
+	if err != nil {
+		t.Fatalf("expected the pin to be served despite the failed lookup, got: %s", err)
+	}
+	if len(addrs) != 1 || addrs[0] != "192.0.2.1" {
+		t.Errorf("expected the pinned address\nexpected [192.0.2.1]\nactual %v\n", addrs)
+	}
+	if r.Current() != "192.0.2.1" {
+		t.Errorf("expected the failed lookup to leave the pin alone, have %q", r.Current())
+	}
+}
+
+func TestResolvedHostErrorsWithNothingToServe(t *testing.T) {
+	ctx := context.Background()
+	r := &ResolvedHost{}
+
+	// No pin and no cached answer: the lookup failure is all we have
+	if _, err := r.Get(ctx, "db.invalid"); err == nil {
+		t.Errorf("expected an error resolving an invalid hostname with no pin to fall back on")
+	}
+}
+
+func TestResolvedHostInvalidate(t *testing.T) {
+	ctx := context.Background()
+	r := &ResolvedHost{}
+
+	if _, err := r.Get(ctx, "localhost"); err != nil {
+		t.Fatalf("could not resolve localhost: %s", err)
+	}
+	r.Confirm("192.0.2.1")
+
+	r.Invalidate()
+	if r.Current() != "" {
+		t.Errorf("expected no pinned address after Invalidate, got %s", r.Current())
+	}
+
+	// A failed connection drops the pin so we pick up a replacement instance
+	addrs, err := r.Get(ctx, "localhost")
+	if err != nil {
+		t.Fatalf("could not resolve localhost after invalidating: %s", err)
+	}
+	if slices.Contains(addrs, "192.0.2.1") {
+		t.Errorf("expected freshly resolved addresses after Invalidate, got the stale pin in %v", addrs)
+	}
+}
+
+func TestResolvedHostReresolvesForDifferentHostname(t *testing.T) {
+	ctx := context.Background()
+	r := &ResolvedHost{}
+
+	if _, err := r.Get(ctx, "localhost"); err != nil {
+		t.Fatalf("could not resolve localhost: %s", err)
+	}
+	r.Confirm("192.0.2.1")
+
+	// A pin only applies to the hostname it was resolved from, so that connecting
+	// to a different host (e.g. after a config change) does not reuse it
+	addrs, err := r.Get(ctx, "127.0.0.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if len(addrs) != 1 || addrs[0] != "127.0.0.1" {
+		t.Errorf("expected a new lookup for a different hostname\nexpected [127.0.0.1]\nactual %v\n", addrs)
+	}
+	if r.Current() != "" {
+		t.Errorf("expected the old hostname's pin to be dropped, have %q", r.Current())
+	}
+}

--- a/state/state.go
+++ b/state/state.go
@@ -304,6 +304,10 @@ type Server struct {
 	HighFreqPrevState  PersistedHighFreqState
 	HighFreqStateMutex *sync.Mutex
 
+	// Shared DNS resolution for this server, so that the separate connections
+	// used by the different snapshot types reach the same instance
+	ResolvedHost *ResolvedHost
+
 	CollectionStatus      CollectionStatus
 	CollectionStatusMutex *sync.Mutex
 
@@ -350,6 +354,7 @@ func MakeServer(config config.ServerConfig, testRun bool) *Server {
 		QueryRuns:             make(map[int64]*QueryRun),
 		QueryRunsMutex:        &sync.Mutex{},
 		LogParseMutex:         &sync.RWMutex{},
+		ResolvedHost:          &ResolvedHost{},
 		Fingerprints:          NewFingerprints(),
 	}
 	server.Grant.Store(&Grant{Config: pganalyze_collector.ServerMessage_Config{Features: &pganalyze_collector.ServerMessage_Features{}}})


### PR DESCRIPTION
This is a follow-up to #846, broken out from that commit and tweaked a
bit. This is pretty much Claude's work and very lightly reviewed at
this point; I'm only including it here for reference. I plan to focus
on other work and won't pursue this PR.

---

Each snapshot type opens its own connection, so each one resolves
db_host independently. However, Aurora reader endpoints follow
failovers, so consecutive connections can reach different instances.
Within a single minute, the query statistics connection and the full
snapshot connection can disagree.

Resolve the hostname once per server and share the result, so the
connections stay separate but talk to the same instance. The address is
supplied to lib/pq through a custom dialer, because pq takes the dial
address from the dialer but reads the TLS server name straight out of
the connection parameters. Passing it to the dialer leaves hostname
verification intact.

The pinned address is the one a connection last actually succeeded to,
not the first address of a lookup: pinning the lookup result could
wedge collection permanently on a host whose lookup orders an
unreachable address first (IPv6 on an IPv4-only network). The rest of
the latest answer is kept as dial fallbacks with net.Dialer-style
partial deadlines, so a dead pinned instance costs one failed attempt
inside a single dial rather than a failed snapshot, and the pin moves
to whatever connected. The dialer consults the shared resolution at
dial time, so long-lived pools (the log follower) reconnect through the
current pin as well.

The pin is kept as long as the hostname keeps resolving to it: the
hostname is re-resolved at most once a minute, and the pin is evicted
once ten consecutive answers omit it. That catches the case where the
pinned instance still accepts connections but is no longer what the
hostname points at - after an Aurora failover, the old writer keeps
serving connections in its new reader role - within about ten minutes,
while endpoints with a stable answer re-confirm the pin on every lookup
and are never churned. Requiring several consecutive misses keeps
rotating multi-reader endpoints, where a valid pin is missing from most
single answers, from evicting a healthy pin needlessly. A failed lookup
leaves the pin alone, so a resolver outage cannot take down a working
pin. A failed connection drops the pin only for network-level errors: a
bad password or a missing database says nothing about the address, and
must not push the next snapshot connection onto a different instance.

Hosts written as an IP, Unix sockets, and the Cloud SQL and AlloyDB
drivers (which are given an instance name rather than a hostname) are
left alone. This reduces how often the instance changes under us, but
the reference point is still checked against the instance identity.
