### PR TITLE
Introduce a new way to run Docker image release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ packages/tmp/
 test/
 pganalyze-collector
 pganalyze-collector-helper
+pganalyze-collector-image-*.oci.tar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,8 +165,59 @@ jobs:
           pganalyze-collector-*.tgz
         if-no-files-found: error
 
+  # The Docker images are built here but deliberately not pushed: the archives are
+  # attached to the release, and pushing them to quay.io is a manual step. See
+  # "Releasing docker images" in CONTRIBUTING.md.
+  build_docker_amd64:
+    runs-on: ubuntu-24.04
+    permissions: {}
+    # ensure we don't release on create events for branches (only tags)
+    if: ${{ startsWith( github.ref, 'refs/tags' ) }}
+
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Build image
+      run: |
+        make docker_image_amd64
+
+    - name: Upload image as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: docker_image_amd64
+        path: pganalyze-collector-image-linux-amd64.oci.tar
+        if-no-files-found: error
+
+  build_docker_arm64:
+    runs-on: ubuntu-24.04-arm
+    permissions: {}
+    # ensure we don't release on create events for branches (only tags)
+    if: ${{ startsWith( github.ref, 'refs/tags' ) }}
+
+    steps:
+
+    - name: Check out code
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Build image
+      run: |
+        make docker_image_arm64
+
+    - name: Upload image as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: docker_image_arm64
+        path: pganalyze-collector-image-linux-arm64.oci.tar
+        if-no-files-found: error
+
   release:
-    needs: [build, build_arm, build_packages_x86_64, build_packages_arm64, build_charts]
+    needs: [build, build_arm, build_packages_x86_64, build_packages_arm64, build_charts, build_docker_amd64, build_docker_arm64]
     runs-on: ubuntu-latest
     # ensure we don't release on create events for branches (only tags)
     if: ${{ startsWith( github.ref, 'refs/tags' ) }}
@@ -196,6 +247,16 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         name: charts
+
+    - name: Download Docker image (amd64)
+      uses: actions/download-artifact@v4
+      with:
+        name: docker_image_amd64
+
+    - name: Download Docker image (arm64)
+      uses: actions/download-artifact@v4
+      with:
+        name: docker_image_arm64
 
     - name: Get version and git version from tag
       id: get_version
@@ -275,6 +336,26 @@ jobs:
         asset_path: ./pganalyze-collector_${{ steps.get_version.outputs.version }}_arm64.deb
         asset_name: pganalyze-collector_${{ steps.get_version.outputs.version }}_arm64.deb
         asset_content_type: application/octet-stream
+
+    - name: Upload release Docker image (amd64)
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./pganalyze-collector-image-linux-amd64.oci.tar
+        asset_name: pganalyze-collector-image-linux-amd64.oci.tar
+        asset_content_type: application/x-tar
+
+    - name: Upload release Docker image (arm64)
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./pganalyze-collector-image-linux-arm64.oci.tar
+        asset_name: pganalyze-collector-image-linux-arm64.oci.tar
+        asset_content_type: application/x-tar
 
   release_charts:
     needs: [release]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /pganalyze-collector
 /pganalyze-collector-helper
 /pganalyze-collector-setup
