### PR TITLE
Add 30 second timeout for opening WebSocket connections

### DIFF
--- a/config/read.go
+++ b/config/read.go
@@ -507,6 +507,17 @@ func CreateWebSocketDialer(conf ServerConfig) websocket.Dialer {
 		Proxy: func(req *http.Request) (*url.URL, error) {
 			return proxyConfig.ProxyFunc()(req.URL)
 		},
+		// Bound the whole connection attempt (TCP connect, proxy CONNECT, TLS and
+		// the HTTP upgrade). Without this, an unreachable address is only given up
+		// on after the kernel's TCP connect timeout, which is 2+ minutes on Linux
+		// and can be multiplied when the hostname resolves to several addresses.
+		HandshakeTimeout: 30 * time.Second,
+		// Match the dial settings of the HTTP client (see CreateHTTPClient)
+		NetDialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
 	}
 }
 


### PR DESCRIPTION
This matches how we handle HTTP connections, and avoids a confusing stall in the collector logs that might be attributed to the next action to occur (e.g. context deadline on making a database connection after we switched to an HTTP grant).