### PR TITLE
Retire submitSnapshot for http upload

### DIFF
--- a/output/upload.go
+++ b/output/upload.go
@@ -116,7 +116,7 @@ func uploadViaWebsocketOrHttp(ctx context.Context, server *state.Server, logger 
 			return err
 		}
 		if opts.TestRun {
-			return markTestRun(uploadCtx, server, opts)
+			return markTestRun(uploadCtx, server, opts, logger)
 		}
 	}
 	return nil

--- a/output/upload.go
+++ b/output/upload.go
@@ -42,7 +42,7 @@ func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *
 				continue
 			}
 
-			err = uploadViaWebsocketOrHttp(ctx, server, logger, opts, data, s.SnapshotUuid, s.CollectedAt.AsTime(), false, snapshotUploadTimeout)
+			err = uploadViaWebsocketOrHttp(ctx, server, logger, opts, data, s.SnapshotUuid, snapshotUploadTimeout)
 			if err != nil {
 				logger.PrintError("Error uploading snapshot: %s", err)
 			} else if !opts.TestRun {
@@ -55,7 +55,7 @@ func snapshotUploadForServer(ctx context.Context, server *state.Server, logger *
 				continue
 			}
 
-			err = uploadViaWebsocketOrHttp(ctx, server, logger, opts, data, s.SnapshotUuid, s.CollectedAt.AsTime(), false, snapshotUploadTimeout)
+			err = uploadViaWebsocketOrHttp(ctx, server, logger, opts, data, s.SnapshotUuid, snapshotUploadTimeout)
 			if err != nil {
 				logger.PrintError("Error uploading snapshot: %s", err)
 				continue
@@ -97,7 +97,7 @@ func summarizeCounts(counts map[string]uint8) string {
 	return details
 }
 
-func uploadViaWebsocketOrHttp(ctx context.Context, server *state.Server, logger *util.Logger, opts state.CollectionOpts, data []byte, snapshotUUID string, collectedAt time.Time, compactSnapshot bool, httpUploadTimeout time.Duration) error {
+func uploadViaWebsocketOrHttp(ctx context.Context, server *state.Server, logger *util.Logger, opts state.CollectionOpts, data []byte, snapshotUUID string, httpUploadTimeout time.Duration) error {
 	var compressedData bytes.Buffer
 	w := zlib.NewWriter(&compressedData)
 	w.Write(data)
@@ -111,11 +111,13 @@ func uploadViaWebsocketOrHttp(ctx context.Context, server *state.Server, logger 
 	} else {
 		uploadCtx, cancel := context.WithTimeout(ctx, httpUploadTimeout)
 		defer cancel()
-		s3Location, err := uploadSnapshot(uploadCtx, server.Config.HTTPClientWithRetry, server.Grant.Load(), logger, compressedData.Bytes(), snapshotUUID)
+		_, err := uploadSnapshot(uploadCtx, server.Config.HTTPClientWithRetry, server.Grant.Load(), logger, compressedData.Bytes(), snapshotUUID)
 		if err != nil {
 			return err
 		}
-		return submitSnapshot(uploadCtx, server, opts, logger, s3Location, collectedAt, compactSnapshot)
+		if opts.TestRun {
+			return markTestRun(uploadCtx, server, opts)
+		}
 	}
 	return nil
 }

--- a/output/upload_http_legacy.go
+++ b/output/upload_http_legacy.go
@@ -3,17 +3,13 @@ package output
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"io"
-	"mime"
 	"mime/multipart"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/pganalyze/collector/config"
@@ -106,28 +102,13 @@ func uploadToS3(ctx context.Context, httpClient *http.Client, S3URL string, S3Fi
 	return s3Resp.Key, nil
 }
 
-func submitSnapshot(ctx context.Context, server *state.Server, opts state.CollectionOpts, logger *util.Logger, s3Location string, collectedAt time.Time, compact bool) error {
-	requestURL := server.Config.APIBaseURL + "/v2/snapshots"
-
-	if opts.TestRun {
-		requestURL = server.Config.APIBaseURL + "/v2/snapshots/test"
-	} else if compact {
-		requestURL = server.Config.APIBaseURL + "/v2/snapshots/compact"
-	}
-
-	data := url.Values{
-		"s3_location":  {s3Location},
-		"collected_at": {fmt.Sprintf("%d", collectedAt.Unix())},
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "POST", requestURL, strings.NewReader(data.Encode()))
+func markTestRun(ctx context.Context, server *state.Server, opts state.CollectionOpts) error {
+	req, err := http.NewRequestWithContext(ctx, "POST", server.Config.APIBaseURL+"/v2/snapshots/test", nil)
 	if err != nil {
 		return err
 	}
 
 	req.Header = config.APIHeaders(server.Config, opts.TestRun, opts.StartedAt)
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Accept", "application/json,text/plain")
 
 	resp, err := server.Config.HTTPClientWithRetry.Do(req)
 	if err != nil {
@@ -135,39 +116,12 @@ func submitSnapshot(ctx context.Context, server *state.Server, opts state.Collec
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Error when submitting: %s\n", body)
-	}
-
-	if opts.TestRun {
-		contentType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("Error decoding response: %s\n", err)
+			return err
 		}
-
-		var msg string
-
-		if contentType == "application/json" {
-			var jsonBody struct {
-				Message string `json:"message"`
-			}
-			err = json.Unmarshal(body, &jsonBody)
-			if err != nil {
-				return fmt.Errorf("Error decoding response: %s\n", err)
-			}
-			msg = jsonBody.Message
-		} else {
-			msg = string(body)
-		}
-
-		if len(msg) > 0 {
-			logger.PrintInfo("  %s", msg)
-		}
+		return fmt.Errorf("Error when marking test run: %s", body)
 	}
 
 	return nil

--- a/output/upload_http_legacy.go
+++ b/output/upload_http_legacy.go
@@ -3,9 +3,11 @@ package output
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"io"
+	"mime"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -102,13 +104,14 @@ func uploadToS3(ctx context.Context, httpClient *http.Client, S3URL string, S3Fi
 	return s3Resp.Key, nil
 }
 
-func markTestRun(ctx context.Context, server *state.Server, opts state.CollectionOpts) error {
+func markTestRun(ctx context.Context, server *state.Server, opts state.CollectionOpts, logger *util.Logger) error {
 	req, err := http.NewRequestWithContext(ctx, "POST", server.Config.APIBaseURL+"/v2/snapshots/test", nil)
 	if err != nil {
 		return err
 	}
 
 	req.Header = config.APIHeaders(server.Config, opts.TestRun, opts.StartedAt)
+	req.Header.Add("Accept", "application/json,text/plain")
 
 	resp, err := server.Config.HTTPClientWithRetry.Do(req)
 	if err != nil {
@@ -116,12 +119,36 @@ func markTestRun(ctx context.Context, server *state.Server, opts state.Collectio
 	}
 	defer resp.Body.Close()
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
 	if resp.StatusCode != http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return err
-		}
 		return fmt.Errorf("Error when marking test run: %s", body)
+	}
+
+	contentType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil {
+		return fmt.Errorf("Error decoding response: %s", err)
+	}
+
+	var msg string
+	if contentType == "application/json" {
+		var jsonBody struct {
+			Message string `json:"message"`
+		}
+		err = json.Unmarshal(body, &jsonBody)
+		if err != nil {
+			return fmt.Errorf("Error decoding response: %s", err)
+		}
+		msg = jsonBody.Message
+	} else {
+		msg = string(body)
+	}
+
+	if len(msg) > 0 {
+		logger.PrintInfo("  %s", msg)
 	}
 
 	return nil


### PR DESCRIPTION
A follow-up of https://github.com/pganalyze/collector/pull/859

While I was reviewing it, I noticed that we're doing an extra HTTP request with `submitSnapshot`. This only has the meaning when `opts.TestRun` is on, so let's only make an extra HTTP request in that case.

We could also do further cleanups, like the following:

* now we don't really use the `s3Location` from `uploadSnapshot`, we can retire things around there too
* `/v2/snapshots/test` is not doing much on the server side (only updating `last_test_snapshot_at`), also we don't do this with websocket case, so we can revisit what we want to do it