+/pganalyze-collector-image-*.oci.tar
 packages/tmp
 /tmp
 integration_test/*.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,13 +116,35 @@ time="2024-04-26T02:01:07Z" level=info msg="Generating README Documentation for 
 2. Once PR is merged, create a new tag `git tag v0.x.y`, then push it `git push origin v0.x.y`
 3. Once a new tag is pushed, GitHub Action Release will be kicked and create a new release (this will take about 2 hours, due to the package build and test)
 4. Modify the newly created release's description to match to CHANGELOG.md
-5. Release docker images using `make docker_release` (this requires access to the Quay.io push key, as well as "docker buildx" with QEMU emulation support, see below)
+5. Release docker images (see below)
 6. Sign and release packages using `make -C packages repo` (this requires access to the Keybase GPG key)
 
-To run step 5 from an Ubuntu 24.04 VM, do the following:
-(use a c8i.2xlarge instance or higher, takes ~10+ minutes)
+#### Releasing docker images
 
+The Release workflow builds the images for both architectures on native runners
+and attaches them to the GitHub release as OCI archives. Push these images to
+quay.io by following the steps below.
+
+##### Prerequisites
+
+Nothing is compiled here, so any machine will do. You need `docker` with the
+buildx plugin, `skopeo`, and `gh`.
+
+<details>
+<summary>On macOS</summary>
+
+With Docker Desktop already installed (it provides `docker` and `docker buildx`):
+
+```sh
+brew install skopeo gh
 ```
+
+</details>
+
+<details>
+<summary>On a fresh Ubuntu 24.04 EC2 instance</summary>
+
+```sh
 # Add Docker's official GPG key:
 sudo apt-get update && \
 sudo apt-get install -y ca-certificates curl gnupg && \
@@ -136,16 +158,34 @@ echo \
   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null && \
 sudo apt-get update && \
-sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin qemu-user-static binfmt-support make
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin skopeo make && \
+sudo snap install gh
+```
+
+Prefix the publishing commands below with `sudo`, so that they run as the same
+user the credentials are stored for.
+
+</details>
+
+##### Publishing
+
+```sh
+git checkout v0.x.y
 
 # Get password (entered interactively) from Quay.io
 # (under the robot accounts of the pganalyze organization)
-sudo docker login -u="pganalyze+push" quay.io
+# Both tools need it, as they keep their credentials separately
+docker login -u="pganalyze+push" quay.io
+skopeo login -u="pganalyze+push" quay.io
 
-# Pull collector repository and build
-git clone https://github.com/pganalyze/collector.git && \
-cd collector && \
-sudo make docker_release
+# Download the two images that the Release workflow built
+gh release download v0.x.y -p '*.oci.tar'
+
+# Push both into the staging repository
+make docker_release_staging
+
+# Publish: join them into one multi-architecture image under the release tags
+make docker_release_manifest
 ```
 
 ### Updating wait event types and names

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ifeq ($(shell uname), Darwin)
 endif
 PROTOC_URL := $(PROTOC_BASE_URL)v$(PROTOC_VERSION_NEEDED)/$(PROTOC_FILENAME)
 
-.PHONY: default build build_dist vendor test docker_release packages integration_test
+.PHONY: default build build_dist vendor test docker_image_amd64 docker_image_arm64 docker_release_staging docker_release_manifest packages integration_test
 
 default: build test
 
@@ -68,15 +68,51 @@ packages:
 	make -C packages
 
 DOCKER_RELEASE_TAG := $(shell git describe --tags --exact-match --abbrev=0 2> /dev/null)
-docker_release:
-	@test -n "$(DOCKER_RELEASE_TAG)" || (echo "ERROR: DOCKER_RELEASE_TAG is not set, make sure you are on a git release tag or override by setting DOCKER_RELEASE_TAG" ; exit 1)
-	docker buildx create --name collector-build --driver docker-container
-	docker buildx build --platform linux/amd64,linux/arm64 --builder collector-build --push \
-	-t quay.io/pganalyze/collector:$(DOCKER_RELEASE_TAG) \
-	-t quay.io/pganalyze/collector:latest \
-	-t quay.io/pganalyze/collector:stable \
+DOCKER_IMAGE := quay.io/pganalyze/collector
+DOCKER_STAGING_IMAGE := quay.io/pganalyze/collector-staging
+DOCKER_BUILDER := collector-build
+DOCKER_OCI_AMD64 := pganalyze-collector-image-linux-amd64.oci.tar
+DOCKER_OCI_ARM64 := pganalyze-collector-image-linux-arm64.oci.tar
+
+# Builds one architecture as an OCI archive. The Release workflow runs these on a
+# native runner per architecture and attaches the archives to the GitHub release,
+# which are then published with docker_release_staging and docker_release_manifest.
+define docker_build_oci
+docker buildx inspect $(DOCKER_BUILDER) > /dev/null 2>&1 || docker buildx create --name $(DOCKER_BUILDER) --driver docker-container
+	docker buildx build --platform linux/$(1) --builder $(DOCKER_BUILDER) \
+	--provenance=true \
+	--output type=oci,dest=$(2) \
 	.
-	docker buildx rm collector-build
+	docker buildx rm $(DOCKER_BUILDER)
+endef
+
+docker_image_amd64:
+	$(call docker_build_oci,amd64,$(DOCKER_OCI_AMD64))
+
+docker_image_arm64:
+	$(call docker_build_oci,arm64,$(DOCKER_OCI_ARM64))
+
+# Pushes the OCI archives downloaded from the GitHub release into the
+# collector-staging repository in quay.io, which is where docker_release_manifest
+# reads them from.
+docker_release_staging:
+	@test -n "$(DOCKER_RELEASE_TAG)" || (echo "ERROR: DOCKER_RELEASE_TAG is not set, make sure you are on a git release tag or override by setting DOCKER_RELEASE_TAG" ; exit 1)
+	@test -f $(DOCKER_OCI_AMD64) || (echo "ERROR: $(DOCKER_OCI_AMD64) not found, download it with: gh release download $(DOCKER_RELEASE_TAG) -p '*.oci.tar'" ; exit 1)
+	@test -f $(DOCKER_OCI_ARM64) || (echo "ERROR: $(DOCKER_OCI_ARM64) not found, download it with: gh release download $(DOCKER_RELEASE_TAG) -p '*.oci.tar'" ; exit 1)
+	skopeo copy --multi-arch all oci-archive:$(DOCKER_OCI_AMD64) docker://$(DOCKER_STAGING_IMAGE):$(DOCKER_RELEASE_TAG)-amd64
+	skopeo copy --multi-arch all oci-archive:$(DOCKER_OCI_ARM64) docker://$(DOCKER_STAGING_IMAGE):$(DOCKER_RELEASE_TAG)-arm64
+
+# Publishes the release, by joining the two staged single-architecture images into
+# one manifest list under the release tags.
+docker_release_manifest:
+	@test -n "$(DOCKER_RELEASE_TAG)" || (echo "ERROR: DOCKER_RELEASE_TAG is not set, make sure you are on a git release tag or override by setting DOCKER_RELEASE_TAG" ; exit 1)
+	docker buildx imagetools create \
+	-t $(DOCKER_IMAGE):$(DOCKER_RELEASE_TAG) \
+	-t $(DOCKER_IMAGE):latest \
+	-t $(DOCKER_IMAGE):stable \
+	$(DOCKER_STAGING_IMAGE):$(DOCKER_RELEASE_TAG)-amd64 \
+	$(DOCKER_STAGING_IMAGE):$(DOCKER_RELEASE_TAG)-arm64
+	docker buildx imagetools inspect $(DOCKER_IMAGE):$(DOCKER_RELEASE_TAG)
 
 output/pganalyze_collector/snapshot.pb.go: $(PROTOBUF_FILES)
 ifdef PROTOC_VERSION
@@ -91,11 +127,11 @@ install_protoc:
 ifeq (,$(findstring $(PROTOC_VERSION_NEEDED), $(PROTOC_VERSION)))
 	@echo "⚠️  protoc version needed: $(PROTOC_VERSION_NEEDED) vs $(PROTOC_VERSION) installed"
 	@echo "ℹ️  Vendoring protoc $(PROTOC_VERSION_NEEDED)"
-  
+
 	@mkdir -p tmp
 	curl --location --output tmp/$(PROTOC_FILENAME) $(PROTOC_URL)
 	unzip -d protoc tmp/$(PROTOC_FILENAME)
 	rm tmp/$(PROTOC_FILENAME)
-  
+
 	@echo "ℹ️  If this is macOS, you will need to try running the binary yourself, then go to Security & Privacy to explicitly allow it."
 endif


### PR DESCRIPTION
Currently, docker image release step is pretty manual - launch the EC2 instance and do some prep, then wait for it to finish.
While I was trying to release 0.73.0, I was having a problem with this, where the `make docker_release` command hung due to some deadlock and never finish. This `docker_release` was also using the emulator to build the arm image, which was taking extra time too.

To make this step better, have the current release GH action build the docker images (triggered when we push the tag like `v0.73.0`), then the operator (aka some folks from pganalyze) will publish that image to our quay.io repo. 