### PR TITLE
Fix some concurrency hazards

### DIFF
--- a/runner/query_run.go
+++ b/runner/query_run.go
@@ -38,37 +38,53 @@ func SetupQueryRunnerForAllServers(ctx context.Context, servers []*state.Server,
 }
 
 func run(ctx context.Context, server *state.Server, collectionOpts state.CollectionOpts, logger *util.Logger) {
-	for id, query := range server.QueryRuns {
-		if !query.FinishedAt.IsZero() {
-			continue
-		}
-
+	for _, query := range pendingQueryRuns(server) {
 		server.QueryRunsMutex.Lock()
-		server.QueryRuns[id].StartedAt = time.Now()
+		query.StartedAt = time.Now()
 		server.QueryRunsMutex.Unlock()
 		logger.PrintVerbose("Query run %d starting: %s", query.Id, query.QueryText)
 
-		result, err := runQueryOnDatabase(ctx, server, collectionOpts, logger, id, query)
+		result, err := runQueryOnDatabase(ctx, server, collectionOpts, logger, query)
 		if err != nil {
 			server.QueryRunsMutex.Lock()
-			server.QueryRuns[id].FinishedAt = time.Now()
-			server.QueryRuns[id].Error = err.Error()
+			query.FinishedAt = time.Now()
+			query.Error = err.Error()
 			server.QueryRunsMutex.Unlock()
 			continue
 		}
 
 		server.QueryRunsMutex.Lock()
-		server.QueryRuns[id].FinishedAt = time.Now()
-		server.QueryRuns[id].Result = result
+		query.FinishedAt = time.Now()
+		query.Result = result
+		queryRun := *query
 		server.QueryRunsMutex.Unlock()
 
 		// Activity snapshots will eventually send the query run result, but to reduce latency
 		// we also send a query run snapshot immediately after the query has finished.
-		output.SubmitQueryRunSnapshot(ctx, server, collectionOpts, logger, *server.QueryRuns[id])
+		output.SubmitQueryRunSnapshot(ctx, server, collectionOpts, logger, queryRun)
 	}
 }
 
-func runQueryOnDatabase(ctx context.Context, server *state.Server, collectionOpts state.CollectionOpts, logger *util.Logger, id int64, query *state.QueryRun) (string, error) {
+// Returns the query runs that have not been run yet
+//
+// The map must be read whilst holding the mutex, since the WebSocket message handler
+// adds new query runs to it concurrently.
+func pendingQueryRuns(server *state.Server) []*state.QueryRun {
+	var pending []*state.QueryRun
+
+	server.QueryRunsMutex.Lock()
+	defer server.QueryRunsMutex.Unlock()
+
+	for _, query := range server.QueryRuns {
+		if query.FinishedAt.IsZero() {
+			pending = append(pending, query)
+		}
+	}
+
+	return pending
+}
+
+func runQueryOnDatabase(ctx context.Context, server *state.Server, collectionOpts state.CollectionOpts, logger *util.Logger, query *state.QueryRun) (string, error) {
 	if query.Type != pganalyze_collector.QueryRunType_EXPLAIN {
 		logger.PrintVerbose("Unhandled query run type %d for %d", query.Type, query.Id)
 		return "", errors.New("Unhandled query run type")
@@ -97,7 +113,7 @@ func runQueryOnDatabase(ctx context.Context, server *state.Server, collectionOpt
 		return "", err
 	}
 	server.QueryRunsMutex.Lock()
-	server.QueryRuns[id].BackendPid = pid
+	query.BackendPid = pid
 	server.QueryRunsMutex.Unlock()
 
 	for name, value := range query.PostgresSettings {

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -57,21 +57,24 @@ func (schedule Schedule) Schedule(ctx context.Context, wg *sync.WaitGroup, runne
 			case <-ctx.Done():
 				return
 			case <-time.After(delay):
-				func() {
-					// Cancel runner at latest right before next scheduled execution should
-					// occur, to prevent skipping over runner executions by accident.
-					deadline := nextExecutions[1].Add(-1 * time.Second)
-					// Extend the deadline of very short runs to avoid pointless cancellations.
-					if nextExecutions[1].Sub(nextExecutions[0]) < 19*time.Second {
-						deadline = nextExecutions[0].Add(19 * time.Second)
-					}
-					ctx, cancel := context.WithDeadline(ctx, deadline)
-					defer cancel()
-					runner(ctx)
-				}()
+				runWithDeadline(ctx, runner, nextExecutions[0], nextExecutions[1])
 			}
 		}
 	}()
+}
+
+// runWithDeadline - Runs the given runner, ensuring it does not run over into
+// the next execution
+func runWithDeadline(ctx context.Context, runner func(context.Context), thisExecution time.Time, nextExecution time.Time) {
+	deadline := nextExecution.Add(-1 * time.Second)
+	// Extend the deadline of very short runs to avoid excessively frequent
+	// cancellations.
+	if nextExecution.Sub(thisExecution) < 19*time.Second {
+		deadline = thisExecution.Add(19 * time.Second)
+	}
+	ctx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	runner(ctx)
 }
 
 // ScheduleSecondary - Behaves almost like Schedule, but ignores the point in time
@@ -82,7 +85,8 @@ func (schedule Schedule) ScheduleSecondary(ctx context.Context, primarySchedule 
 		defer wg.Done()
 		for {
 			timeNow := time.Now()
-			delay := schedule.interval.Next(timeNow).Sub(timeNow)
+			nextExecutions := schedule.interval.NextN(timeNow, 2)
+			delay := nextExecutions[0].Sub(timeNow)
 			delayPrimary := primarySchedule.interval.Next(timeNow).Sub(timeNow)
 
 			// Make sure to not run more often than once a second - this can happen
@@ -101,7 +105,7 @@ func (schedule Schedule) ScheduleSecondary(ctx context.Context, primarySchedule 
 				if int(delay.Seconds()) == int(delayPrimary.Seconds()) {
 					logger.PrintVerbose("Skipping run for %s since it overlaps with primary schedule", logName)
 				} else {
-					runner(ctx)
+					runWithDeadline(ctx, runner, nextExecutions[0], nextExecutions[1])
 				}
 			}
 		}

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -1,8 +1,15 @@
 package scheduler
 
 import (
+	"context"
+	"io"
+	"log"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/gorhill/cronexpr"
+	"github.com/pganalyze/collector/util"
 )
 
 func TestScheduler(t *testing.T) {
@@ -18,4 +25,77 @@ func TestScheduler(t *testing.T) {
 	if expectedNextRun != actualNextRun {
 		t.Errorf("\nNext run:\n\texpected %s\n\tactual %s\n\n", expectedNextRun, actualNextRun)
 	}
+}
+
+// Verifies that scheduled runs get a deadline that ends right before the next
+// scheduled execution, so a stuck run cannot overlap the run after it. Without a
+// deadline on the secondary schedule, a wedged 1-minute stats run held
+// HighFreqStateMutex indefinitely, which blocks the full snapshot (mutex
+// acquisition ignores context cancellation) and the collector's reload.
+func TestRunWithDeadline(t *testing.T) {
+	thisExecution := time.Date(2013, 1, 1, 0, 1, 0, 0, time.UTC)
+
+	tests := []struct {
+		name          string
+		nextExecution time.Time
+		expected      time.Time
+	}{
+		{
+			name:          "one minute interval ends before the next execution",
+			nextExecution: thisExecution.Add(1 * time.Minute),
+			expected:      thisExecution.Add(59 * time.Second),
+		},
+		{
+			name:          "ten second interval is extended to avoid pointless cancellations",
+			nextExecution: thisExecution.Add(10 * time.Second),
+			expected:      thisExecution.Add(19 * time.Second),
+		},
+	}
+
+	for _, test := range tests {
+		var actual time.Time
+		var ok bool
+		runWithDeadline(context.Background(), func(ctx context.Context) {
+			actual, ok = ctx.Deadline()
+		}, thisExecution, test.nextExecution)
+
+		if !ok {
+			t.Errorf("%s:\n\texpected a deadline on the runner's context, got none\n", test.name)
+		} else if actual != test.expected {
+			t.Errorf("%s:\n\texpected %s\n\tactual %s\n\n", test.name, test.expected, actual)
+		}
+	}
+}
+
+// Verifies that ScheduleSecondary actually applies that deadline
+func TestScheduleSecondaryRunsHaveDeadline(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+
+	// A two second secondary schedule, with a primary that only runs on the hour,
+	// so no run gets skipped for overlapping with the primary
+	secondary := Schedule{interval: cronexpr.MustParse("*/2 * * * * * *")}
+	primary := Schedule{interval: cronexpr.MustParse("0 0 * * * * *")}
+
+	deadlines := make(chan time.Time, 1)
+	secondary.ScheduleSecondary(ctx, primary, &wg, func(ctx context.Context) {
+		deadline, _ := ctx.Deadline()
+		select {
+		case deadlines <- deadline:
+		default:
+		}
+	}, &util.Logger{Destination: log.New(io.Discard, "", 0)}, "test runs")
+
+	select {
+	case deadline := <-deadlines:
+		if deadline.IsZero() {
+			t.Error("TestScheduleSecondaryRunsHaveDeadline: expected the runner's context to carry a deadline, got none")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("TestScheduleSecondaryRunsHaveDeadline: secondary schedule did not run")
+	}
+
+	cancel()
+	wg.Wait()
 }

--- a/util/reconnecting_socket.go
+++ b/util/reconnecting_socket.go
@@ -191,7 +191,12 @@ func (w *ReconnectingSocket) WriteMessage(ctx context.Context, data []byte) erro
 func (w *ReconnectingSocket) Disconnect() {
 	w.requested.Store(false)
 	if w.Connected() {
-		w.shutdown <- struct{}{}
+		// The channel reader is stopped once the context is canceled, so we must
+		// not block on the send when the collector is shutting down or reloading
+		select {
+		case w.shutdown <- struct{}{}:
+		case <-w.ctx.Done():
+		}
 	}
 }
 


### PR DESCRIPTION
See individual commits:

- Reconnecting socket: Don't block in Disconnect after context cancellation
- Scheduler: Enforce the run time limit for secondary schedules too
- Query runs: Read the query run map while holding the mutex
