### PR TITLE
Reconnecting socket: Bound connection attempts by the caller's context

### DIFF
--- a/output/grant.go
+++ b/output/grant.go
@@ -14,6 +14,10 @@ import (
 	"github.com/pganalyze/collector/util"
 )
 
+// Maximum time to wait for the WebSocket connection to be established before
+// falling back to the HTTP-based grant (when the WebSocket is not required)
+const websocketConnectTimeout = 10 * time.Second
+
 // EnsureGrant - Ensures the server has a valid grant stored from either WebSocket or HTTP-based grant API
 func EnsureGrant(ctx context.Context, server *state.Server, opts state.CollectionOpts, logger *util.Logger, refetchAlways bool) error {
 	if opts.ForceEmptyGrant {
@@ -28,7 +32,17 @@ func EnsureGrant(ctx context.Context, server *state.Server, opts state.Collectio
 		return nil
 	}
 
-	err := server.WebSocket.Connect()
+	var err error
+	if server.Config.APIRequireWebsocket {
+		err = server.WebSocket.Connect(ctx)
+	} else {
+		// Don't let a slow or unreachable WebSocket endpoint hold up the collection
+		// run, since we can fall back to the HTTP-based grant. The reconnect logic
+		// keeps trying to establish the WebSocket in the background.
+		connectCtx, cancel := context.WithTimeout(ctx, websocketConnectTimeout)
+		err = server.WebSocket.Connect(connectCtx)
+		cancel()
+	}
 	if err != nil {
 		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectWebSocket, "error starting WebSocket: %s", err)
 		if server.Config.APIRequireWebsocket {

--- a/util/reconnecting_socket.go
+++ b/util/reconnecting_socket.go
@@ -28,8 +28,7 @@ type ReconnectingSocket struct {
 	ctx       context.Context
 	requested atomic.Bool
 	conn      atomic.Pointer[websocket.Conn]
-	start     chan struct{}
-	startWait chan error
+	start     chan connectRequest
 	shutdown  chan struct{}
 }
 
@@ -38,6 +37,16 @@ type ReconnectingSocket struct {
 type socketWrite struct {
 	data []byte
 	// Must be buffered (capacity 1), so the writer goroutine never blocks
+	// handing back the result to a caller that has stopped waiting
+	result chan error
+}
+
+// connectRequest - A single request to establish the connection, together with
+// the channel used to hand the outcome back to the caller
+type connectRequest struct {
+	// Bounds the connection attempt made on behalf of this request
+	ctx context.Context
+	// Must be buffered (capacity 1), so the manager goroutine never blocks
 	// handing back the result to a caller that has stopped waiting
 	result chan error
 }
@@ -63,36 +72,41 @@ const (
 // The passed context must eventually be canceled in order for internal Goroutines to be stopped.
 func NewReconnectingSocket(ctx context.Context, logger *Logger, dialer websocket.Dialer, url string, headers map[string][]string, reconnectInterval time.Duration, clientErrorTimeout time.Duration) *ReconnectingSocket {
 	w := &ReconnectingSocket{
-		Read:      make(chan []byte),
-		write:     make(chan socketWrite),
-		ctx:       ctx,
-		dialer:    dialer,
-		url:       url,
-		headers:   headers,
-		logger:    logger,
-		start:     make(chan struct{}, 1),
-		startWait: make(chan error, 1),
-		shutdown:  make(chan struct{}),
+		Read:     make(chan []byte),
+		write:    make(chan socketWrite),
+		ctx:      ctx,
+		dialer:   dialer,
+		url:      url,
+		headers:  headers,
+		logger:   logger,
+		start:    make(chan connectRequest),
+		shutdown: make(chan struct{}),
 	}
 
+	// Manager goroutine: serializes connection attempts and shutdowns
 	go func() {
 		var skipConnectUntil time.Time
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-w.start:
+			case req := <-w.start:
+				var err error
 				if w.Connected() || !w.requested.Load() {
-					w.startWait <- nil
+					// Nothing to do
+				} else if req.ctx.Err() != nil {
+					// The caller gave up while waiting for an earlier attempt to finish
+					err = req.ctx.Err()
 				} else if time.Now().After(skipConnectUntil) {
-					connectStatus, err := w.connect(ctx)
+					var connectStatus int
+					connectStatus, err = w.connect(req.ctx)
 					if connectStatus >= 400 && connectStatus < 500 {
 						skipConnectUntil = time.Now().Add(clientErrorTimeout) // Delay reconnect when server responds with 4xx errors
 					}
-					w.startWait <- err
 				} else {
-					w.startWait <- ErrorConnectRateLimited
+					err = ErrorConnectRateLimited
 				}
+				req.result <- err
 			case <-w.shutdown:
 				w.closeConnection(w.conn.Load())
 			}
@@ -107,16 +121,7 @@ func NewReconnectingSocket(ctx context.Context, logger *Logger, dialer websocket
 				return
 			case <-time.After(reconnectInterval):
 				if !w.Connected() && w.requested.Load() {
-					select {
-					case w.start <- struct{}{}:
-					case <-ctx.Done():
-						return
-					}
-					select {
-					case <-w.startWait:
-					case <-ctx.Done():
-						return
-					}
+					w.requestConnect(ctx)
 				}
 			}
 		}
@@ -130,20 +135,37 @@ func (w *ReconnectingSocket) Connected() bool {
 
 // Connect - Blocks until connection is either established, or fails to be established
 //
+// The passed context bounds the connection attempt: when it is canceled, the
+// attempt is abandoned and ctx.Err() is returned. This does not stop the socket
+// from reconnecting in the background later on.
+//
 // Does nothing if the WebSocket is already connected
-func (w *ReconnectingSocket) Connect() error {
+func (w *ReconnectingSocket) Connect(ctx context.Context) error {
 	w.requested.Store(true)
 	if w.Connected() {
 		return nil
 	}
+	return w.requestConnect(ctx)
+}
+
+// requestConnect - Hands a connection request to the manager goroutine and
+// waits for its outcome, giving up when either the passed context or the
+// socket's own context is canceled
+func (w *ReconnectingSocket) requestConnect(ctx context.Context) error {
+	// Must be buffered with capacity 1, see connectRequest definition
+	req := connectRequest{ctx: ctx, result: make(chan error, 1)}
 	select {
-	case w.start <- struct{}{}:
+	case w.start <- req:
+	case <-ctx.Done():
+		return ctx.Err()
 	case <-w.ctx.Done():
 		return w.ctx.Err()
 	}
 	select {
-	case err := <-w.startWait:
+	case err := <-req.result:
 		return err
+	case <-ctx.Done():
+		return ctx.Err()
 	case <-w.ctx.Done():
 		return w.ctx.Err()
 	}
@@ -200,19 +222,37 @@ func (w *ReconnectingSocket) Disconnect() {
 	}
 }
 
+// connect - Makes a single connection attempt, bounded by the passed context
+// (in addition to the socket's own context and the dialer's handshake timeout)
+//
+// Returns the HTTP status code of the handshake response, if there was one.
 func (w *ReconnectingSocket) connect(ctx context.Context) (int, error) {
 	var connectStatus int
-	connCtx, cancelConn := context.WithCancel(ctx)
-	conn, response, err := w.dialer.DialContext(ctx, w.url, w.headers)
+
+	// The dial only lives as long as the request that triggered it, but must also
+	// stop when the socket as a whole is shut down
+	dialCtx, cancelDial := context.WithCancel(ctx)
+	defer cancelDial()
+	stopAfterFunc := context.AfterFunc(w.ctx, cancelDial)
+	defer stopAfterFunc()
+
+	conn, response, err := w.dialer.DialContext(dialCtx, w.url, w.headers)
 	if response != nil {
 		connectStatus = response.StatusCode
 	}
 	if err != nil {
-		cancelConn()
-		w.logger.PrintWarning("Error starting websocket: %s %v", err, response)
-		return 0, err
+		if response != nil {
+			w.logger.PrintWarning("Error starting websocket: %s (HTTP status %d)", err, connectStatus)
+		} else {
+			w.logger.PrintWarning("Error starting websocket: %s", err)
+		}
+		return connectStatus, err
 	}
 	w.conn.Store(conn)
+
+	// The established connection is independent of the request that started it,
+	// and lives until it fails or the socket is shut down
+	connCtx, cancelConn := context.WithCancel(w.ctx)
 	// Writer goroutine
 	go func() {
 		ticker := time.NewTicker(socketPingInterval)

--- a/util/reconnecting_socket_test.go
+++ b/util/reconnecting_socket_test.go
@@ -48,7 +48,7 @@ func TestSocketReconnect(t *testing.T) {
 		1*time.Second,
 	)
 
-	err = socket.Connect()
+	err = socket.Connect(ctx)
 	if err != nil {
 		t.Errorf("TestSocketReconnect: failed initial socket connection: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestSocketConnectReturnsAfterContextCancel(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- socket.Connect()
+		done <- socket.Connect(context.Background())
 	}()
 
 	select {
@@ -95,6 +95,109 @@ func TestSocketConnectReturnsAfterContextCancel(t *testing.T) {
 		// Connect() returned (with or without an error) instead of hanging.
 	case <-time.After(5 * time.Second):
 		t.Fatal("TestSocketConnectReturnsAfterContextCancel: Connect() blocked indefinitely after context cancellation")
+	}
+}
+
+// Verifies that the context passed to Connect() bounds the connection attempt,
+// so a slow or unreachable endpoint does not stall the caller (e.g. EnsureGrant
+// falling back to the HTTP-based grant). The server here accepts the TCP
+// connection but never answers the handshake, which is only given up on after
+// the dialer's handshake timeout otherwise.
+func TestSocketConnectReturnsAfterCallerContextTimeout(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ln, err := net.Listen("tcp", "localhost:9127")
+	if err != nil {
+		t.Fatalf("TestSocketConnectReturnsAfterCallerContextTimeout: failed to start listener: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Hold the connection open without responding
+			go func() {
+				<-ctx.Done()
+				c.Close()
+			}()
+		}
+	}()
+
+	socket := util.NewReconnectingSocket(
+		ctx, &util.Logger{Destination: log.New(os.Stderr, "", 0)},
+		websocket.Dialer{HandshakeTimeout: 30 * time.Second}, "ws://localhost:9127", make(map[string][]string),
+		1*time.Second,
+		1*time.Second,
+	)
+
+	connectCtx, connectCancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer connectCancel()
+
+	start := time.Now()
+	err = socket.Connect(connectCtx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("TestSocketConnectReturnsAfterCallerContextTimeout: expected an error for a connection that was never established")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("TestSocketConnectReturnsAfterCallerContextTimeout: Connect() took %v, expected it to return shortly after the 200ms context timeout", elapsed)
+	}
+	if socket.Connected() {
+		t.Error("TestSocketConnectReturnsAfterCallerContextTimeout: socket unexpectedly reports as connected")
+	}
+}
+
+// Verifies that a caller's context only bounds its own connection attempt, and
+// does not tear down an established connection or stop later attempts
+func TestSocketConnectCallerContextDoesNotAffectConnection(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serverMux := http.NewServeMux()
+	serverMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		<-ctx.Done()
+	})
+	s := &http.Server{Addr: "localhost:9128", Handler: serverMux}
+	ln, err := net.Listen("tcp", s.Addr)
+	if err != nil {
+		t.Fatalf("TestSocketConnectCallerContextDoesNotAffectConnection: failed to start socket: %v", err)
+	}
+	go s.Serve(ln)
+	defer s.Shutdown(context.Background())
+
+	socket := util.NewReconnectingSocket(
+		ctx, &util.Logger{Destination: log.New(os.Stderr, "", 0)},
+		websocket.Dialer{}, "ws://localhost:9128", make(map[string][]string),
+		1*time.Second,
+		1*time.Second,
+	)
+
+	connectCtx, connectCancel := context.WithCancel(ctx)
+	err = socket.Connect(connectCtx)
+	if err != nil {
+		t.Fatalf("TestSocketConnectCallerContextDoesNotAffectConnection: failed initial socket connection: %v", err)
+	}
+	connectCancel()
+
+	// Canceling the caller's context must not close the connection
+	time.Sleep(100 * time.Millisecond)
+	if !socket.Connected() {
+		t.Fatal("TestSocketConnectCallerContextDoesNotAffectConnection: connection was closed after the caller's context was canceled")
+	}
+
+	err = socket.WriteMessage(ctx, []byte("still connected"))
+	if err != nil {
+		t.Errorf("TestSocketConnectCallerContextDoesNotAffectConnection: unexpected write error: %v", err)
 	}
 }
 
@@ -136,7 +239,7 @@ func TestSocketWriteMessage(t *testing.T) {
 		1*time.Second,
 	)
 
-	err = socket.Connect()
+	err = socket.Connect(ctx)
 	if err != nil {
 		t.Fatalf("TestSocketWriteMessage: failed initial socket connection: %v", err)
 	}


### PR DESCRIPTION
EnsureGrant blocked on WebSocket.Connect() until the dial finished, and the dial was only bounded by the socket's process-wide context. With the dialer's handshake timeout in place (#871) this is capped at 30 seconds per attempt, but a grant call can still wait for a background reconnect attempt to finish before its own is even started, and the run's own deadline can't interrupt either of them. For an unreachable WebSocket endpoint that means every full snapshot and test run stalls for up to a minute before the first database query, even though the HTTP fallback could serve the grant right away.

Connect() now takes a context that bounds the connection attempt. Each request carries its own context and result channel, replacing the shared start/startWait pair, so callers can't receive each other's results and a caller that gives up doesn't leave a stale result behind. An established connection keeps living on the socket's context. EnsureGrant uses this to wait at most 10 seconds for the WebSocket when api_require_websocket is off, then falls back to the HTTP-based grant while the reconnect loop keeps trying in the background.

In passing fix the 4xx back-off never engaging: connect() returned status 0 on every error, so the 8 minute delay after a 4xx handshake response was dead code. The status is now returned on error and included in the warning.