### PR TITLE
Allow disabling WebSocket use via config setting

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -273,6 +273,10 @@ type ServerConfig struct {
 	// Require WebSocket connection (if false, will try WebSocket but fall back to legacy HTTPS API)
 	APIRequireWebsocket bool `ini:"api_require_websocket"`
 
+	// Disable WebSocket connection entirely and only use the legacy HTTPS API
+	// (compatibility mode for environments that can't support WebSockets, will be removed in the future)
+	APIDisableWebsocket bool `ini:"api_disable_websocket"`
+
 	// WebSocket URL to be used for API WebSocket connection
 	WebSocketUrl string
 

--- a/config/read.go
+++ b/config/read.go
@@ -427,6 +427,9 @@ func getDefaultConfig() *ServerConfig {
 	if apiRequireWebSocket := os.Getenv("API_REQUIRE_WEBSOCKET"); apiRequireWebSocket != "" {
 		config.APIRequireWebsocket = parseConfigBool(apiRequireWebSocket)
 	}
+	if apiDisableWebSocket := os.Getenv("API_DISABLE_WEBSOCKET"); apiDisableWebSocket != "" {
+		config.APIDisableWebsocket = parseConfigBool(apiDisableWebSocket)
+	}
 
 	return config
 }
@@ -850,6 +853,10 @@ func preprocessConfig(config *ServerConfig) (*ServerConfig, error) {
 		wsUrl.Scheme = "wss"
 	}
 	config.WebSocketUrl = wsUrl.String()
+
+	if config.APIRequireWebsocket && config.APIDisableWebsocket {
+		return config, fmt.Errorf("api_require_websocket and api_disable_websocket can't both be enabled")
+	}
 
 	return config, nil
 }

--- a/config/read_test.go
+++ b/config/read_test.go
@@ -96,3 +96,33 @@ func TestPreprocessConfigAiven(t *testing.T) {
 	}
 
 }
+
+func TestPreprocessConfigWebsocketSettings(t *testing.T) {
+	{
+		var config ServerConfig
+		config.APIDisableWebsocket = true
+		_, err := preprocessConfig(&config)
+		if err != nil {
+			t.Errorf("api_disable_websocket alone: want nil; got %v", err)
+		}
+	}
+
+	{
+		var config ServerConfig
+		config.APIRequireWebsocket = true
+		_, err := preprocessConfig(&config)
+		if err != nil {
+			t.Errorf("api_require_websocket alone: want nil; got %v", err)
+		}
+	}
+
+	{
+		var config ServerConfig
+		config.APIRequireWebsocket = true
+		config.APIDisableWebsocket = true
+		_, err := preprocessConfig(&config)
+		if err == nil {
+			t.Errorf("api_require_websocket and api_disable_websocket together: want error; got nil")
+		}
+	}
+}

--- a/output/grant.go
+++ b/output/grant.go
@@ -28,8 +28,9 @@ func EnsureGrant(ctx context.Context, server *state.Server, opts state.Collectio
 		return nil
 	}
 
-	err := server.WebSocket.Connect()
-	if err != nil {
+	if server.Config.APIDisableWebsocket {
+		server.SelfTest.MarkCollectionAspectNotAvailable(state.CollectionAspectWebSocket, "disabled by collector setting api_disable_websocket / API_DISABLE_WEBSOCKET")
+	} else if err := server.WebSocket.Connect(); err != nil {
 		server.SelfTest.MarkCollectionAspectError(state.CollectionAspectWebSocket, "error starting WebSocket: %s", err)
 		if server.Config.APIRequireWebsocket {
 			return fmt.Errorf("Error starting WebSocket: %w", err)

--- a/runner/websocket.go
+++ b/runner/websocket.go
@@ -21,6 +21,11 @@ func SetupWebsocketForAllServers(ctx context.Context, servers []*state.Server, o
 	}
 	for _, server := range servers {
 		prefixedLogger := logger.WithPrefixAndRememberErrors(server.Config.SectionName)
+		if server.Config.APIDisableWebsocket {
+			prefixedLogger.PrintWarning("WebSocket connections disabled by collector setting api_disable_websocket / API_DISABLE_WEBSOCKET, using legacy HTTP compatibility mode. Note that a future collector release will require WebSocket support, and this setting will be removed.")
+		}
+		// The socket is always set up (but only connected on demand, see output.EnsureGrant),
+		// so callers can rely on it being present
 		server.WebSocket = util.NewReconnectingSocket(
 			ctx, prefixedLogger,
 			config.CreateWebSocketDialer(server.Config),


### PR DESCRIPTION
Due to reports of specific environments running into problems with WebSocket use after the refactoring in the 0.67.0 release, this temporarily adds a setting API_DISABLE_WEBSOCKET / api_disable_websocket to turn off WebSockets and immediately go through the HTTP upload path instead.

We still intend to fully remove the HTTP upload path in a future release, since it does not support certain newer functionality (like the query runs feature), but this is a necessary interim solution to avoid gaps in snapshot data.